### PR TITLE
[Flutter] Profile Bottom Sheet - WEBRTC-2449

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -389,8 +389,11 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (context) => txClientViewModel,
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (context) => txClientViewModel),
+        ChangeNotifierProvider(create: (context) => ProfileProvider()),
+      ],
       child: MaterialApp(
         title: 'Telnyx WebRTC',
         theme: AppTheme.lightTheme,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_callkit_incoming/entities/call_event.dart';
 import 'package:flutter_callkit_incoming/flutter_callkit_incoming.dart';
 import 'package:flutter_fgbg/flutter_fgbg.dart';
+import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
 import 'package:telnyx_flutter_webrtc/view/screen/homes_screen.dart';
 import 'package:telnyx_flutter_webrtc/view/telnyx_client_view_model.dart';
 import 'package:telnyx_flutter_webrtc/service/notification_service.dart';

--- a/lib/model/profile_model.dart
+++ b/lib/model/profile_model.dart
@@ -1,0 +1,64 @@
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+
+class Profile {
+  final String name;
+  final bool isTokenLogin;
+  final String token;
+  final String sipUser;
+  final String sipPassword;
+  final String sipCallerIDName;
+  final String sipCallerIDNumber;
+
+  Profile({
+    required this.name,
+    required this.isTokenLogin,
+    this.token = '',
+    this.sipUser = '',
+    this.sipPassword = '',
+    this.sipCallerIDName = '',
+    this.sipCallerIDNumber = '',
+  });
+
+  factory Profile.fromJson(Map<String, dynamic> json) {
+    return Profile(
+      name: json['name'] as String,
+      isTokenLogin: json['isTokenLogin'] as bool,
+      token: json['token'] as String? ?? '',
+      sipUser: json['sipUser'] as String? ?? '',
+      sipPassword: json['sipPassword'] as String? ?? '',
+      sipCallerIDName: json['sipCallerIDName'] as String? ?? '',
+      sipCallerIDNumber: json['sipCallerIDNumber'] as String? ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'isTokenLogin': isTokenLogin,
+      'token': token,
+      'sipUser': sipUser,
+      'sipPassword': sipPassword,
+      'sipCallerIDName': sipCallerIDName,
+      'sipCallerIDNumber': sipCallerIDNumber,
+    };
+  }
+
+  TelnyxConfig toTelnyxConfig() {
+    if (isTokenLogin) {
+      return TokenConfig(
+        token: token,
+        sipCallerIDName: sipCallerIDName,
+        sipCallerIDNumber: sipCallerIDNumber,
+        debug: false,
+      );
+    } else {
+      return CredentialConfig(
+        sipUser: sipUser,
+        sipPassword: sipPassword,
+        sipCallerIDName: sipCallerIDName,
+        sipCallerIDNumber: sipCallerIDNumber,
+        debug: false,
+      );
+    }
+  }
+}

--- a/lib/model/profile_model.dart
+++ b/lib/model/profile_model.dart
@@ -43,10 +43,10 @@ class Profile {
     };
   }
 
-  TelnyxConfig toTelnyxConfig() {
+  Config toTelnyxConfig() {
     if (isTokenLogin) {
       return TokenConfig(
-        token: token,
+        sipToken: token,
         sipCallerIDName: sipCallerIDName,
         sipCallerIDNumber: sipCallerIDNumber,
         debug: false,

--- a/lib/model/profile_model.dart
+++ b/lib/model/profile_model.dart
@@ -1,7 +1,6 @@
 import 'package:telnyx_webrtc/config/telnyx_config.dart';
 
 class Profile {
-  final String name;
   final bool isTokenLogin;
   final String token;
   final String sipUser;
@@ -10,7 +9,6 @@ class Profile {
   final String sipCallerIDNumber;
 
   Profile({
-    required this.name,
     required this.isTokenLogin,
     this.token = '',
     this.sipUser = '',
@@ -21,7 +19,6 @@ class Profile {
 
   factory Profile.fromJson(Map<String, dynamic> json) {
     return Profile(
-      name: json['name'] as String,
       isTokenLogin: json['isTokenLogin'] as bool,
       token: json['token'] as String? ?? '',
       sipUser: json['sipUser'] as String? ?? '',
@@ -33,7 +30,6 @@ class Profile {
 
   Map<String, dynamic> toJson() {
     return {
-      'name': name,
       'isTokenLogin': isTokenLogin,
       'token': token,
       'sipUser': sipUser,

--- a/lib/provider/profile_provider.dart
+++ b/lib/provider/profile_provider.dart
@@ -48,7 +48,7 @@ class ProfileProvider with ChangeNotifier {
   }
 
   Future<void> addProfile(Profile profile) async {
-    if (_profiles.any((p) => p.name == profile.name)) {
+    if (_profiles.any((p) => p.sipCallerIDName == profile.sipCallerIDName)) {
       throw Exception('A profile with this name already exists');
     }
     _profiles.add(profile);
@@ -57,8 +57,8 @@ class ProfileProvider with ChangeNotifier {
   }
 
   Future<void> removeProfile(String name) async {
-    _profiles.removeWhere((profile) => profile.name == name);
-    if (_selectedProfile?.name == name) {
+    _profiles.removeWhere((profile) => profile.sipCallerIDName == name);
+    if (_selectedProfile?.sipCallerIDName == name) {
       _selectedProfile = null;
     }
     await _saveProfiles();
@@ -66,7 +66,7 @@ class ProfileProvider with ChangeNotifier {
   }
 
   Future<void> selectProfile(String name) async {
-    _selectedProfile = _profiles.firstWhere((profile) => profile.name == name);
+    _selectedProfile = _profiles.firstWhere((profile) => profile.sipCallerIDName == name);
     await _saveProfiles();
     notifyListeners();
   }

--- a/lib/provider/profile_provider.dart
+++ b/lib/provider/profile_provider.dart
@@ -1,0 +1,73 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences.dart';
+import 'package:telnyx_flutter_webrtc/model/profile_model.dart';
+
+class ProfileProvider with ChangeNotifier {
+  static const String _profilesKey = 'profiles';
+  static const String _selectedProfileKey = 'selected_profile';
+  List<Profile> _profiles = [];
+  Profile? _selectedProfile;
+
+  List<Profile> get profiles => _profiles;
+  Profile? get selectedProfile => _selectedProfile;
+
+  ProfileProvider() {
+    _loadProfiles();
+  }
+
+  Future<void> _loadProfiles() async {
+    final prefs = await SharedPreferences.getInstance();
+    final profilesJson = prefs.getStringList(_profilesKey) ?? [];
+    _profiles = profilesJson
+        .map((json) => Profile.fromJson(jsonDecode(json)))
+        .toList();
+
+    final selectedProfileJson = prefs.getString(_selectedProfileKey);
+    if (selectedProfileJson != null) {
+      _selectedProfile = Profile.fromJson(jsonDecode(selectedProfileJson));
+    }
+    notifyListeners();
+  }
+
+  Future<void> _saveProfiles() async {
+    final prefs = await SharedPreferences.getInstance();
+    final profilesJson = _profiles
+        .map((profile) => jsonEncode(profile.toJson()))
+        .toList();
+    await prefs.setStringList(_profilesKey, profilesJson);
+
+    if (_selectedProfile != null) {
+      await prefs.setString(
+        _selectedProfileKey,
+        jsonEncode(_selectedProfile!.toJson()),
+      );
+    } else {
+      await prefs.remove(_selectedProfileKey);
+    }
+  }
+
+  Future<void> addProfile(Profile profile) async {
+    if (_profiles.any((p) => p.name == profile.name)) {
+      throw Exception('A profile with this name already exists');
+    }
+    _profiles.add(profile);
+    await _saveProfiles();
+    notifyListeners();
+  }
+
+  Future<void> removeProfile(String name) async {
+    _profiles.removeWhere((profile) => profile.name == name);
+    if (_selectedProfile?.name == name) {
+      _selectedProfile = null;
+    }
+    await _saveProfiles();
+    notifyListeners();
+  }
+
+  Future<void> selectProfile(String name) async {
+    _selectedProfile = _profiles.firstWhere((profile) => profile.name == name);
+    await _saveProfiles();
+    notifyListeners();
+  }
+}

--- a/lib/provider/profile_provider.dart
+++ b/lib/provider/profile_provider.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
-import 'package:shared_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:telnyx_flutter_webrtc/model/profile_model.dart';
 
 class ProfileProvider with ChangeNotifier {

--- a/lib/utils/theme.dart
+++ b/lib/utils/theme.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 // Theme colors
 const surfaceColor = Color(0xFFFEFDF5);
+const darkSurfaceColor = Color(0xFFf6f4e6);
 const primaryColor = Colors.black;
 const secondaryColor = Colors.white;
 const disabledColor = Color(0xFF808080); // Gray for disabled state
@@ -17,7 +18,7 @@ class AppTheme {
         onPrimary: secondaryColor,
         secondary: secondaryColor,
         onSecondary: primaryColor,
-        surface: surfaceColor,
+        surface: darkSurfaceColor,
       ),
 
       textTheme: TextTheme(

--- a/lib/view/widgets/login/bottom_sheet/add_profile_form.dart
+++ b/lib/view/widgets/login/bottom_sheet/add_profile_form.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:telnyx_flutter_webrtc/model/profile_model.dart';
+import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
+import 'package:telnyx_flutter_webrtc/utils/dimensions.dart';
+
+class AddProfileForm extends StatefulWidget {
+  final VoidCallback onCancelPressed;
+
+  const AddProfileForm({Key? key, required this.onCancelPressed})
+      : super(key: key);
+
+  @override
+  _AddProfileFormState createState() => _AddProfileFormState();
+}
+
+class _AddProfileFormState extends State<AddProfileForm> {
+  bool _isTokenLogin = false;
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _tokenController = TextEditingController();
+  final _sipUserController = TextEditingController();
+  final _sipPasswordController = TextEditingController();
+  final _sipCallerIDNameController = TextEditingController();
+  final _sipCallerIDNumberController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _tokenController.dispose();
+    _sipUserController.dispose();
+    _sipPasswordController.dispose();
+    _sipCallerIDNameController.dispose();
+    _sipCallerIDNumberController.dispose();
+    super.dispose();
+  }
+
+  void _resetForm() {
+    _nameController.clear();
+    _tokenController.clear();
+    _sipUserController.clear();
+    _sipPasswordController.clear();
+    _sipCallerIDNameController.clear();
+    _sipCallerIDNumberController.clear();
+    _isTokenLogin = false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: spacingM),
+          Row(
+            children: [
+              Switch(
+                value: _isTokenLogin,
+                onChanged: (value) {
+                  setState(() {
+                    _isTokenLogin = value;
+                  });
+                },
+              ),
+              const SizedBox(width: spacingS),
+              Text(_isTokenLogin ? 'Token Login' : 'Credential Login'),
+            ],
+          ),
+          const SizedBox(height: spacingM),
+          if (_isTokenLogin)
+            TextFormField(
+              controller: _tokenController,
+              decoration: const InputDecoration(
+                labelText: 'Token',
+                hintText: 'Enter your token',
+              ),
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Please enter a token';
+                }
+                return null;
+              },
+            )
+          else
+            Column(
+              children: [
+                TextFormField(
+                  controller: _sipUserController,
+                  decoration: const InputDecoration(
+                    labelText: 'SIP Username',
+                    hintText: 'Enter your SIP username',
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter a SIP username';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: spacingS),
+                TextFormField(
+                  controller: _sipPasswordController,
+                  decoration: const InputDecoration(
+                    labelText: 'SIP Password',
+                    hintText: 'Enter your SIP password',
+                  ),
+                  obscureText: true,
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter a SIP password';
+                    }
+                    return null;
+                  },
+                ),
+              ],
+            ),
+          const SizedBox(height: spacingM),
+          TextFormField(
+            controller: _sipCallerIDNameController,
+            decoration: const InputDecoration(
+              labelText: 'Caller ID Name',
+              hintText: 'Enter your caller ID name',
+            ),
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return 'Please enter a caller ID name';
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: spacingS),
+          TextFormField(
+            controller: _sipCallerIDNumberController,
+            keyboardType: TextInputType.phone,
+            decoration: const InputDecoration(
+              labelText: 'Caller ID Number',
+              hintText: 'Enter your caller ID number',
+            ),
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return 'Please enter a caller ID number';
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: spacingL),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                onPressed: () {
+                  setState(() {
+                    _resetForm();
+                  });
+                  widget.onCancelPressed();
+                },
+                child: const Text('Cancel'),
+              ),
+              const SizedBox(width: spacingM),
+              ElevatedButton(
+                onPressed: () {
+                  if (_formKey.currentState!.validate()) {
+                    final profile = Profile(
+                      isTokenLogin: _isTokenLogin,
+                      token: _tokenController.text,
+                      sipUser: _sipUserController.text,
+                      sipPassword: _sipPasswordController.text,
+                      sipCallerIDName: _sipCallerIDNameController.text,
+                      sipCallerIDNumber: _sipCallerIDNumberController.text,
+                    );
+
+                    try {
+                      context.read<ProfileProvider>().addProfile(profile);
+                      setState(() {
+                        _resetForm();
+                      });
+                      widget.onCancelPressed();
+                    } catch (e) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(e.toString())),
+                      );
+                    }
+                  }
+                },
+                child: const Text('Save'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/widgets/login/bottom_sheet/add_profile_form.dart
+++ b/lib/view/widgets/login/bottom_sheet/add_profile_form.dart
@@ -5,9 +5,10 @@ import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
 import 'package:telnyx_flutter_webrtc/utils/dimensions.dart';
 
 class AddProfileForm extends StatefulWidget {
+  final Profile? existingProfile;
   final VoidCallback onCancelPressed;
 
-  const AddProfileForm({Key? key, required this.onCancelPressed})
+  const AddProfileForm({Key? key, required this.onCancelPressed, this.existingProfile})
       : super(key: key);
 
   @override
@@ -23,6 +24,20 @@ class _AddProfileFormState extends State<AddProfileForm> {
   final _sipPasswordController = TextEditingController();
   final _sipCallerIDNameController = TextEditingController();
   final _sipCallerIDNumberController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.existingProfile != null) {
+      final profile = widget.existingProfile!;
+      _isTokenLogin = profile.isTokenLogin;
+      _tokenController.text = profile.token;
+      _sipUserController.text = profile.sipUser;
+      _sipPasswordController.text = profile.sipPassword;
+      _sipCallerIDNameController.text = profile.sipCallerIDName;
+      _sipCallerIDNumberController.text = profile.sipCallerIDNumber;
+    }
+  }
 
   @override
   void dispose() {

--- a/lib/view/widgets/login/bottom_sheet/profile_list.dart
+++ b/lib/view/widgets/login/bottom_sheet/profile_list.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
+
+class ProfileList extends StatelessWidget {
+  const ProfileList({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ProfileProvider>(
+      builder: (context, provider, child) {
+        if (provider.profiles.isEmpty) {
+          return const Center(
+            child: Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Text('No profiles yet'),
+            ),
+          );
+        }
+
+        return ListView.builder(
+          shrinkWrap: true,
+          itemCount: provider.profiles.length,
+          itemBuilder: (context, index) {
+            final profile = provider.profiles[index];
+            final isSelected = provider.selectedProfile?.sipCallerIDName ==
+                profile.sipCallerIDName;
+
+            return  ListTile(
+              title: Text(profile.sipCallerIDName),
+              subtitle: Text(profile.isTokenLogin ? 'Token' : 'Credentials'),
+              selected: isSelected,
+              selectedTileColor: Theme.of(context).colorScheme.surface,
+              leading: Icon(
+                profile.isTokenLogin ? Icons.key : Icons.person,
+                color: isSelected
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).iconTheme.color,
+              ),
+              trailing: IconButton(
+                icon: const Icon(Icons.delete),
+                onPressed: () =>
+                    provider.removeProfile(profile.sipCallerIDName),
+              ),
+              onTap: () => provider.selectProfile(profile.sipCallerIDName),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/view/widgets/login/bottom_sheet/profile_list.dart
+++ b/lib/view/widgets/login/bottom_sheet/profile_list.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:telnyx_flutter_webrtc/model/profile_model.dart';
 import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
 
 class ProfileList extends StatelessWidget {
-  const ProfileList({Key? key}) : super(key: key);
+  final void Function(Profile) onProfileEditSelected;
+  const ProfileList({Key? key, required this.onProfileEditSelected})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +29,7 @@ class ProfileList extends StatelessWidget {
             final isSelected = provider.selectedProfile?.sipCallerIDName ==
                 profile.sipCallerIDName;
 
-            return  ListTile(
+            return ListTile(
               title: Text(profile.sipCallerIDName),
               subtitle: Text(profile.isTokenLogin ? 'Token' : 'Credentials'),
               selected: isSelected,
@@ -37,10 +40,20 @@ class ProfileList extends StatelessWidget {
                     ? Theme.of(context).colorScheme.primary
                     : Theme.of(context).iconTheme.color,
               ),
-              trailing: IconButton(
-                icon: const Icon(Icons.delete),
-                onPressed: () =>
-                    provider.removeProfile(profile.sipCallerIDName),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.edit),
+                    onPressed: () =>
+                      onProfileEditSelected(profile),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.delete),
+                    onPressed: () =>
+                        provider.removeProfile(profile.sipCallerIDName),
+                  ),
+                ],
               ),
               onTap: () => provider.selectProfile(profile.sipCallerIDName),
             );

--- a/lib/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart
+++ b/lib/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:telnyx_flutter_webrtc/model/profile_model.dart';
 import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
 import 'package:telnyx_flutter_webrtc/utils/dimensions.dart';
 import 'package:telnyx_flutter_webrtc/view/widgets/login/bottom_sheet/add_profile_form.dart';
@@ -16,6 +17,7 @@ class ProfileSwitcherBottomSheet extends StatefulWidget {
 class _ProfileSwitcherBottomSheetState
     extends State<ProfileSwitcherBottomSheet> {
   bool _isAddingProfile = false;
+  Profile? _selectedProfile;
 
   @override
   Widget build(BuildContext context) {
@@ -75,13 +77,21 @@ class _ProfileSwitcherBottomSheetState
                   _isAddingProfile = false;
                 }),
               },
+              existingProfile: _selectedProfile,
             )
           else
             Flexible(
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  const ProfileList(),
+                  ProfileList(
+                    onProfileEditSelected: (profile) => {
+                      setState(() {
+                        _selectedProfile = profile;
+                        _isAddingProfile = true;
+                      }),
+                    },
+                  ),
                   const SizedBox(height: spacingL),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.end,

--- a/lib/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart
+++ b/lib/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:telnyx_flutter_webrtc/model/profile_model.dart';
 import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
 import 'package:telnyx_flutter_webrtc/utils/dimensions.dart';
+import 'package:telnyx_flutter_webrtc/view/widgets/login/bottom_sheet/add_profile_form.dart';
+import 'package:telnyx_flutter_webrtc/view/widgets/login/bottom_sheet/profile_list.dart';
 
 class ProfileSwitcherBottomSheet extends StatefulWidget {
   const ProfileSwitcherBottomSheet({super.key});
@@ -25,39 +26,56 @@ class _ProfileSwitcherBottomSheetState
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Row(
-                children: [
-                  IconButton(
-                    icon: const Icon(Icons.close),
-                    onPressed: () => Navigator.pop(context),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  'Existing Profiles',
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
                   ),
-                  const Text(
-                    'Existing Profiles',
-                    style: TextStyle(
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ],
-              ),
-              if (!_isAddingProfile)
-                TextButton.icon(
-                  onPressed: () {
-                    setState(() {
-                      _isAddingProfile = true;
-                    });
-                  },
-                  icon: const Icon(Icons.add),
-                  label: const Text('Add new profile'),
                 ),
-            ],
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.pop(context),
+                ),
+              ],
+            ),
           ),
+          if (!_isAddingProfile)
+            ElevatedButton.icon(
+              onPressed: () {
+                setState(() {
+                  _isAddingProfile = true;
+                });
+              },
+              icon: const Icon(Icons.add, color: Colors.black),
+              label: const Text(
+                'Add new profile',
+                style: TextStyle(
+                  color: Colors.black,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Theme.of(context).colorScheme.surface,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(24.0),
+                ),
+              ),
+            ),
           const SizedBox(height: spacingM),
           if (_isAddingProfile)
-            const AddProfileForm()
+            AddProfileForm(
+              onCancelPressed: () => {
+                setState(() {
+                  _isAddingProfile = false;
+                }),
+              },
+            )
           else
             Flexible(
               child: Column(
@@ -86,239 +104,6 @@ class _ProfileSwitcherBottomSheetState
                 ],
               ),
             ),
-        ],
-      ),
-    );
-  }
-}
-
-class ProfileList extends StatelessWidget {
-  const ProfileList({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Consumer<ProfileProvider>(
-      builder: (context, provider, child) {
-        if (provider.profiles.isEmpty) {
-          return const Center(
-            child: Padding(
-              padding: EdgeInsets.all(16.0),
-              child: Text('No profiles yet'),
-            ),
-          );
-        }
-
-        return ListView.builder(
-          shrinkWrap: true,
-          itemCount: provider.profiles.length,
-          itemBuilder: (context, index) {
-            final profile = provider.profiles[index];
-            final isSelected = provider.selectedProfile?.sipCallerIDName ==
-                profile.sipCallerIDName;
-
-            return ListTile(
-              title: Text(profile.sipCallerIDName),
-              subtitle: Text(profile.isTokenLogin ? 'Token' : 'Credentials'),
-              selected: isSelected,
-              selectedTileColor: Theme.of(context).colorScheme.surface,
-              leading: Icon(
-                profile.isTokenLogin ? Icons.key : Icons.person,
-                color: isSelected
-                    ? Theme.of(context).colorScheme.primary
-                    : Theme.of(context).iconTheme.color,
-              ),
-              trailing: IconButton(
-                icon: const Icon(Icons.delete),
-                onPressed: () =>
-                    provider.removeProfile(profile.sipCallerIDName),
-              ),
-              onTap: () => provider.selectProfile(profile.sipCallerIDName),
-            );
-          },
-        );
-      },
-    );
-  }
-}
-
-class AddProfileForm extends StatefulWidget {
-  const AddProfileForm({Key? key}) : super(key: key);
-
-  @override
-  _AddProfileFormState createState() => _AddProfileFormState();
-}
-
-class _AddProfileFormState extends State<AddProfileForm> {
-  bool _isTokenLogin = false;
-  final _formKey = GlobalKey<FormState>();
-  final _nameController = TextEditingController();
-  final _tokenController = TextEditingController();
-  final _sipUserController = TextEditingController();
-  final _sipPasswordController = TextEditingController();
-  final _sipCallerIDNameController = TextEditingController();
-  final _sipCallerIDNumberController = TextEditingController();
-
-  @override
-  void dispose() {
-    _nameController.dispose();
-    _tokenController.dispose();
-    _sipUserController.dispose();
-    _sipPasswordController.dispose();
-    _sipCallerIDNameController.dispose();
-    _sipCallerIDNumberController.dispose();
-    super.dispose();
-  }
-
-  void _resetForm() {
-    _nameController.clear();
-    _tokenController.clear();
-    _sipUserController.clear();
-    _sipPasswordController.clear();
-    _sipCallerIDNameController.clear();
-    _sipCallerIDNumberController.clear();
-    _isTokenLogin = false;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Form(
-      key: _formKey,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const SizedBox(height: spacingM),
-          Row(
-            children: [
-              Switch(
-                value: _isTokenLogin,
-                onChanged: (value) {
-                  setState(() {
-                    _isTokenLogin = value;
-                  });
-                },
-              ),
-              const SizedBox(width: spacingS),
-              Text(_isTokenLogin ? 'Token Login' : 'Credential Login'),
-            ],
-          ),
-          const SizedBox(height: spacingM),
-          if (_isTokenLogin)
-            TextFormField(
-              controller: _tokenController,
-              decoration: const InputDecoration(
-                labelText: 'Token',
-                hintText: 'Enter your token',
-              ),
-              validator: (value) {
-                if (value == null || value.isEmpty) {
-                  return 'Please enter a token';
-                }
-                return null;
-              },
-            )
-          else
-            Column(
-              children: [
-                TextFormField(
-                  controller: _sipUserController,
-                  decoration: const InputDecoration(
-                    labelText: 'SIP Username',
-                    hintText: 'Enter your SIP username',
-                  ),
-                  validator: (value) {
-                    if (value == null || value.isEmpty) {
-                      return 'Please enter a SIP username';
-                    }
-                    return null;
-                  },
-                ),
-                const SizedBox(height: spacingS),
-                TextFormField(
-                  controller: _sipPasswordController,
-                  decoration: const InputDecoration(
-                    labelText: 'SIP Password',
-                    hintText: 'Enter your SIP password',
-                  ),
-                  obscureText: true,
-                  validator: (value) {
-                    if (value == null || value.isEmpty) {
-                      return 'Please enter a SIP password';
-                    }
-                    return null;
-                  },
-                ),
-              ],
-            ),
-          const SizedBox(height: spacingM),
-          TextFormField(
-            controller: _sipCallerIDNameController,
-            decoration: const InputDecoration(
-              labelText: 'Caller ID Name',
-              hintText: 'Enter your caller ID name',
-            ),
-            validator: (value) {
-              if (value == null || value.isEmpty) {
-                return 'Please enter a caller ID name';
-              }
-              return null;
-            },
-          ),
-          const SizedBox(height: spacingS),
-          TextFormField(
-            controller: _sipCallerIDNumberController,
-            decoration: const InputDecoration(
-              labelText: 'Caller ID Number',
-              hintText: 'Enter your caller ID number',
-            ),
-            validator: (value) {
-              if (value == null || value.isEmpty) {
-                return 'Please enter a caller ID number';
-              }
-              return null;
-            },
-          ),
-          const SizedBox(height: spacingL),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: () {
-                  setState(() {
-                    _resetForm();
-                  });
-                },
-                child: const Text('Cancel'),
-              ),
-              const SizedBox(width: spacingM),
-              ElevatedButton(
-                onPressed: () {
-                  if (_formKey.currentState!.validate()) {
-                    final profile = Profile(
-                      isTokenLogin: _isTokenLogin,
-                      token: _tokenController.text,
-                      sipUser: _sipUserController.text,
-                      sipPassword: _sipPasswordController.text,
-                      sipCallerIDName: _sipCallerIDNameController.text,
-                      sipCallerIDNumber: _sipCallerIDNumberController.text,
-                    );
-
-                    try {
-                      context.read<ProfileProvider>().addProfile(profile);
-                      setState(() {
-                        _resetForm();
-                      });
-                    } catch (e) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text(e.toString())),
-                      );
-                    }
-                  }
-                },
-                child: const Text('Save'),
-              ),
-            ],
-          ),
         ],
       ),
     );

--- a/lib/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart
+++ b/lib/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart
@@ -1,0 +1,320 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:telnyx_flutter_webrtc/model/profile_model.dart';
+import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
+import 'package:telnyx_flutter_webrtc/utils/dimensions.dart';
+
+class ProfileSwitcherBottomSheet extends StatefulWidget {
+  const ProfileSwitcherBottomSheet({super.key});
+
+  @override
+  State<ProfileSwitcherBottomSheet> createState() =>
+      _ProfileSwitcherBottomSheetState();
+}
+
+class _ProfileSwitcherBottomSheetState extends State<ProfileSwitcherBottomSheet> {
+  bool _isAddingProfile = false;
+  bool _isTokenLogin = false;
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _tokenController = TextEditingController();
+  final _sipUserController = TextEditingController();
+  final _sipPasswordController = TextEditingController();
+  final _sipCallerIDNameController = TextEditingController();
+  final _sipCallerIDNumberController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _tokenController.dispose();
+    _sipUserController.dispose();
+    _sipPasswordController.dispose();
+    _sipCallerIDNameController.dispose();
+    _sipCallerIDNumberController.dispose();
+    super.dispose();
+  }
+
+  void _resetForm() {
+    _nameController.clear();
+    _tokenController.clear();
+    _sipUserController.clear();
+    _sipPasswordController.clear();
+    _sipCallerIDNameController.clear();
+    _sipCallerIDNumberController.clear();
+    _isTokenLogin = false;
+  }
+
+  Widget _buildProfileList() {
+    return Consumer<ProfileProvider>(
+      builder: (context, provider, child) {
+        if (provider.profiles.isEmpty) {
+          return const Center(
+            child: Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Text('No profiles yet'),
+            ),
+          );
+        }
+
+        return ListView.builder(
+          shrinkWrap: true,
+          itemCount: provider.profiles.length,
+          itemBuilder: (context, index) {
+            final profile = provider.profiles[index];
+            final isSelected = provider.selectedProfile?.name == profile.name;
+
+            return ListTile(
+              title: Text(profile.name),
+              subtitle: Text(profile.isTokenLogin ? 'Token' : 'Credentials'),
+              selected: isSelected,
+              selectedTileColor: Theme.of(context).colorScheme.primaryContainer,
+              leading: Icon(
+                profile.isTokenLogin ? Icons.key : Icons.person,
+                color: isSelected
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).iconTheme.color,
+              ),
+              trailing: IconButton(
+                icon: const Icon(Icons.delete),
+                onPressed: () => provider.removeProfile(profile.name),
+              ),
+              onTap: () => provider.selectProfile(profile.name),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildAddProfileForm() {
+    return Form(
+      key: _formKey,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextFormField(
+            controller: _nameController,
+            decoration: const InputDecoration(
+              labelText: 'Profile Name',
+              hintText: 'Enter a name for this profile',
+            ),
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return 'Please enter a profile name';
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: spacingM),
+          Row(
+            children: [
+              Switch(
+                value: _isTokenLogin,
+                onChanged: (value) {
+                  setState(() {
+                    _isTokenLogin = value;
+                  });
+                },
+              ),
+              const SizedBox(width: spacingS),
+              Text(_isTokenLogin ? 'Token Login' : 'Credential Login'),
+            ],
+          ),
+          const SizedBox(height: spacingM),
+          if (_isTokenLogin)
+            TextFormField(
+              controller: _tokenController,
+              decoration: const InputDecoration(
+                labelText: 'Token',
+                hintText: 'Enter your token',
+              ),
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Please enter a token';
+                }
+                return null;
+              },
+            )
+          else
+            Column(
+              children: [
+                TextFormField(
+                  controller: _sipUserController,
+                  decoration: const InputDecoration(
+                    labelText: 'SIP Username',
+                    hintText: 'Enter your SIP username',
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter a SIP username';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: spacingS),
+                TextFormField(
+                  controller: _sipPasswordController,
+                  decoration: const InputDecoration(
+                    labelText: 'SIP Password',
+                    hintText: 'Enter your SIP password',
+                  ),
+                  obscureText: true,
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter a SIP password';
+                    }
+                    return null;
+                  },
+                ),
+              ],
+            ),
+          const SizedBox(height: spacingM),
+          TextFormField(
+            controller: _sipCallerIDNameController,
+            decoration: const InputDecoration(
+              labelText: 'Caller ID Name',
+              hintText: 'Enter your caller ID name',
+            ),
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return 'Please enter a caller ID name';
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: spacingS),
+          TextFormField(
+            controller: _sipCallerIDNumberController,
+            decoration: const InputDecoration(
+              labelText: 'Caller ID Number',
+              hintText: 'Enter your caller ID number',
+            ),
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return 'Please enter a caller ID number';
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: spacingL),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                onPressed: () {
+                  setState(() {
+                    _isAddingProfile = false;
+                    _resetForm();
+                  });
+                },
+                child: const Text('Cancel'),
+              ),
+              const SizedBox(width: spacingM),
+              ElevatedButton(
+                onPressed: () {
+                  if (_formKey.currentState!.validate()) {
+                    final profile = Profile(
+                      name: _nameController.text,
+                      isTokenLogin: _isTokenLogin,
+                      token: _tokenController.text,
+                      sipUser: _sipUserController.text,
+                      sipPassword: _sipPasswordController.text,
+                      sipCallerIDName: _sipCallerIDNameController.text,
+                      sipCallerIDNumber: _sipCallerIDNumberController.text,
+                    );
+
+                    try {
+                      context.read<ProfileProvider>().addProfile(profile);
+                      setState(() {
+                        _isAddingProfile = false;
+                        _resetForm();
+                      });
+                    } catch (e) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(e.toString())),
+                      );
+                    }
+                  }
+                },
+                child: const Text('Save'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.pop(context),
+                  ),
+                  const Text(
+                    'Existing Profiles',
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
+              ),
+              if (!_isAddingProfile)
+                TextButton.icon(
+                  onPressed: () {
+                    setState(() {
+                      _isAddingProfile = true;
+                    });
+                  },
+                  icon: const Icon(Icons.add),
+                  label: const Text('Add new profile'),
+                ),
+            ],
+          ),
+          const SizedBox(height: spacingM),
+          if (_isAddingProfile)
+            _buildAddProfileForm()
+          else
+            Flexible(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _buildProfileList(),
+                  const SizedBox(height: spacingL),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(context),
+                        child: const Text('Cancel'),
+                      ),
+                      const SizedBox(width: spacingM),
+                      ElevatedButton(
+                        onPressed: context.watch<ProfileProvider>().selectedProfile != null
+                            ? () => Navigator.pop(context)
+                            : null,
+                        child: const Text('Confirm'),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart
+++ b/lib/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart
@@ -59,7 +59,7 @@ class _ProfileSwitcherBottomSheetState
                 'Add new profile',
                 style: TextStyle(
                   color: Colors.black,
-                  fontWeight: FontWeight.bold,
+                  fontWeight: FontWeight.w400,
                 ),
               ),
               style: ElevatedButton.styleFrom(

--- a/lib/view/widgets/login/login_controls.dart
+++ b/lib/view/widgets/login/login_controls.dart
@@ -17,6 +17,7 @@ class _LoginControlsState extends State<LoginControls> {
   void _showProfileSwitcher() {
     showModalBottomSheet(
       context: context,
+      backgroundColor: Colors.white,
       isScrollControlled: true,
       builder: (context) => Padding(
         padding: EdgeInsets.only(
@@ -39,7 +40,7 @@ class _LoginControlsState extends State<LoginControls> {
         const SizedBox(height: spacingS),
         Row(
           children: <Widget>[
-            Text(selectedProfile?.name ?? 'No profile selected'),
+            Text(selectedProfile?.sipCallerIDName ?? 'No profile selected'),
             SizedBox(width: spacingS),
             TextButton(
               onPressed: _showProfileSwitcher,

--- a/lib/view/widgets/login/login_controls.dart
+++ b/lib/view/widgets/login/login_controls.dart
@@ -37,7 +37,7 @@ class _LoginControlsState extends State<LoginControls> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         Text('Profile', style: Theme.of(context).textTheme.labelMedium),
-        const SizedBox(height: spacingS),
+        const SizedBox(height: spacingXS),
         Row(
           children: <Widget>[
             Text(selectedProfile?.sipCallerIDName ?? 'No profile selected'),
@@ -48,6 +48,7 @@ class _LoginControlsState extends State<LoginControls> {
             ),
           ],
         ),
+        const SizedBox(height: spacingS),
         SizedBox(
           width: double.infinity,
           child: ElevatedButton(
@@ -65,7 +66,22 @@ class _LoginControlsState extends State<LoginControls> {
                     }
                   }
                 : null,
-            child: const Text('Connect'),
+            child: Consumer<TelnyxClientViewModel>(
+              builder: (context, provider, child) {
+                if (provider.loggingIn) {
+                  return SizedBox(
+                    width: spacingXL,
+                    height: spacingXL,
+                    child: const CircularProgressIndicator(
+                      color: Colors.white,
+                      strokeWidth: 2,
+                    ),
+                  );
+                } else {
+                  return const Text('Connect');
+                }
+              },
+            ),
           ),
         ),
       ],

--- a/lib/view/widgets/login/login_controls.dart
+++ b/lib/view/widgets/login/login_controls.dart
@@ -4,6 +4,7 @@ import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
 import 'package:telnyx_flutter_webrtc/utils/dimensions.dart';
 import 'package:telnyx_flutter_webrtc/view/telnyx_client_view_model.dart';
 import 'package:telnyx_flutter_webrtc/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
 
 class LoginControls extends StatefulWidget {
   const LoginControls({super.key});

--- a/lib/view/widgets/login/login_controls.dart
+++ b/lib/view/widgets/login/login_controls.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
 import 'package:telnyx_flutter_webrtc/utils/dimensions.dart';
 import 'package:telnyx_flutter_webrtc/view/telnyx_client_view_model.dart';
-import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_flutter_webrtc/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart';
 
 class LoginControls extends StatefulWidget {
   const LoginControls({super.key});
@@ -12,38 +13,35 @@ class LoginControls extends StatefulWidget {
 }
 
 class _LoginControlsState extends State<LoginControls> {
-  bool isTokenLogin = false;
+  void _showProfileSwitcher() {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: const ProfileSwitcherBottomSheet(),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
+    final profileProvider = context.watch<ProfileProvider>();
+    final selectedProfile = profileProvider.selectedProfile;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Token Login', style: Theme.of(context).textTheme.labelMedium),
-        const SizedBox(height: spacingS),
-        Row(
-          children: <Widget>[
-            Switch(
-              value: isTokenLogin,
-              onChanged: (value) {
-                setState(() {
-                  isTokenLogin = value;
-                });
-              },
-            ),
-            SizedBox(width: spacingS),
-            Text(isTokenLogin ? 'On' : 'Off'),
-          ],
-        ),
-        const SizedBox(height: spacingXL),
         Text('Profile', style: Theme.of(context).textTheme.labelMedium),
         const SizedBox(height: spacingS),
         Row(
           children: <Widget>[
-            Text('User'),
+            Text(selectedProfile?.name ?? 'No profile selected'),
             SizedBox(width: spacingS),
             TextButton(
-              onPressed: () {},
+              onPressed: _showProfileSwitcher,
               child: const Text('Switch Profile'),
             ),
           ],
@@ -51,17 +49,20 @@ class _LoginControlsState extends State<LoginControls> {
         SizedBox(
           width: double.infinity,
           child: ElevatedButton(
-            onPressed: () {
-              Provider.of<TelnyxClientViewModel>(context, listen: false).login(
-                CredentialConfig(
-                  sipUser: 'placeholder',
-                  sipPassword: 'placeholder',
-                  sipCallerIDName: 'placeholder',
-                  sipCallerIDNumber: 'placeholder',
-                  debug: false,
-                ),
-              );
-            },
+            onPressed: selectedProfile != null
+                ? () {
+                    final viewModel = context.read<TelnyxClientViewModel>();
+                    if (selectedProfile.isTokenLogin) {
+                      viewModel.loginWithToken(
+                        selectedProfile.toTelnyxConfig() as TokenConfig,
+                      );
+                    } else {
+                      viewModel.login(
+                        selectedProfile.toTelnyxConfig() as CredentialConfig,
+                      );
+                    }
+                  }
+                : null,
             child: const Text('Connect'),
           ),
         ),


### PR DESCRIPTION
Implements the profile switcher logic which includes adding a new profile for a fresh login.

Features:
- Add profile (Token and SIP Credentials)
- Delete profile
- Select Profile
- Persistent storage using SharedPreferences
- Automatic login with selected profile

Changes:
- Created profile model for storing user credentials
- Added profile provider with SharedPreferences persistence
- Implemented profile switcher bottom sheet UI
- Updated login controls to use profiles
- Added support for token and credential login

Jira: WEBRTC-2449