### PR TITLE
Handle TokenConfig reconnection for PushNotifications 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -287,11 +287,11 @@ Future<void> main() async {
             // Check if we are from push, if we are do nothing, reconnection will happen there in handlePush. Otherwise connect
             if (!txClientViewModel.callFromPush)
               {
-                if (config is CredentialConfig)
+                if (config != null && config is CredentialConfig)
                   {
                     txClientViewModel.login(config),
                   }
-                else if (config is TokenConfig)
+                else if (config != null && config is TokenConfig)
                   {
                     txClientViewModel.loginWithToken(config),
                   },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:telnyx_webrtc/telnyx_client.dart';
 import 'package:telnyx_webrtc/model/telnyx_message.dart';
 import 'package:telnyx_webrtc/model/socket_method.dart';
 import 'package:telnyx_flutter_webrtc/utils/theme.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
 
 final logger = Logger();
 final txClientViewModel = TelnyxClientViewModel();
@@ -227,11 +228,11 @@ Future _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 
           logger.i('iOS notification token :: $token');
         }
-        final credentialConfig = await txClientViewModel.getCredentialConfig();
+        final config = await txClientViewModel.getConfig();
         telnyxClient.handlePushNotification(
           pushMetaData,
-          credentialConfig,
-          null,
+          config is CredentialConfig ? config : null,
+          config is TokenConfig ? config : null,
         );
         break;
       case Event.actionDidUpdateDevicePushTokenVoip:
@@ -276,7 +277,7 @@ Future<void> main() async {
     await AppInitializer().initialize();
   }
 
-  final credentialConfig = await txClientViewModel.getCredentialConfig();
+  final config = await txClientViewModel.getConfig();
   runApp(
     BackgroundDetector(
       onLifecycleEvent: (AppLifecycleState state) => {
@@ -286,7 +287,14 @@ Future<void> main() async {
             // Check if we are from push, if we are do nothing, reconnection will happen there in handlePush. Otherwise connect
             if (!txClientViewModel.callFromPush)
               {
-                txClientViewModel.login(credentialConfig),
+                if (config is CredentialConfig)
+                  {
+                    txClientViewModel.login(config),
+                  }
+                else if (config is TokenConfig)
+                  {
+                    txClientViewModel.loginWithToken(config),
+                  },
               },
           }
         else if (state == AppLifecycleState.paused)
@@ -319,9 +327,13 @@ Future<void> handlePush(Map<dynamic, dynamic> data) async {
     pushMetaData = PushMetaData.fromJson(data);
     logger.i('iOS notification token :: $token');
   }
-  final credentialConfig = await txClientViewModel.getCredentialConfig();
+  final config = await txClientViewModel.getConfig();
   txClientViewModel
-    ..handlePushNotification(pushMetaData!, credentialConfig, null)
+    ..handlePushNotification(
+      pushMetaData!,
+      config is CredentialConfig ? config : null,
+      config is TokenConfig ? config : null,
+    )
     ..observeResponses();
   logger.i('actionCallIncoming :: Received Incoming Call! Handle Push');
 }

--- a/lib/model/profile_model.dart
+++ b/lib/model/profile_model.dart
@@ -1,3 +1,8 @@
+import 'dart:io';
+
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_callkit_incoming/flutter_callkit_incoming.dart';
 import 'package:telnyx_webrtc/config/telnyx_config.dart';
 
 class Profile {
@@ -7,6 +12,7 @@ class Profile {
   final String sipPassword;
   final String sipCallerIDName;
   final String sipCallerIDNumber;
+  final String? notificationToken;
 
   Profile({
     required this.isTokenLogin,
@@ -15,6 +21,7 @@ class Profile {
     this.sipPassword = '',
     this.sipCallerIDName = '',
     this.sipCallerIDNumber = '',
+    this.notificationToken = '',
   });
 
   factory Profile.fromJson(Map<String, dynamic> json) {
@@ -25,6 +32,7 @@ class Profile {
       sipPassword: json['sipPassword'] as String? ?? '',
       sipCallerIDName: json['sipCallerIDName'] as String? ?? '',
       sipCallerIDNumber: json['sipCallerIDNumber'] as String? ?? '',
+      notificationToken: json['notificationToken'] as String? ?? '',
     );
   }
 
@@ -36,15 +44,27 @@ class Profile {
       'sipPassword': sipPassword,
       'sipCallerIDName': sipCallerIDName,
       'sipCallerIDNumber': sipCallerIDNumber,
+      'notificationToken': notificationToken,
     };
   }
 
-  Config toTelnyxConfig() {
+  Future<String?> getNotificationTokenForPlatform() async {
+    var token;
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      token = (await FirebaseMessaging.instance.getToken())!;
+    } else if (Platform.isIOS) {
+      token = await FlutterCallkitIncoming.getDevicePushTokenVoIP();
+    }
+    return token;
+  }
+
+  Future<Config> toTelnyxConfig() async {
     if (isTokenLogin) {
       return TokenConfig(
         sipToken: token,
         sipCallerIDName: sipCallerIDName,
         sipCallerIDNumber: sipCallerIDNumber,
+        notificationToken: await getNotificationTokenForPlatform() ?? '',
         debug: false,
       );
     } else {
@@ -53,6 +73,7 @@ class Profile {
         sipPassword: sipPassword,
         sipCallerIDName: sipCallerIDName,
         sipCallerIDNumber: sipCallerIDNumber,
+        notificationToken: await getNotificationTokenForPlatform() ?? '',
         debug: false,
       );
     }

--- a/lib/model/profile_model.dart
+++ b/lib/model/profile_model.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_callkit_incoming/flutter_callkit_incoming.dart';
@@ -51,6 +52,10 @@ class Profile {
   Future<String?> getNotificationTokenForPlatform() async {
     var token;
     if (defaultTargetPlatform == TargetPlatform.android) {
+      // If no apps are initialized, initialize one now.
+      if (Firebase.apps.isEmpty) {
+        await Firebase.initializeApp();
+      }
       token = (await FirebaseMessaging.instance.getToken())!;
     } else if (Platform.isIOS) {
       token = await FlutterCallkitIncoming.getDevicePushTokenVoIP();

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -382,13 +382,7 @@ class TelnyxClientViewModel with ChangeNotifier {
         debug: true,
       );
     } else {
-      return CredentialConfig(
-        sipCallerIDName: 'Flutter Voice',
-        sipCallerIDNumber: '',
-        sipUser: MOCK_USER,
-        sipPassword: MOCK_PASSWORD,
-        debug: true,
-      );
+     return null;
     }
   }
 
@@ -407,12 +401,7 @@ class TelnyxClientViewModel with ChangeNotifier {
         debug: true,
       );
     } else {
-      return TokenConfig(
-        sipCallerIDName: 'Flutter Voice',
-        sipCallerIDNumber: '',
-        sipToken: '',
-        debug: true,
-      );
+      return null;
     }
   }
 

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -353,12 +353,22 @@ class TelnyxClientViewModel with ChangeNotifier {
 
   bool waitingForInvite = false;
 
-  Future<CredentialConfig> getCredentialConfig() async {
+  Future<Config?> getConfig() async {
+    final config = await _getCredentialConfig();
+    if (config != null) {
+      return config;
+    } else {
+      return await _getTokenConfig();
+    }
+  }
+
+  Future<CredentialConfig?> _getCredentialConfig() async {
     final prefs = await SharedPreferences.getInstance();
     final sipUser = prefs.getString('sipUser');
     final sipPassword = prefs.getString('sipPassword');
     final sipName = prefs.getString('sipName');
     final sipNumber = prefs.getString('sipNumber');
+    final notificationToken = prefs.getString('notificationToken');
     if (sipUser != null &&
         sipPassword != null &&
         sipName != null &&
@@ -368,6 +378,7 @@ class TelnyxClientViewModel with ChangeNotifier {
         sipCallerIDNumber: sipNumber,
         sipUser: sipUser,
         sipPassword: sipPassword,
+        notificationToken: notificationToken,
         debug: true,
       );
     } else {
@@ -376,6 +387,30 @@ class TelnyxClientViewModel with ChangeNotifier {
         sipCallerIDNumber: '',
         sipUser: MOCK_USER,
         sipPassword: MOCK_PASSWORD,
+        debug: true,
+      );
+    }
+  }
+
+  Future<TokenConfig?> _getTokenConfig() async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString('token');
+    final sipName = prefs.getString('sipName');
+    final sipNumber = prefs.getString('sipNumber');
+    final notificationToken = prefs.getString('notificationToken');
+    if (token != null && sipName != null && sipNumber != null) {
+      return TokenConfig(
+        sipCallerIDName: sipName,
+        sipCallerIDNumber: sipNumber,
+        sipToken: token,
+        notificationToken: notificationToken,
+        debug: true,
+      );
+    } else {
+      return TokenConfig(
+        sipCallerIDName: 'Flutter Voice',
+        sipCallerIDNumber: '',
+        sipToken: '',
         debug: true,
       );
     }

--- a/lib/view/widgets/login/login_controls.dart
+++ b/lib/view/widgets/login/login_controls.dart
@@ -53,16 +53,13 @@ class _LoginControlsState extends State<LoginControls> {
           width: double.infinity,
           child: ElevatedButton(
             onPressed: selectedProfile != null
-                ? () {
+                ? () async {
                     final viewModel = context.read<TelnyxClientViewModel>();
-                    if (selectedProfile.isTokenLogin) {
-                      viewModel.loginWithToken(
-                        selectedProfile.toTelnyxConfig() as TokenConfig,
-                      );
-                    } else {
-                      viewModel.login(
-                        selectedProfile.toTelnyxConfig() as CredentialConfig,
-                      );
+                    final config = await selectedProfile.toTelnyxConfig();
+                    if (config is TokenConfig) {
+                      viewModel.loginWithToken(config);
+                    } else if (config is CredentialConfig) {
+                      viewModel.login(config);
                     }
                   }
                 : null,


### PR DESCRIPTION
[ENGDESK-38173 - Handle TokenConfig reconnection for PushNotifications .](https://telnyx.atlassian.net/browse/ENGDESK-38173)

---
<!-- Describe your changes here -->

## :older_man: :baby: Behaviors
### Before changes
- We were only handle CredentialConfigs when reconnecting to the TelnyxClient as a result of a push notification in the sample app, meaning people using TokenConfigs could not log back in to receive the call. 

### After changes
- We now handle both Credential and Token Configs when reconnecting as a result of a push notification in the sample app.

## ✋ Manual testing
1. Launch app
2. Register with Token
3. Login
4. Logout
5. Call and receive push notification + reconnect and connect to call
6. Retest flow with Credential Config as well. 
