### PR TITLE
feat: implement ping pong communication to keep socket alive

### DIFF
--- a/packages/telnyx_webrtc/CHANGELOG.md
+++ b/packages/telnyx_webrtc/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.8
+
+- Implement Ping / Pong socket functionality to socket alive
+- Fix serialized variable names for enhanced backend functionality
+- Code formatting 
+
 ## 0.0.7
 
 - General bug fixes

--- a/packages/telnyx_webrtc/lib/model/socket_method.dart
+++ b/packages/telnyx_webrtc/lib/model/socket_method.dart
@@ -8,5 +8,6 @@ class SocketMethod {
   static const RINGING = "telnyx_rtc.ringing";
   static const CLIENT_READY = "telnyx_rtc.clientReady";
   static const GATEWAY_STATE = "telnyx_rtc.gatewayState";
+  static const PING = "telnyx_rtc.ping";
   static const LOGIN = "login";
 }

--- a/packages/telnyx_webrtc/lib/model/verto/send/info_dtmf_message_body.dart
+++ b/packages/telnyx_webrtc/lib/model/verto/send/info_dtmf_message_body.dart
@@ -40,7 +40,7 @@ class InfoParams {
         ? DialogParams.fromJson(json['dialogParams'])
         : null;
     dtmf = json['dtmf'];
-    sessid = json['sessionId'];
+    sessid = json['sessid'];
   }
 
   Map<String, dynamic> toJson() {
@@ -49,7 +49,7 @@ class InfoParams {
       data['dialogParams'] = dialogParams!.toJson();
     }
     data['dtmf'] = dtmf;
-    data['sessionId'] = sessid;
+    data['sessid'] = sessid;
     return data;
   }
 }

--- a/packages/telnyx_webrtc/lib/model/verto/send/invite_answer_message_body.dart
+++ b/packages/telnyx_webrtc/lib/model/verto/send/invite_answer_message_body.dart
@@ -39,7 +39,7 @@ class InviteParams {
         ? DialogParams.fromJson(json['dialogParams'])
         : null;
     sdp = json['sdp'];
-    sessid = json['sessionId'];
+    sessid = json['sessid'];
     userAgent = json['User-Agent'];
   }
 
@@ -49,7 +49,7 @@ class InviteParams {
       data['dialogParams'] = dialogParams!.toJson();
     }
     data['sdp'] = sdp;
-    data['sessionId'] = sessid;
+    data['sessid'] = sessid;
     data['User-Agent'] = userAgent;
     return data;
   }

--- a/packages/telnyx_webrtc/lib/model/verto/send/modify_message_body.dart
+++ b/packages/telnyx_webrtc/lib/model/verto/send/modify_message_body.dart
@@ -40,7 +40,7 @@ class ModifyParams {
     dialogParams = json['dialogParams'] != null
         ? DialogParams.fromJson(json['dialogParams'])
         : null;
-    sessid = json['sessionId'];
+    sessid = json['sessid'];
   }
 
   Map<String, dynamic> toJson() {
@@ -49,7 +49,7 @@ class ModifyParams {
     if (dialogParams != null) {
       data['dialogParams'] = dialogParams!.toJson();
     }
-    data['sessionId'] = sessid;
+    data['sessid'] = sessid;
     return data;
   }
 }

--- a/packages/telnyx_webrtc/lib/model/verto/send/pong_message_body.dart
+++ b/packages/telnyx_webrtc/lib/model/verto/send/pong_message_body.dart
@@ -1,0 +1,43 @@
+class PongMessage {
+  String? jsonrpc;
+  String? id;
+  Result? result;
+
+  PongMessage({this.jsonrpc, this.id, this.result});
+
+  PongMessage.fromJson(Map<String, dynamic> json) {
+    jsonrpc = json['jsonrpc'];
+    id = json['id'];
+    result =
+        json['result'] != null ? Result.fromJson(json['result']) : null;
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['jsonrpc'] = jsonrpc;
+    data['id'] = id;
+    if (result != null) {
+      data['result'] = result!.toJson();
+    }
+    return data;
+  }
+}
+
+class Result {
+  String? message;
+  String? sessid;
+
+  Result({this.message, this.sessid});
+
+  Result.fromJson(Map<String, dynamic> json) {
+    message = json['message'];
+    sessid = json['sessid'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['message'] = message;
+    data['sessid'] = sessid;
+    return data;
+  }
+}

--- a/packages/telnyx_webrtc/lib/model/verto/send/pong_message_body.dart
+++ b/packages/telnyx_webrtc/lib/model/verto/send/pong_message_body.dart
@@ -8,8 +8,7 @@ class PongMessage {
   PongMessage.fromJson(Map<String, dynamic> json) {
     jsonrpc = json['jsonrpc'];
     id = json['id'];
-    result =
-        json['result'] != null ? Result.fromJson(json['result']) : null;
+    result = json['result'] != null ? Result.fromJson(json['result']) : null;
   }
 
   Map<String, dynamic> toJson() {

--- a/packages/telnyx_webrtc/lib/model/verto/send/send_bye_message_body.dart
+++ b/packages/telnyx_webrtc/lib/model/verto/send/send_bye_message_body.dart
@@ -42,7 +42,7 @@ class SendByeParams {
     dialogParams = json['dialogParams'] != null
         ? ByeDialogParams.fromJson(json['dialogParams'])
         : null;
-    sessid = json['sessionId'];
+    sessid = json['sessid'];
   }
 
   Map<String, dynamic> toJson() {
@@ -52,7 +52,7 @@ class SendByeParams {
     if (dialogParams != null) {
       data['dialogParams'] = dialogParams!.toJson();
     }
-    data['sessionId'] = sessid;
+    data['sessid'] = sessid;
     return data;
   }
 }

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -176,7 +176,7 @@ class Peer {
             sessid: sessionId,
             userAgent: "Flutter-1.0");
         var inviteMessage = InviteAnswerMessage(
-            id: const Uuid().toString(),
+            id: const Uuid().v4(),
             jsonrpc: JsonRPCConstant.jsonrpc,
             method: SocketMethod.INVITE,
             params: inviteParams);
@@ -263,7 +263,7 @@ class Peer {
             sessid: session.sid,
             userAgent: "Flutter-1.0");
         var answerMessage = InviteAnswerMessage(
-            id: const Uuid().toString(),
+            id: const Uuid().v4(),
             jsonrpc: JsonRPCConstant.jsonrpc,
             method: SocketMethod.ANSWER,
             params: inviteParams);

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -18,6 +18,7 @@ import 'package:uuid/uuid.dart';
 import 'package:flutter/foundation.dart';
 
 import 'model/jsonrpc.dart';
+import 'model/verto/send/pong_message_body.dart';
 
 typedef OnSocketMessageReceived = void Function(TelnyxMessage message);
 typedef OnSocketErrorReceived = void Function(TelnyxSocketError message);
@@ -244,6 +245,17 @@ class TelnyxClient {
           _logger.i(
               'Received WebSocket message - Contains Method :: $messageJson');
           switch (messageJson['method']) {
+            case SocketMethod.PING:
+              {
+                var result = Result(message: "PONG", sessid: sessid);
+                var pongMessage = PongMessage(
+                    jsonrpc: JsonRPCConstant.jsonrpc,
+                    id: const Uuid().v4(),
+                    result: result);
+                String jsonPongMessage = jsonEncode(pongMessage);
+                txSocket.send(jsonPongMessage);
+                break;
+              }
             case SocketMethod.CLIENT_READY:
               {
                 if (_gatewayState != GatewayState.REGED) {

--- a/packages/telnyx_webrtc/lib/tx_socket.dart
+++ b/packages/telnyx_webrtc/lib/tx_socket.dart
@@ -19,6 +19,8 @@ class TxSocket {
   void connect() async {
     try {
       _socket = await WebSocket.connect(hostAddress);
+      _socket.pingInterval = const Duration(seconds: 10);
+      _socket.timeout(const Duration(seconds: 30));
       onOpen.call();
       _socket.listen((dynamic data) {
         onMessage.call(data);

--- a/packages/telnyx_webrtc/pubspec.yaml
+++ b/packages/telnyx_webrtc/pubspec.yaml
@@ -3,7 +3,7 @@ description: Enable real-time communication with WebRTC and Telnyx. Create and r
 homepage: https://telnyx.com/
 repository: https://github.com/team-telnyx/flutter-voice-sdk
 issue_tracker: https://github.com/team-telnyx/flutter-voice-sdk/issues?q=is%3Aopen+is%3Aissue
-version: 0.0.7
+version: 0.0.8
 
 environment:
   sdk: ">=2.16.2 <3.0.0"


### PR DESCRIPTION
<!-- Describe your changes here -->
This PR introduces the pong reply to received ping messages in order to keep the websocket alive on the client side. 

This resolves the user issue described here: 
https://github.com/team-telnyx/flutter-voice-sdk/issues/20#issuecomment-1262430931 

## :older_man: :baby: Behaviors
### Before changes
Not responding to ping messages. I'm not sure what has changed recently but before this wasn't required to keep the socket open. Recently though, the socket is closing when inactive for a certain amount of time. 

### After changes
Reply to each ping message with a pong message, modelled after the JS SDK 

## ✋ Manual testing
1. Log into the application
2. Monitor logs and see the ping pong exchange
