### PR TITLE
Fix for where destination number should be number not name

### DIFF
--- a/packages/telnyx_webrtc/CHANGELOG.md
+++ b/packages/telnyx_webrtc/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.1.2](https://pub.dev/packages/telnyx_webrtc/versions/0.1.2) (2024-12-20)
+
+### Bug Fixing
+
+- Fixed an issue where, when accepting a an invite, the destination number was being set to name instead of number.
+
 ## [0.1.1](https://pub.dev/packages/telnyx_webrtc/versions/0.1.1) (2024-12-12)
 
 ### Enhancement

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -591,7 +591,7 @@ class TelnyxClient {
       ..sessionCallerName = callerName
       ..sessionCallerNumber = callerNumber
       ..callState = CallState.active
-      ..sessionDestinationNumber = invite.callerIdName ?? 'Unknown Caller'
+      ..sessionDestinationNumber = invite.callerIdNumber ?? '-1'
       ..sessionClientState = clientState;
 
     final destinationNum = invite.callerIdNumber;

--- a/packages/telnyx_webrtc/pubspec.yaml
+++ b/packages/telnyx_webrtc/pubspec.yaml
@@ -3,7 +3,7 @@ description: Enable real-time communication with WebRTC and Telnyx. Create and r
 homepage: https://telnyx.com/
 repository: https://github.com/team-telnyx/flutter-voice-sdk
 issue_tracker: https://github.com/team-telnyx/flutter-voice-sdk/issues
-version: 0.1.1
+version: 0.1.2
 
 environment:
   sdk: ">=3.0.0 <3.22.3"


### PR DESCRIPTION
[WEBRTC-2048](https://telnyx.atlassian.net/browse/WEBRTC-2048)

---
<!-- Describe your changes here -->

## :older_man: :baby: Behaviors
### Before changes
Destination number was being set as name, or where null being set to 'Unknown Caller', when accepting a call

### After changes
Destination number is now being set as actual number, or where null being set to '-1', when accepting a call

## ✋ Manual testing
1. Receive call
2. Accept
3. Check destination number is correct


[WEBRTC-2048]: https://telnyx.atlassian.net/browse/WEBRTC-2048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ