### PR TITLE
Bump Dependencies (UUID)

### DIFF
--- a/packages/telnyx_webrtc/CHANGELOG.md
+++ b/packages/telnyx_webrtc/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.1.4](https://pub.dev/packages/telnyx_webrtc/versions/0.1.4) (2025-01-28)
+
+### Enhancement
+
+- Update UUID dependency to latest version to avoid conflicts with implementers of the SDK
+
 ## [0.1.3](https://pub.dev/packages/telnyx_webrtc/versions/0.1.3) (2025-01-06)
 
 ### Enhancement

--- a/packages/telnyx_webrtc/pubspec.yaml
+++ b/packages/telnyx_webrtc/pubspec.yaml
@@ -12,12 +12,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_webrtc: ^0.12.5+hotfix.2
+  flutter_webrtc: ^0.12.7
   logger: ^2.5.0
-  uuid: ^3.0.6
-  just_audio: ^0.9.42
-  shared_preferences: ^2.2.3
-  connectivity_plus: ^6.1.0
+  uuid: ^4.5.1
+  just_audio: ^0.9.43
+  shared_preferences: ^2.4.0
+  connectivity_plus: ^6.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
[WEBRTC-2460 - UUID Dependency Bump.](https://telnyx.atlassian.net/browse/WEBRTC-2460)

---
<!-- Describe your changes here -->

## :older_man: :baby: Behaviors
### Before changes
- Old version of UUID causing conflicts for implementers.

### After changes
- Latest version of UUID

## ✋ Manual testing
1. Launch app and use as normal

