### PR TITLE
[Flutter] Profile Bottom Sheet

### DIFF
--- a/lib/view/screen/login_screen.dart
+++ b/lib/view/screen/login_screen.dart
@@ -9,6 +9,8 @@ import 'package:logger/logger.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:telnyx_webrtc/config/telnyx_config.dart';
 import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb;
+import 'package:telnyx_flutter_webrtc/view/widgets/login/login_controls.dart';
+import 'package:telnyx_flutter_webrtc/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -143,63 +145,12 @@ class _LoginScreenState extends State<LoginScreen> with WidgetsBindingObserver {
               child: CircularProgressIndicator(),
             )
           : Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: TextFormField(
-                      controller: sipUserController,
-                      decoration: const InputDecoration(
-                        border: OutlineInputBorder(),
-                        labelText: 'SIP Username',
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: TextFormField(
-                      controller: sipPasswordController,
-                      obscureText: true,
-                      decoration: const InputDecoration(
-                        border: OutlineInputBorder(),
-                        labelText: 'SIP Password',
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: TextFormField(
-                      controller: sipNameController,
-                      decoration: const InputDecoration(
-                        border: OutlineInputBorder(),
-                        labelText: 'Caller ID Name',
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: TextFormField(
-                      controller: sipNumberController,
-                      decoration: const InputDecoration(
-                        border: OutlineInputBorder(),
-                        labelText: 'Caller ID Number',
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: TextButton(
-                      style: TextButton.styleFrom(
-                        foregroundColor: Colors.blue,
-                      ),
-                      onPressed: () {
-                        _attemptLogin();
-                      },
-                      child: const Text('Login'),
-                    ),
-                  ),
-                ],
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: ChangeNotifierProvider(
+                  create: (_) => ProfileModel(),
+                  child: const LoginControls(),
+                ),
               ),
             ),
     );

--- a/lib/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart
+++ b/lib/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart
@@ -1,0 +1,286 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:telnyx_webrtc/telnyx_config.dart';
+
+class ProfileModel extends ChangeNotifier {
+  List<Map<String, dynamic>> profiles = [];
+  int? selectedProfileIndex;
+
+  void addProfile(Map<String, dynamic> profile) {
+    profiles.add(profile);
+    notifyListeners();
+  }
+
+  void removeProfile(int index) {
+    if (index == selectedProfileIndex) {
+      selectedProfileIndex = null;
+    } else if (index < selectedProfileIndex!) {
+      selectedProfileIndex = selectedProfileIndex! - 1;
+    }
+    profiles.removeAt(index);
+    notifyListeners();
+  }
+
+  void selectProfile(int index) {
+    selectedProfileIndex = index;
+    notifyListeners();
+  }
+
+  Map<String, dynamic>? get selectedProfile {
+    if (selectedProfileIndex == null) return null;
+    return profiles[selectedProfileIndex!];
+  }
+}
+
+class ProfileSwitcherBottomSheet extends StatefulWidget {
+  const ProfileSwitcherBottomSheet({Key? key}) : super(key: key);
+
+  @override
+  _ProfileSwitcherBottomSheetState createState() => _ProfileSwitcherBottomSheetState();
+}
+
+class _ProfileSwitcherBottomSheetState extends State<ProfileSwitcherBottomSheet> {
+  bool isTokenLogin = false;
+  bool isAddingProfile = false;
+  final _formKey = GlobalKey<FormState>();
+  final _usernameController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _tokenController = TextEditingController();
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _passwordController.dispose();
+    _tokenController.dispose();
+    super.dispose();
+  }
+
+  void _addProfile() {
+    if (!_formKey.currentState!.validate()) return;
+
+    final profileModel = Provider.of<ProfileModel>(context, listen: false);
+    Map<String, dynamic> profile;
+
+    if (isTokenLogin) {
+      profile = {
+        'type': 'token',
+        'token': _tokenController.text,
+      };
+    } else {
+      profile = {
+        'type': 'credentials',
+        'username': _usernameController.text,
+        'password': _passwordController.text,
+      };
+    }
+
+    profileModel.addProfile(profile);
+    setState(() {
+      isAddingProfile = false;
+      _usernameController.clear();
+      _passwordController.clear();
+      _tokenController.clear();
+    });
+  }
+
+  Widget _buildAddProfileForm() {
+    return Form(
+      key: _formKey,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Switch(
+                value: isTokenLogin,
+                onChanged: (value) {
+                  setState(() {
+                    isTokenLogin = value;
+                  });
+                },
+              ),
+              const SizedBox(width: 8),
+              Text(isTokenLogin ? 'Token' : 'Credentials'),
+            ],
+          ),
+          const SizedBox(height: 16),
+          if (isTokenLogin)
+            TextFormField(
+              controller: _tokenController,
+              decoration: const InputDecoration(
+                labelText: 'Token',
+                border: OutlineInputBorder(),
+              ),
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Please enter a token';
+                }
+                return null;
+              },
+            )
+          else
+            Column(
+              children: [
+                TextFormField(
+                  controller: _usernameController,
+                  decoration: const InputDecoration(
+                    labelText: 'Username',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter a username';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 8),
+                TextFormField(
+                  controller: _passwordController,
+                  decoration: const InputDecoration(
+                    labelText: 'Password',
+                    border: OutlineInputBorder(),
+                  ),
+                  obscureText: true,
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter a password';
+                    }
+                    return null;
+                  },
+                ),
+              ],
+            ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                onPressed: () {
+                  setState(() {
+                    isAddingProfile = false;
+                  });
+                },
+                child: const Text('Cancel'),
+              ),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: _addProfile,
+                child: const Text('Sign In'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProfileList() {
+    return Consumer<ProfileModel>(
+      builder: (context, profileModel, child) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListView.builder(
+              shrinkWrap: true,
+              itemCount: profileModel.profiles.length,
+              itemBuilder: (context, index) {
+                final profile = profileModel.profiles[index];
+                final isSelected = index == profileModel.selectedProfileIndex;
+
+                return ListTile(
+                  title: Text(
+                    profile['type'] == 'token'
+                        ? 'Token Profile'
+                        : profile['username'],
+                  ),
+                  subtitle: Text(profile['type']),
+                  selected: isSelected,
+                  leading: Icon(
+                    isSelected ? Icons.check_circle : Icons.account_circle,
+                    color: isSelected ? Theme.of(context).primaryColor : null,
+                  ),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete),
+                    onPressed: () => profileModel.removeProfile(index),
+                  ),
+                  onTap: () => profileModel.selectProfile(index),
+                );
+              },
+            ),
+            if (!isAddingProfile)
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: ElevatedButton.icon(
+                  onPressed: () {
+                    setState(() {
+                      isAddingProfile = true;
+                    });
+                  },
+                  icon: const Icon(Icons.add),
+                  label: const Text('Add new profile'),
+                ),
+              ),
+            if (isAddingProfile)
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: _buildAddProfileForm(),
+              ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () => Navigator.pop(context),
+              ),
+              const Text(
+                'Existing Profiles',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+          const Divider(),
+          _buildProfileList(),
+          const Divider(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancel'),
+              ),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: () {
+                  final profileModel = Provider.of<ProfileModel>(
+                    context,
+                    listen: false,
+                  );
+                  if (profileModel.selectedProfile != null) {
+                    Navigator.pop(context, profileModel.selectedProfile);
+                  }
+                },
+                child: const Text('Confirm'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/widgets/login/login_controls.dart
+++ b/lib/view/widgets/login/login_controls.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:telnyx_webrtc/telnyx_config.dart';
+import 'package:telnyx_flutter_webrtc/main_view_model.dart';
+import 'package:telnyx_flutter_webrtc/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart';
+
+class LoginControls extends StatefulWidget {
+  const LoginControls({Key? key}) : super(key: key);
+
+  @override
+  _LoginControlsState createState() => _LoginControlsState();
+}
+
+class _LoginControlsState extends State<LoginControls> {
+  String selectedProfileName = 'User';
+
+  void _showProfileSwitcher() async {
+    final result = await showModalBottomSheet<Map<String, dynamic>>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: const ProfileSwitcherBottomSheet(),
+      ),
+    );
+
+    if (result != null) {
+      setState(() {
+        selectedProfileName = result['type'] == 'token'
+            ? 'Token Profile'
+            : result['username'];
+      });
+
+      if (result['type'] == 'token') {
+        Provider.of<MainViewModel>(context, listen: false).login(
+          TokenConfig(
+            token: result['token'],
+            debug: false,
+          ),
+        );
+      } else {
+        Provider.of<MainViewModel>(context, listen: false).login(
+          CredentialConfig(
+            sipUser: result['username'],
+            sipPassword: result['password'],
+            sipCallerIDName: result['username'],
+            sipCallerIDNumber: result['username'],
+            debug: false,
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          children: <Widget>[
+            Text(selectedProfileName),
+            const SizedBox(width: 8),
+            TextButton(
+              onPressed: _showProfileSwitcher,
+              child: const Text('Switch Profile'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: () {
+              // Connect button will be enabled when a profile is selected
+              // The login is handled in the profile switcher
+            },
+            child: const Text('Connect'),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Implements WEBRTC-2449: Profile Bottom Sheet

## Changes
- Add ProfileSwitcherBottomSheet component with support for Token and Credential profiles
- Create LoginControls widget with profile switching functionality
- Update LoginScreen to use new components
- Add ProfileModel for state management

## Features
- Add profile (Token and SIP Credentials)
- Delete profile
- Select Profile
- Dynamic profile display in login controls
- Form validation and state management

## Testing
Please verify:
1. Profile switching functionality
2. Adding new profiles (both Token and Credentials)
3. Deleting profiles
4. Profile selection and connection
5. Form validation

Jira: [WEBRTC-2449](https://telnyx.atlassian.net/browse/WEBRTC-2449)

[WEBRTC-2449]: https://telnyx.atlassian.net/browse/WEBRTC-2449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ