### PR TITLE
Custom Logging Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,57 @@ Once an instance is created, you can call the .connect() method to connect to th
     TelnyxClient _telnyxClient = TelnyxClient();
 ```
 
+### Logging Configuration
+The SDK provides a flexible logging system that allows you to control the verbosity of logs and even implement your own custom logging solution. There are two main aspects to configure:
+
+1. **Log Level**
+The `LogLevel` enum determines which types of logs are displayed:
+```dart
+enum LogLevel {
+  none,    // Disable all logs (default)
+  error,   // Print error logs only
+  warning, // Print warning logs only
+  debug,   // Print debug logs only
+  info,    // Print info logs only
+  verto,   // Print verto protocol messages
+  all      // Print all logs
+}
+```
+
+2. **Custom Logger**
+You can implement your own logging solution by extending the `CustomLogger` abstract class:
+```dart
+class MyCustomLogger extends CustomLogger {
+  @override
+  void e(String message) => print('ERROR: $message');
+  
+  @override
+  void w(String message) => print('WARNING: $message');
+  
+  @override
+  void d(String message) => print('DEBUG: $message');
+  
+  @override
+  void i(String message) => print('INFO: $message');
+  
+  @override
+  void v(String message) => print('VERTO: $message');
+}
+```
+
+Both the log level and custom logger can be configured in the `Config` class:
+```dart
+var config = CredentialConfig(
+  sipUser: 'username',
+  sipPassword: 'password',
+  sipCallerIDName: 'Caller Name',
+  sipCallerIDNumber: '1234567890',
+  debug: true,  // Enable logging
+  logLevel: LogLevel.debug,  // Set log level
+  customLogger: MyCustomLogger(),  // Optional: provide custom logger
+);
+```
+
 ### Logging into Telnyx Client
 To log into the Telnyx WebRTC client, you'll need to authenticate using a Telnyx SIP Connection. Follow our [quickstart guide](https://developers.telnyx.com/docs/v2/webrtc/quickstart) to create **JWTs** (JSON Web Tokens) to authenticate. To log in with a token we use the connectWithToken() method. You can also authenticate directly with the SIP Connection `username` and `password` with the connectWithCredential() method:
 

--- a/README.md
+++ b/README.md
@@ -77,19 +77,10 @@ You can implement your own logging solution by extending the `CustomLogger` abst
 ```dart
 class MyCustomLogger extends CustomLogger {
   @override
-  void e(String message) => print('ERROR: $message');
-  
-  @override
-  void w(String message) => print('WARNING: $message');
-  
-  @override
-  void d(String message) => print('DEBUG: $message');
-  
-  @override
-  void i(String message) => print('INFO: $message');
-  
-  @override
-  void v(String message) => print('VERTO: $message');
+  log(LogLevel level, String message) {
+    print('[$level] $message');
+    // Implement any extra logging logic you would like here (eg. Send to a server, write to a file, etc.)
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ var config = CredentialConfig(
   sipPassword: 'password',
   sipCallerIDName: 'Caller Name',
   sipCallerIDNumber: '1234567890',
-  debug: true,  // Enable logging
+  debug: true,  // Enable debug mode which allows you to track call metrics and download them from the portal - this is different to the log level and custom logger
   logLevel: LogLevel.debug,  // Set log level
   customLogger: MyCustomLogger(),  // Optional: provide custom logger
 );

--- a/lib/model/profile_model.dart
+++ b/lib/model/profile_model.dart
@@ -5,7 +5,9 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_callkit_incoming/flutter_callkit_incoming.dart';
 import 'package:telnyx_flutter_webrtc/firebase_options.dart';
+import 'package:telnyx_flutter_webrtc/utils/custom_sdk_logger.dart';
 import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
 
 class Profile {
   final bool isTokenLogin;
@@ -79,6 +81,8 @@ class Profile {
         sipCallerIDNumber: sipCallerIDNumber,
         notificationToken: await getNotificationTokenForPlatform() ?? '',
         debug: false,
+        logLevel: LogLevel.debug,
+        customLogger: CustomSDKLogger()
       );
     } else {
       return CredentialConfig(
@@ -88,6 +92,8 @@ class Profile {
         sipCallerIDNumber: sipCallerIDNumber,
         notificationToken: await getNotificationTokenForPlatform() ?? '',
         debug: false,
+        logLevel: LogLevel.debug,
+        customLogger: CustomSDKLogger(),
       );
     }
   }

--- a/lib/utils/custom_sdk_logger.dart
+++ b/lib/utils/custom_sdk_logger.dart
@@ -1,0 +1,82 @@
+import 'package:logger/logger.dart';
+import 'package:telnyx_webrtc/utils/logging/custom_logger.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+
+/// Custom logger implementation that uses the Logger package to log messages based on the log level set by the user.
+class CustomSDKLogger implements CustomLogger {
+  /// Logger instance used to log messages
+  late Logger logger;
+
+  LogLevel _logLevel = LogLevel.info;
+
+  /// Default constructor that initializes the logger with the default log level
+  CustomSDKLogger() {
+    logger = Logger(
+      filter: CustomLogFilter(_logLevel),
+    );
+  }
+
+  @override
+  void setLogLevel(LogLevel level) {
+    _logLevel = level;
+    logger = Logger(
+      filter: CustomLogFilter(_logLevel),
+    );
+  }
+
+  @override
+  void d(String message) {
+    logger.d(message);
+  }
+
+  @override
+  void e(String message) {
+    logger.e(message);
+  }
+
+  @override
+  void i(String message) {
+    logger.i(message);
+  }
+
+  @override
+  void v(String message) {
+    logger.t(message);
+  }
+
+  @override
+  void w(String message) {
+    logger.w(message);
+  }
+}
+
+/// Custom log filter that will filter logs based on the log level set by the user
+class CustomLogFilter extends LogFilter {
+  /// Log level set by the user
+  final LogLevel logLevel;
+
+  /// Constructor that initializes the log level
+  CustomLogFilter(this.logLevel);
+
+  @override
+  bool shouldLog(LogEvent event) {
+    switch (logLevel) {
+      case LogLevel.none:
+        return false;
+      case LogLevel.error:
+        return event.level == Level.error;
+      case LogLevel.warning:
+        return event.level == Level.warning || event.level == Level.error;
+      case LogLevel.debug:
+        return event.level == Level.debug || event.level == Level.warning || event.level == Level.error;
+      case LogLevel.info:
+        return event.level == Level.info || event.level == Level.debug || event.level == Level.warning || event.level == Level.error;
+      case LogLevel.verto:
+        return event.level == Level.trace || event.level == Level.info || event.level == Level.debug || event.level == Level.warning || event.level == Level.error;
+      case LogLevel.all:
+        return true;
+      default:
+        return false;
+    }
+  }
+}

--- a/lib/utils/custom_sdk_logger.dart
+++ b/lib/utils/custom_sdk_logger.dart
@@ -25,26 +25,47 @@ class CustomSDKLogger implements CustomLogger {
   }
 
   @override
+  void log(LogLevel level, String message) {
+    switch (level) {
+      case LogLevel.error:
+        e(message);
+        break;
+      case LogLevel.warning:
+        w(message);
+        break;
+      case LogLevel.debug:
+        d(message);
+        break;
+      case LogLevel.info:
+        i(message);
+        break;
+      case LogLevel.verto:
+        v(message);
+        break;
+      case LogLevel.all:
+        v(message);
+        break;
+      case LogLevel.none:
+        break;
+    }
+  }
+
   void d(String message) {
     logger.d(message);
   }
 
-  @override
   void e(String message) {
     logger.e(message);
   }
 
-  @override
   void i(String message) {
     logger.i(message);
   }
 
-  @override
   void v(String message) {
     logger.t(message);
   }
 
-  @override
   void w(String message) {
     logger.w(message);
   }

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -9,6 +9,7 @@ import 'package:logger/logger.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:telnyx_flutter_webrtc/file_logger.dart';
 import 'package:telnyx_flutter_webrtc/utils/background_detector.dart';
+import 'package:telnyx_flutter_webrtc/utils/custom_sdk_logger.dart';
 import 'package:telnyx_flutter_webrtc/utils/theme.dart';
 import 'package:telnyx_webrtc/call.dart';
 import 'package:telnyx_webrtc/config/telnyx_config.dart';
@@ -19,6 +20,7 @@ import 'package:telnyx_webrtc/model/verto/receive/received_message_body.dart';
 import 'package:telnyx_webrtc/telnyx_client.dart';
 import 'package:telnyx_webrtc/model/push_notification.dart';
 import 'package:telnyx_webrtc/model/call_state.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
 
 enum CallStateStatus {
   disconnected,
@@ -396,6 +398,8 @@ class TelnyxClientViewModel with ChangeNotifier {
         sipPassword: sipPassword,
         notificationToken: notificationToken,
         debug: true,
+        logLevel: LogLevel.debug,
+        customLogger: CustomSDKLogger(),
       );
     } else {
       return null;
@@ -415,6 +419,7 @@ class TelnyxClientViewModel with ChangeNotifier {
         sipToken: token,
         notificationToken: notificationToken,
         debug: true,
+        logLevel: LogLevel.debug,
       );
     } else {
       return null;

--- a/packages/telnyx_webrtc/README.md
+++ b/packages/telnyx_webrtc/README.md
@@ -55,6 +55,57 @@ Once an instance is created, you can call the .connect() method to connect to th
     TelnyxClient _telnyxClient = TelnyxClient();
 ```
 
+### Logging Configuration
+The SDK provides a flexible logging system that allows you to control the verbosity of logs and even implement your own custom logging solution. There are two main aspects to configure:
+
+1. **Log Level**
+The `LogLevel` enum determines which types of logs are displayed:
+```dart
+enum LogLevel {
+  none,    // Disable all logs (default)
+  error,   // Print error logs only
+  warning, // Print warning logs only
+  debug,   // Print debug logs only
+  info,    // Print info logs only
+  verto,   // Print verto protocol messages
+  all      // Print all logs
+}
+```
+
+2. **Custom Logger**
+You can implement your own logging solution by extending the `CustomLogger` abstract class:
+```dart
+class MyCustomLogger extends CustomLogger {
+  @override
+  void e(String message) => print('ERROR: $message');
+  
+  @override
+  void w(String message) => print('WARNING: $message');
+  
+  @override
+  void d(String message) => print('DEBUG: $message');
+  
+  @override
+  void i(String message) => print('INFO: $message');
+  
+  @override
+  void v(String message) => print('VERTO: $message');
+}
+```
+
+Both the log level and custom logger can be configured in the `Config` class:
+```dart
+var config = CredentialConfig(
+  sipUser: 'username',
+  sipPassword: 'password',
+  sipCallerIDName: 'Caller Name',
+  sipCallerIDNumber: '1234567890',
+  debug: true,  // Enable logging
+  logLevel: LogLevel.debug,  // Set log level
+  customLogger: MyCustomLogger(),  // Optional: provide custom logger
+);
+```
+
 ### Logging into Telnyx Client
 To log into the Telnyx WebRTC client, you'll need to authenticate using a Telnyx SIP Connection. Follow our [quickstart guide](https://developers.telnyx.com/docs/v2/webrtc/quickstart) to create **JWTs** (JSON Web Tokens) to authenticate. To log in with a token we use the connectWithToken() method. You can also authenticate directly with the SIP Connection `username` and `password` with the connectWithCredential() method:
 

--- a/packages/telnyx_webrtc/README.md
+++ b/packages/telnyx_webrtc/README.md
@@ -77,19 +77,10 @@ You can implement your own logging solution by extending the `CustomLogger` abst
 ```dart
 class MyCustomLogger extends CustomLogger {
   @override
-  void e(String message) => print('ERROR: $message');
-  
-  @override
-  void w(String message) => print('WARNING: $message');
-  
-  @override
-  void d(String message) => print('DEBUG: $message');
-  
-  @override
-  void i(String message) => print('INFO: $message');
-  
-  @override
-  void v(String message) => print('VERTO: $message');
+  log(LogLevel level, String message) {
+    print('[$level] $message');
+    // Implement any extra logging logic you would like here (eg. Send to a server, write to a file, etc.)
+  }
 }
 ```
 

--- a/packages/telnyx_webrtc/README.md
+++ b/packages/telnyx_webrtc/README.md
@@ -99,8 +99,8 @@ var config = CredentialConfig(
   sipUser: 'username',
   sipPassword: 'password',
   sipCallerIDName: 'Caller Name',
-  sipCallerIDNumber: '1234567890',
-  debug: true,  // Enable logging
+  sipCallerIDNumber: '1234567890', 
+   debug: true,  // Enable debug mode which allows you to track call metrics and download them from the portal - this is different to the log level and custom logger
   logLevel: LogLevel.debug,  // Set log level
   customLogger: MyCustomLogger(),  // Optional: provide custom logger
 );

--- a/packages/telnyx_webrtc/lib/call.dart
+++ b/packages/telnyx_webrtc/lib/call.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
-import 'package:logger/logger.dart';
 import 'package:telnyx_webrtc/model/jsonrpc.dart';
 import 'package:telnyx_webrtc/telnyx_client.dart';
 
@@ -22,13 +21,21 @@ import 'package:telnyx_webrtc/model/call_state.dart';
 import 'package:telnyx_webrtc/model/gateway_state.dart';
 import 'package:telnyx_webrtc/model/telnyx_message.dart';
 
+/// Callback function to notify the user of the call state change
 typedef CallStateCallback = void Function(CallState state);
 
+/// The CallHandler class is used to handle the call state changes and notify
+/// the user of the changes via the [onCallStateChanged] callback.
 class CallHandler {
+  /// Callback function to notify the user of the call state change
   late CallStateCallback onCallStateChanged;
 
+  /// Default constructor that initializes the [onCallStateChanged] callback
   CallHandler(this.onCallStateChanged);
 
+  /// Changes the call state to the specified [state] and invokes the
+  /// [onCallStateChanged] callback to notify the user of the change
+  /// along with the [call] object that the state change is associated with.
   void changeState(CallState state, Call call) {
     // You can add any additional logic here before invoking the callback
     call.callState = state;
@@ -39,6 +46,7 @@ class CallHandler {
 /// The Call class which is used for call related methods such as hold/mute or
 /// creating invitations, declining calls, etc.
 class Call {
+  /// Default constructor that initializes the call with the provided parameters
   Call(
     this.txSocket,
     this._txClient,
@@ -50,10 +58,14 @@ class Call {
     this.debug,
   );
 
+  /// Initializes the call with the provided parameters
   late CallHandler callHandler;
+
+  /// The current state of the call
   late CallState callState;
 
-  final audioService = AudioService();
+  /// The audio service used to play audio files
+  final _audioService = AudioService();
 
   final bool debug;
   final Function callEnded;
@@ -71,7 +83,6 @@ class Call {
   String sessionDestinationNumber = '';
   String sessionClientState = '';
   Map<String, String> customHeaders = {};
-  final _logger = Logger();
 
   /// Creates an invitation to send to a [destinationNumber] or SIP Destination
   /// using the provided [callerName], [callerNumber] and a [clientState]
@@ -91,6 +102,8 @@ class Call {
     );
   }
 
+  /// Receives a remote session with the provided [sdp] and sets the remote
+  /// session on the peer connection
   void onRemoteSessionReceived(String? sdp) {
     if (sdp != null) {
       peerConnection?.remoteSessionReceived(sdp);
@@ -141,18 +154,18 @@ class Call {
     final String jsonByeMessage = jsonEncode(byeMessage);
 
     if (_txClient.gatewayState != GatewayState.reged) {
-      _logger
-          .d('Session end gateway not  registered ${_txClient.gatewayState}');
+      _txClient.logger
+          .d('Session end :: gateway not registered ${_txClient.gatewayState}');
       return;
     } else {
-      _logger.d('Session end peer connection null');
+      _txClient.logger.d('Session end :: peer connection null');
     }
 
     txSocket.send(jsonByeMessage);
     if (peerConnection != null) {
       peerConnection?.closeSession();
     } else {
-      _logger.d('Session end peer connection null');
+      _txClient.logger.d('Session end :: peer connection null');
     }
     stopAudio();
     callHandler.changeState(CallState.done, this);
@@ -203,6 +216,7 @@ class Call {
     peerConnection?.muteUnmuteMic();
   }
 
+  /// Either enables or disables the speaker phone based on the current state
   void enableSpeakerPhone(bool enable) {
     peerConnection?.enableSpeakerPhone(enable);
   }
@@ -255,29 +269,34 @@ class Call {
     txSocket.send(jsonModifyMessage);
   }
 
-  // Example file path for 'web/assets/audio/sound.wav'
+  /// Plays the ringtone audio file
+  /// Example file path for 'web/assets/audio/sound.wav'
   void playAudio(String filePath) {
     if (filePath.isNotEmpty) {
-      audioService.playLocalFile(filePath);
+      _audioService.playLocalFile(filePath);
     }
   }
 
-  // Play ringtone for only web, iOS and Android will use native audio player
+  /// Plays the specified ringtone file
+  /// Play ringtone for only web, iOS and Android will use native audio player
   void playRingtone(String filePath) {
     if (kIsWeb && filePath.isNotEmpty) {
-      audioService.playLocalFile(filePath);
+      _audioService.playLocalFile(filePath);
       return;
     }
   }
 
+  /// Stops the audio file from playing
   void stopAudio() {
-    audioService.stopAudio();
+    _audioService.stopAudio();
   }
 }
 
+/// The AudioService class is used to play audio files
 class AudioService {
   final AudioPlayer _audioPlayer = AudioPlayer();
 
+  /// Plays the audio file specified by the [filePath]
   Future<void> playLocalFile(String filePath) async {
     // Ensure the file path is correct and accessible from the web directory
     await _audioPlayer.setAsset(filePath);
@@ -285,6 +304,7 @@ class AudioService {
     await _audioPlayer.play();
   }
 
+  /// Stops the audio file from playing
   Future<void> stopAudio() async {
     // Ensure the file path is correct and accessible from the web directory
     await _audioPlayer.stop();

--- a/packages/telnyx_webrtc/lib/call.dart
+++ b/packages/telnyx_webrtc/lib/call.dart
@@ -14,6 +14,7 @@ import 'package:telnyx_webrtc/peer/peer.dart'
     if (dart.library.html) 'package:telnyx_webrtc/peer/web/peer.dart';
 import 'package:telnyx_webrtc/tx_socket.dart'
     if (dart.library.js) 'package:telnyx_webrtc/tx_socket_web.dart';
+import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
 import 'package:uuid/uuid.dart';
 import 'package:just_audio/just_audio.dart';
 
@@ -154,18 +155,18 @@ class Call {
     final String jsonByeMessage = jsonEncode(byeMessage);
 
     if (_txClient.gatewayState != GatewayState.reged) {
-      _txClient.logger
+      GlobalLogger()
           .d('Session end :: gateway not registered ${_txClient.gatewayState}');
       return;
     } else {
-      _txClient.logger.d('Session end :: peer connection null');
+      GlobalLogger().d('Session end :: peer connection null');
     }
 
     txSocket.send(jsonByeMessage);
     if (peerConnection != null) {
       peerConnection?.closeSession();
     } else {
-      _txClient.logger.d('Session end :: peer connection null');
+      GlobalLogger().d('Session end :: peer connection null');
     }
     stopAudio();
     callHandler.changeState(CallState.done, this);

--- a/packages/telnyx_webrtc/lib/config/telnyx_config.dart
+++ b/packages/telnyx_webrtc/lib/config/telnyx_config.dart
@@ -1,21 +1,46 @@
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+import 'package:telnyx_webrtc/utils/logging/custom_logger.dart';
+
 /// Base configuration class for common parameters
 class Config {
+  /// Base configuration class for common parameters
   Config({
     required this.sipCallerIDName,
     required this.sipCallerIDNumber,
     this.notificationToken,
     this.autoReconnect,
+    this.logLevel = LogLevel.info,
     required this.debug,
+    this.customLogger,
     this.ringTonePath,
     this.ringbackPath,
   });
 
+  /// Name associated with the SIP account
   final String sipCallerIDName;
+
+  /// Number associated with the SIP account
   final String sipCallerIDNumber;
+
+  /// Token used to register the device for notifications if required (FCM or APNS)
   final String? notificationToken;
+
+  /// Flag to decide whether or not to attempt a reconnect (3 attempts) in the case of a login failure with legitimate credentials
   final bool? autoReconnect;
+
+  /// Log level to set for SDK Logging
+  final LogLevel logLevel;
+
+  /// Flag to enable debug logs
   final bool debug;
+
+  /// Custom logger to use for logging - if left null the default logger will be used which uses the Logger package
+  final CustomLogger? customLogger;
+
+  /// Path to the ringtone file (audio to play when receiving a call)
   final String? ringTonePath;
+
+  /// Path to the ringback file (audio to play when calling)
   final String? ringbackPath;
 }
 
@@ -26,7 +51,24 @@ class Config {
 /// [notificationToken] is the token used to register the device for notifications if required (FCM or APNS)
 /// The [autoReconnect] flag decided whether or not to attempt a reconnect (3 attempts) in the case of a login failure with
 /// legitimate credentials
+/// [logLevel] is the log level to set for SDK Logging
+/// [debug] flag to enable debug logs which will collect stats for each call and provide WebRTC stats to view in the portal
+/// [ringTonePath] is the path to the ringtone file (audio to play when receiving a call)
+/// [ringbackPath] is the path to the ringback file (audio to play when calling)
+/// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
 class CredentialConfig extends Config {
+  /// Creates an instance of CredentialConfig which can be used to log in
+  ///
+  /// Uses the [sipUser] and [sipPassword] fields to log in
+  /// [sipCallerIDName] and [sipCallerIDNumber] will be the Name and Number associated
+  /// [notificationToken] is the token used to register the device for notifications if required (FCM or APNS)
+  /// The [autoReconnect] flag decided whether or not to attempt a reconnect (3 attempts) in the case of a login failure with
+  /// legitimate credentials
+  /// [logLevel] is the log level to set for SDK Logging
+  /// [debug] flag to enable debug logs which will collect stats for each call and provide WebRTC stats to view in the portal
+  /// [ringTonePath] is the path to the ringtone file (audio to play when receiving a call)
+  /// [ringbackPath] is the path to the ringback file (audio to play when calling)
+  /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
   CredentialConfig({
     required this.sipUser,
     required this.sipPassword,
@@ -34,12 +76,17 @@ class CredentialConfig extends Config {
     required super.sipCallerIDNumber,
     super.notificationToken,
     super.autoReconnect,
+    required super.logLevel,
     required super.debug,
     super.ringTonePath,
     super.ringbackPath,
+    super.customLogger,
   });
 
+  /// SIP username to log in with. Either a SIP Credential from the Portal or a Generated Credential from the API
   final String sipUser;
+
+  /// SIP password to log in with. Either a SIP Credential from the Portal or a Generated Credential from the API
   final String sipPassword;
 }
 
@@ -50,17 +97,37 @@ class CredentialConfig extends Config {
 /// [notificationToken] is the token used to register the device for notifications if required (FCM or APNS)
 /// The [autoReconnect] flag decided whether or not to attempt a reconnect (3 attempts) in the case of a login failure with
 /// a legitimate token
+/// [logLevel] is the log level to set for SDK Logging
+/// [debug] flag to enable debug logs which will collect stats for each call and provide WebRTC stats to view in the portal
+/// [ringTonePath] is the path to the ringtone file (audio to play when receiving a call)
+/// [ringbackPath] is the path to the ringback file (audio to play when calling)
+/// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
 class TokenConfig extends Config {
+  /// Creates an instance of TokenConfig which can be used to log in
+  ///
+  /// Uses the [sipToken] field to log in
+  /// [sipCallerIDName] and [sipCallerIDNumber] will be the Name and Number associated
+  /// [notificationToken] is the token used to register the device for notifications if required (FCM or APNS)
+  /// The [autoReconnect] flag decided whether or not to attempt a reconnect (3 attempts) in the case of a login failure with
+  /// a legitimate token
+  /// [logLevel] is the log level to set for SDK Logging
+  /// [debug] flag to enable debug logs which will collect stats for each call and provide WebRTC stats to view in the portal
+  /// [ringTonePath] is the path to the ringtone file (audio to play when receiving a call)
+  /// [ringbackPath] is the path to the ringback file (audio to play when calling)
+  /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
   TokenConfig({
     required this.sipToken,
     required super.sipCallerIDName,
     required super.sipCallerIDNumber,
     super.notificationToken,
     super.autoReconnect,
+    required super.logLevel,
     required super.debug,
     super.ringTonePath,
     super.ringbackPath,
+    super.customLogger,
   });
 
+  /// Token to log in with. The token would be generated from a Generated Credential via the API
   final String sipToken;
 }

--- a/packages/telnyx_webrtc/lib/model/verto/receive/received_message_body.dart
+++ b/packages/telnyx_webrtc/lib/model/verto/receive/received_message_body.dart
@@ -47,7 +47,7 @@ class ReceivedMessage {
     }
     if (json['voice_sdk_id'] != null) {
       voiceSdkId = json['voice_sdk_id'];
-      GlobalLogger.logger.i('Voice SDK ID: $voiceSdkId');
+      GlobalLogger().i('Voice SDK ID: $voiceSdkId');
     }
   }
 

--- a/packages/telnyx_webrtc/lib/model/verto/receive/received_message_body.dart
+++ b/packages/telnyx_webrtc/lib/model/verto/receive/received_message_body.dart
@@ -1,7 +1,7 @@
-import 'package:logger/logger.dart';
 import 'package:telnyx_webrtc/model/verto/receive/receive_bye_message_body.dart';
 import 'package:telnyx_webrtc/model/verto/send/invite_answer_message_body.dart';
 import 'package:telnyx_webrtc/model/telnyx_socket_error.dart';
+import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
 
 class ReceivedMessage {
   String? jsonrpc;
@@ -47,7 +47,7 @@ class ReceivedMessage {
     }
     if (json['voice_sdk_id'] != null) {
       voiceSdkId = json['voice_sdk_id'];
-      Logger().i('Voice SDK ID: $voiceSdkId');
+      GlobalLogger.logger.i('Voice SDK ID: $voiceSdkId');
     }
   }
 

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -81,7 +81,7 @@ class Peer {
       final bool enabled = _localStream!.getAudioTracks()[0].enabled;
       _localStream!.getAudioTracks()[0].enabled = !enabled;
     } else {
-      GlobalLogger.logger.d('Peer :: No local stream :: Unable to Mute / Unmute');
+      GlobalLogger().d('Peer :: No local stream :: Unable to Mute / Unmute');
     }
   }
 
@@ -89,7 +89,7 @@ class Peer {
     if (_localStream != null) {
       _localStream!.getAudioTracks()[0].enableSpeakerphone(enable);
     } else {
-      GlobalLogger.logger.d('Peer :: No local stream :: Unable to toggle speaker mode');
+      GlobalLogger().d('Peer :: No local stream :: Unable to toggle speaker mode');
     }
   }
 
@@ -147,7 +147,7 @@ class Peer {
       if (session.remoteCandidates.isNotEmpty) {
         for (var candidate in session.remoteCandidates) {
           if (candidate.candidate != null) {
-            GlobalLogger.logger.i('adding $candidate');
+            GlobalLogger().i('adding $candidate');
             await session.peerConnection?.addCandidate(candidate);
           }
         }
@@ -195,7 +195,7 @@ class Peer {
         _send(jsonInviteMessage);
       });
     } catch (e) {
-      GlobalLogger.logger.e('Peer :: $e');
+      GlobalLogger().e('Peer :: $e');
     }
   }
 
@@ -257,7 +257,7 @@ class Peer {
     try {
       session.peerConnection?.onIceCandidate = (candidate) async {
         if (session.peerConnection != null) {
-          GlobalLogger.logger.i('Peer :: Add Ice Candidate!');
+          GlobalLogger().i('Peer :: Add Ice Candidate!');
           if (candidate.candidate != null) {
             await session.peerConnection?.addCandidate(candidate);
           }
@@ -310,17 +310,17 @@ class Peer {
         _send(jsonAnswerMessage);
       });
     } catch (e) {
-      GlobalLogger.logger.e('Peer :: $e');
+      GlobalLogger().e('Peer :: $e');
     }
   }
 
   void closeSession() {
     final sess = _sessions[_selfId];
     if (sess != null) {
-      GlobalLogger.logger.i('Session end success');
+      GlobalLogger().i('Session end success');
       _closeSession(sess);
     } else {
-      GlobalLogger.logger.d('Session end failed');
+      GlobalLogger().d('Session end failed');
     }
   }
 
@@ -386,19 +386,19 @@ class Peer {
 
       if (!candidate.candidate.toString().contains('127.0.0.1') ||
           currentCall?.callState != CallState.active) {
-        GlobalLogger.logger.i('Peer :: Adding ICE candidate :: ${candidate.toString()}');
+        GlobalLogger().i('Peer :: Adding ICE candidate :: ${candidate.toString()}');
         await peerConnection?.addCandidate(candidate);
       } else {
-        GlobalLogger.logger.i('Peer :: Local candidate skipped!');
+        GlobalLogger().i('Peer :: Local candidate skipped!');
       }
       if (candidate.candidate == null) {
-        GlobalLogger.logger.i('Peer :: onIceCandidate: complete!');
+        GlobalLogger().i('Peer :: onIceCandidate: complete!');
         return;
       }
     };
 
     peerConnection?.onIceConnectionState = (state) {
-      GlobalLogger.logger.i('Peer :: ICE Connection State change :: $state');
+      GlobalLogger().i('Peer :: ICE Connection State change :: $state');
       switch (state) {
         case RTCIceConnectionState.RTCIceConnectionStateConnected:
           final Call? currentCall = _txClient.calls[callId];
@@ -442,14 +442,14 @@ class Peer {
 
   Future<bool> startStats(String callId, String peerId) async {
     if (_debug == false) {
-      GlobalLogger.logger.d(
+      GlobalLogger().d(
         'Peer :: Stats manager will not start. Debug mode not enabled on config',
       );
       return false;
     }
 
     if (peerConnection == null) {
-      GlobalLogger.logger.d('Peer connection null');
+      GlobalLogger().d('Peer connection null');
       return false;
     }
 
@@ -465,7 +465,7 @@ class Peer {
       return;
     }
     _statsManager?.stopStatsReporting();
-    GlobalLogger.logger.i('Peer :: Stats Manager stopped for $callId');
+    GlobalLogger().i('Peer :: Stats Manager stopped for $callId');
   }
 
   void _send(event) {

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -8,12 +8,12 @@ import 'package:telnyx_webrtc/model/verto/send/invite_answer_message_body.dart';
 import 'package:telnyx_webrtc/peer/session.dart';
 import 'package:telnyx_webrtc/peer/signaling_state.dart';
 import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
 import 'package:telnyx_webrtc/utils/stats/webrtc_stats_reporter.dart';
 import 'package:telnyx_webrtc/tx_socket.dart'
     if (dart.library.js) 'package:telnyx_webrtc/tx_socket_web.dart';
 import 'package:telnyx_webrtc/utils/string_utils.dart';
 import 'package:uuid/uuid.dart';
-import 'package:logger/logger.dart';
 import 'package:telnyx_webrtc/model/verto/receive/received_message_body.dart';
 import 'package:telnyx_webrtc/model/call_state.dart';
 import 'package:telnyx_webrtc/model/jsonrpc.dart';
@@ -22,8 +22,6 @@ class Peer {
   RTCPeerConnection? peerConnection;
 
   Peer(this._socket, this._debug, this._txClient);
-
-  final _logger = Logger();
 
   final String _selfId = randomNumeric(6);
 
@@ -83,7 +81,7 @@ class Peer {
       final bool enabled = _localStream!.getAudioTracks()[0].enabled;
       _localStream!.getAudioTracks()[0].enabled = !enabled;
     } else {
-      _logger.d('Peer :: No local stream :: Unable to Mute / Unmute');
+      GlobalLogger.logger.d('Peer :: No local stream :: Unable to Mute / Unmute');
     }
   }
 
@@ -91,7 +89,7 @@ class Peer {
     if (_localStream != null) {
       _localStream!.getAudioTracks()[0].enableSpeakerphone(enable);
     } else {
-      _logger.d('Peer :: No local stream :: Unable to toggle speaker mode');
+      GlobalLogger.logger.d('Peer :: No local stream :: Unable to toggle speaker mode');
     }
   }
 
@@ -149,7 +147,7 @@ class Peer {
       if (session.remoteCandidates.isNotEmpty) {
         for (var candidate in session.remoteCandidates) {
           if (candidate.candidate != null) {
-            _logger.i('adding $candidate');
+            GlobalLogger.logger.i('adding $candidate');
             await session.peerConnection?.addCandidate(candidate);
           }
         }
@@ -197,7 +195,7 @@ class Peer {
         _send(jsonInviteMessage);
       });
     } catch (e) {
-      _logger.e('Peer :: $e');
+      GlobalLogger.logger.e('Peer :: $e');
     }
   }
 
@@ -259,7 +257,7 @@ class Peer {
     try {
       session.peerConnection?.onIceCandidate = (candidate) async {
         if (session.peerConnection != null) {
-          _logger.i('Peer :: Add Ice Candidate!');
+          GlobalLogger.logger.i('Peer :: Add Ice Candidate!');
           if (candidate.candidate != null) {
             await session.peerConnection?.addCandidate(candidate);
           }
@@ -312,17 +310,17 @@ class Peer {
         _send(jsonAnswerMessage);
       });
     } catch (e) {
-      _logger.e('Peer :: $e');
+      GlobalLogger.logger.e('Peer :: $e');
     }
   }
 
   void closeSession() {
     final sess = _sessions[_selfId];
     if (sess != null) {
-      _logger.d('Session end success');
+      GlobalLogger.logger.i('Session end success');
       _closeSession(sess);
     } else {
-      _logger.d('Session end failed');
+      GlobalLogger.logger.d('Session end failed');
     }
   }
 
@@ -388,19 +386,19 @@ class Peer {
 
       if (!candidate.candidate.toString().contains('127.0.0.1') ||
           currentCall?.callState != CallState.active) {
-        _logger.i('Peer :: Adding ICE candidate :: ${candidate.toString()}');
+        GlobalLogger.logger.i('Peer :: Adding ICE candidate :: ${candidate.toString()}');
         await peerConnection?.addCandidate(candidate);
       } else {
-        _logger.i('Peer :: Local candidate skipped!');
+        GlobalLogger.logger.i('Peer :: Local candidate skipped!');
       }
       if (candidate.candidate == null) {
-        _logger.i('Peer :: onIceCandidate: complete!');
+        GlobalLogger.logger.i('Peer :: onIceCandidate: complete!');
         return;
       }
     };
 
     peerConnection?.onIceConnectionState = (state) {
-      _logger.i('Peer :: ICE Connection State change :: $state');
+      GlobalLogger.logger.i('Peer :: ICE Connection State change :: $state');
       switch (state) {
         case RTCIceConnectionState.RTCIceConnectionStateConnected:
           final Call? currentCall = _txClient.calls[callId];
@@ -444,14 +442,14 @@ class Peer {
 
   Future<bool> startStats(String callId, String peerId) async {
     if (_debug == false) {
-      _logger.d(
+      GlobalLogger.logger.d(
         'Peer :: Stats manager will not start. Debug mode not enabled on config',
       );
       return false;
     }
 
     if (peerConnection == null) {
-      _logger.d('Peer connection null');
+      GlobalLogger.logger.d('Peer connection null');
       return false;
     }
 
@@ -467,7 +465,7 @@ class Peer {
       return;
     }
     _statsManager?.stopStatsReporting();
-    _logger.d('Peer :: Stats Manager stopped for $callId');
+    GlobalLogger.logger.i('Peer :: Stats Manager stopped for $callId');
   }
 
   void _send(event) {

--- a/packages/telnyx_webrtc/lib/peer/web/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/web/peer.dart
@@ -88,10 +88,10 @@ class Peer {
   void closeSession() {
     final session = _sessions[_selfId];
     if (session != null) {
-      GlobalLogger.logger.d('Session end success');
+      GlobalLogger().d('Session end success');
       _closeSession(session);
     } else {
-      GlobalLogger.logger.d('Session end failed');
+      GlobalLogger().d('Session end failed');
     }
   }
 
@@ -100,14 +100,14 @@ class Peer {
       final bool enabled = _localStream!.getAudioTracks()[0].enabled;
       _localStream!.getAudioTracks()[0].enabled = !enabled;
     } else {
-      GlobalLogger.logger.d('Peer :: No local stream :: Unable to Mute / Unmute');
+      GlobalLogger().d('Peer :: No local stream :: Unable to Mute / Unmute');
     }
   }
 
   void enableSpeakerPhone(bool enable) {
     if (kIsWeb) {
       // On web, .enableSpeakerphone(...) is still available on recent flutter_webrtc
-      GlobalLogger.logger.d('Peer :: Speaker Enabled :: $enable');
+      GlobalLogger().d('Peer :: Speaker Enabled :: $enable');
       if (_localStream != null) {
         _localStream!.getAudioTracks()[0].enableSpeakerphone(enable);
       }
@@ -116,9 +116,9 @@ class Peer {
 
     if (_localStream != null) {
       _localStream!.getAudioTracks()[0].enableSpeakerphone(enable);
-      GlobalLogger.logger.d('Peer :: Speaker Enabled :: $enable');
+      GlobalLogger().d('Peer :: Speaker Enabled :: $enable');
     } else {
-      GlobalLogger.logger.d('Peer :: No local stream :: Unable to toggle speaker mode');
+      GlobalLogger().d('Peer :: No local stream :: Unable to toggle speaker mode');
     }
   }
 
@@ -178,7 +178,7 @@ class Peer {
       if (session.remoteCandidates.isNotEmpty) {
         for (var candidate in session.remoteCandidates) {
           if (candidate.candidate != null) {
-            GlobalLogger.logger.i('adding remote candidate: $candidate');
+            GlobalLogger().i('adding remote candidate: $candidate');
             await session.peerConnection?.addCandidate(candidate);
           }
         }
@@ -230,7 +230,7 @@ class Peer {
         _send(jsonInviteMessage);
       });
     } catch (e) {
-      GlobalLogger.logger.e('Peer :: _createOffer error: $e');
+      GlobalLogger().e('Peer :: _createOffer error: $e');
     }
   }
 
@@ -306,14 +306,13 @@ class Peer {
         if (candidate.candidate != null) {
           if (!candidate.candidate!.contains('127.0.0.1') ||
               currentCall?.callState != CallState.active) {
-            GlobalLogger.logger.i('Peer :: Add Ice Candidate => ${candidate.candidate}');
+            GlobalLogger().i('Peer :: Add Ice Candidate => ${candidate.candidate}');
             await session.peerConnection?.addCandidate(candidate);
           } else {
-            GlobalLogger.logger
-                .i('Peer :: Local candidate skipped: ${candidate.candidate}');
+            GlobalLogger().i('Peer :: Local candidate skipped: ${candidate.candidate}');
           }
         } else {
-          GlobalLogger.logger.i('Peer :: onIceCandidate: complete');
+          GlobalLogger().i('Peer :: onIceCandidate: complete');
         }
       };
 
@@ -367,12 +366,12 @@ class Peer {
         _send(jsonAnswerMessage);
       });
     } catch (e) {
-      GlobalLogger.logger.e('Peer :: _createAnswer error: $e');
+      GlobalLogger().e('Peer :: _createAnswer error: $e');
     }
   }
 
   Future<MediaStream> createStream(String media) async {
-    GlobalLogger.logger.i('Peer :: Creating stream');
+    GlobalLogger().i('Peer :: Creating stream');
     final Map<String, dynamic> mediaConstraints = {
       'audio': true,
       'video': false,
@@ -396,7 +395,7 @@ class Peer {
     required String callId,
     required String media,
   }) async {
-    GlobalLogger.logger.i('Web Peer :: _createSession => sid=$sessionId, callId=$callId');
+    GlobalLogger().i('Web Peer :: _createSession => sid=$sessionId, callId=$callId');
 
     final newSession = session ?? Session(sid: sessionId, pid: peerId);
     if (media != 'data') {
@@ -421,7 +420,7 @@ class Peer {
         case 'plan-b':
           // Plan B
           pc.onAddStream = (MediaStream stream) {
-            GlobalLogger.logger.i('Peer :: onAddStream => plan-b');
+            GlobalLogger().i('Peer :: onAddStream => plan-b');
             onAddRemoteStream?.call(newSession, stream);
             _remoteStreams.add(stream);
             _remoteRenderer.srcObject = stream;
@@ -433,7 +432,7 @@ class Peer {
         default:
           // Unified Plan
           pc.onTrack = (event) {
-            GlobalLogger.logger.i(
+            GlobalLogger().i(
               'Peer :: onTrack => kind=${event.track.kind}, streams=${event.streams.length}',
             );
             if (event.streams.isNotEmpty) {
@@ -457,18 +456,17 @@ class Peer {
           // Example skipping local candidate if call is active and it's 127.0.0.1
           if (!candidate.candidate!.contains('127.0.0.1') ||
               currentCall?.callState != CallState.active) {
-            GlobalLogger.logger.i('Peer :: Adding ICE candidate => ${candidate.candidate}');
+            GlobalLogger().i('Peer :: Adding ICE candidate => ${candidate.candidate}');
             await pc.addCandidate(candidate);
           } else {
-            GlobalLogger.logger
-                .i('Peer :: Local candidate skipped => ${candidate.candidate}');
+            GlobalLogger().i('Peer :: Local candidate skipped => ${candidate.candidate}');
           }
         } else {
-          GlobalLogger.logger.i('Peer :: onIceCandidate: complete');
+          GlobalLogger().i('Peer :: onIceCandidate: complete');
         }
       }
       ..onIceConnectionState = (state) {
-        GlobalLogger.logger.i('Peer :: ICE Connection State => $state');
+        GlobalLogger().i('Peer :: ICE Connection State => $state');
         switch (state) {
           case RTCIceConnectionState.RTCIceConnectionStateFailed:
             pc.restartIce();
@@ -482,7 +480,7 @@ class Peer {
         }
       }
       ..onRemoveStream = (stream) {
-        GlobalLogger.logger.i('Peer :: onRemoveStream => ${stream.id}');
+        GlobalLogger().i('Peer :: onRemoveStream => ${stream.id}');
         onRemoveRemoteStream?.call(newSession, stream);
         _remoteStreams.removeWhere((it) => it.id == stream.id);
       }
@@ -501,7 +499,7 @@ class Peer {
   void _addDataChannel(Session session, RTCDataChannel channel) {
     channel
       ..onDataChannelState = (state) {
-        GlobalLogger.logger.i('Peer :: DataChannel State => $state');
+        GlobalLogger().i('Peer :: DataChannel State => $state');
       }
       ..onMessage = (RTCDataChannelMessage data) {
         onDataChannelMessage?.call(session, channel, data);
@@ -516,20 +514,19 @@ class Peer {
     RTCPeerConnection pc,
   ) async {
     if (!_debug) {
-      GlobalLogger.logger
-          .d('Peer :: Stats manager will NOT start; debug mode not enabled.');
+      GlobalLogger().d('Peer :: Stats manager will NOT start; debug mode not enabled.');
       return false;
     }
     _statsManager = WebRTCStatsReporter(_socket, pc, callId, peerId);
     await _statsManager?.startStatsReporting();
-    GlobalLogger.logger.d('Peer :: Stats Manager started for callId=$callId');
+    GlobalLogger().d('Peer :: Stats Manager started for callId=$callId');
     return true;
   }
 
   void stopStats(String callId) {
     if (!_debug) return;
     _statsManager?.stopStatsReporting();
-    GlobalLogger.logger.d('Peer :: Stats Manager stopped for $callId');
+    GlobalLogger().d('Peer :: Stats Manager stopped for $callId');
   }
 
   Future<void> _cleanSessions() async {

--- a/packages/telnyx_webrtc/lib/peer/web/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/web/peer.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
-import 'package:logger/logger.dart';
 import 'package:telnyx_webrtc/config.dart';
 import 'package:telnyx_webrtc/model/call_state.dart';
 import 'package:telnyx_webrtc/model/jsonrpc.dart';
@@ -15,6 +14,7 @@ import 'package:telnyx_webrtc/peer/signaling_state.dart';
 import 'package:telnyx_webrtc/telnyx_client.dart';
 import 'package:telnyx_webrtc/tx_socket.dart'
     if (dart.library.js) 'package:telnyx_webrtc/tx_socket_web.dart';
+import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
 import 'package:telnyx_webrtc/utils/string_utils.dart';
 import 'package:telnyx_webrtc/utils/stats/webrtc_stats_reporter.dart';
 import 'package:uuid/uuid.dart';
@@ -22,7 +22,6 @@ import 'package:uuid/uuid.dart';
 class Peer {
   Peer(this._socket, this._debug, this._txClient);
 
-  final Logger _logger = Logger();
   final TxSocket _socket;
   final TelnyxClient _txClient;
   final bool _debug;
@@ -89,10 +88,10 @@ class Peer {
   void closeSession() {
     final session = _sessions[_selfId];
     if (session != null) {
-      _logger.d('Session end success');
+      GlobalLogger.logger.d('Session end success');
       _closeSession(session);
     } else {
-      _logger.d('Session end failed');
+      GlobalLogger.logger.d('Session end failed');
     }
   }
 
@@ -101,14 +100,14 @@ class Peer {
       final bool enabled = _localStream!.getAudioTracks()[0].enabled;
       _localStream!.getAudioTracks()[0].enabled = !enabled;
     } else {
-      _logger.d('Peer :: No local stream :: Unable to Mute / Unmute');
+      GlobalLogger.logger.d('Peer :: No local stream :: Unable to Mute / Unmute');
     }
   }
 
   void enableSpeakerPhone(bool enable) {
     if (kIsWeb) {
       // On web, .enableSpeakerphone(...) is still available on recent flutter_webrtc
-      _logger.d('Peer :: Speaker Enabled :: $enable');
+      GlobalLogger.logger.d('Peer :: Speaker Enabled :: $enable');
       if (_localStream != null) {
         _localStream!.getAudioTracks()[0].enableSpeakerphone(enable);
       }
@@ -117,9 +116,9 @@ class Peer {
 
     if (_localStream != null) {
       _localStream!.getAudioTracks()[0].enableSpeakerphone(enable);
-      _logger.d('Peer :: Speaker Enabled :: $enable');
+      GlobalLogger.logger.d('Peer :: Speaker Enabled :: $enable');
     } else {
-      _logger.d('Peer :: No local stream :: Unable to toggle speaker mode');
+      GlobalLogger.logger.d('Peer :: No local stream :: Unable to toggle speaker mode');
     }
   }
 
@@ -179,7 +178,7 @@ class Peer {
       if (session.remoteCandidates.isNotEmpty) {
         for (var candidate in session.remoteCandidates) {
           if (candidate.candidate != null) {
-            _logger.i('adding remote candidate: $candidate');
+            GlobalLogger.logger.i('adding remote candidate: $candidate');
             await session.peerConnection?.addCandidate(candidate);
           }
         }
@@ -231,7 +230,7 @@ class Peer {
         _send(jsonInviteMessage);
       });
     } catch (e) {
-      _logger.e('Peer :: _createOffer error: $e');
+      GlobalLogger.logger.e('Peer :: _createOffer error: $e');
     }
   }
 
@@ -307,14 +306,14 @@ class Peer {
         if (candidate.candidate != null) {
           if (!candidate.candidate!.contains('127.0.0.1') ||
               currentCall?.callState != CallState.active) {
-            _logger.i('Peer :: Add Ice Candidate => ${candidate.candidate}');
+            GlobalLogger.logger.i('Peer :: Add Ice Candidate => ${candidate.candidate}');
             await session.peerConnection?.addCandidate(candidate);
           } else {
-            _logger
+            GlobalLogger.logger
                 .i('Peer :: Local candidate skipped: ${candidate.candidate}');
           }
         } else {
-          _logger.i('Peer :: onIceCandidate: complete');
+          GlobalLogger.logger.i('Peer :: onIceCandidate: complete');
         }
       };
 
@@ -368,12 +367,12 @@ class Peer {
         _send(jsonAnswerMessage);
       });
     } catch (e) {
-      _logger.e('Peer :: _createAnswer error: $e');
+      GlobalLogger.logger.e('Peer :: _createAnswer error: $e');
     }
   }
 
   Future<MediaStream> createStream(String media) async {
-    _logger.i('Peer :: Creating stream');
+    GlobalLogger.logger.i('Peer :: Creating stream');
     final Map<String, dynamic> mediaConstraints = {
       'audio': true,
       'video': false,
@@ -397,7 +396,7 @@ class Peer {
     required String callId,
     required String media,
   }) async {
-    _logger.i('Web Peer :: _createSession => sid=$sessionId, callId=$callId');
+    GlobalLogger.logger.i('Web Peer :: _createSession => sid=$sessionId, callId=$callId');
 
     final newSession = session ?? Session(sid: sessionId, pid: peerId);
     if (media != 'data') {
@@ -422,7 +421,7 @@ class Peer {
         case 'plan-b':
           // Plan B
           pc.onAddStream = (MediaStream stream) {
-            _logger.i('Peer :: onAddStream => plan-b');
+            GlobalLogger.logger.i('Peer :: onAddStream => plan-b');
             onAddRemoteStream?.call(newSession, stream);
             _remoteStreams.add(stream);
             _remoteRenderer.srcObject = stream;
@@ -434,7 +433,7 @@ class Peer {
         default:
           // Unified Plan
           pc.onTrack = (event) {
-            _logger.i(
+            GlobalLogger.logger.i(
               'Peer :: onTrack => kind=${event.track.kind}, streams=${event.streams.length}',
             );
             if (event.streams.isNotEmpty) {
@@ -458,18 +457,18 @@ class Peer {
           // Example skipping local candidate if call is active and it's 127.0.0.1
           if (!candidate.candidate!.contains('127.0.0.1') ||
               currentCall?.callState != CallState.active) {
-            _logger.i('Peer :: Adding ICE candidate => ${candidate.candidate}');
+            GlobalLogger.logger.i('Peer :: Adding ICE candidate => ${candidate.candidate}');
             await pc.addCandidate(candidate);
           } else {
-            _logger
+            GlobalLogger.logger
                 .i('Peer :: Local candidate skipped => ${candidate.candidate}');
           }
         } else {
-          _logger.i('Peer :: onIceCandidate: complete');
+          GlobalLogger.logger.i('Peer :: onIceCandidate: complete');
         }
       }
       ..onIceConnectionState = (state) {
-        _logger.i('Peer :: ICE Connection State => $state');
+        GlobalLogger.logger.i('Peer :: ICE Connection State => $state');
         switch (state) {
           case RTCIceConnectionState.RTCIceConnectionStateFailed:
             pc.restartIce();
@@ -483,7 +482,7 @@ class Peer {
         }
       }
       ..onRemoveStream = (stream) {
-        _logger.i('Peer :: onRemoveStream => ${stream.id}');
+        GlobalLogger.logger.i('Peer :: onRemoveStream => ${stream.id}');
         onRemoveRemoteStream?.call(newSession, stream);
         _remoteStreams.removeWhere((it) => it.id == stream.id);
       }
@@ -502,7 +501,7 @@ class Peer {
   void _addDataChannel(Session session, RTCDataChannel channel) {
     channel
       ..onDataChannelState = (state) {
-        _logger.i('Peer :: DataChannel State => $state');
+        GlobalLogger.logger.i('Peer :: DataChannel State => $state');
       }
       ..onMessage = (RTCDataChannelMessage data) {
         onDataChannelMessage?.call(session, channel, data);
@@ -517,20 +516,20 @@ class Peer {
     RTCPeerConnection pc,
   ) async {
     if (!_debug) {
-      _logger
+      GlobalLogger.logger
           .d('Peer :: Stats manager will NOT start; debug mode not enabled.');
       return false;
     }
     _statsManager = WebRTCStatsReporter(_socket, pc, callId, peerId);
     await _statsManager?.startStatsReporting();
-    _logger.d('Peer :: Stats Manager started for callId=$callId');
+    GlobalLogger.logger.d('Peer :: Stats Manager started for callId=$callId');
     return true;
   }
 
   void stopStats(String callId) {
     if (!_debug) return;
     _statsManager?.stopStatsReporting();
-    _logger.d('Peer :: Stats Manager stopped for $callId');
+    GlobalLogger.logger.d('Peer :: Stats Manager stopped for $callId');
   }
 
   Future<void> _cleanSessions() async {

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -30,7 +30,6 @@ import 'package:telnyx_webrtc/model/push_notification.dart';
 import 'package:telnyx_webrtc/model/verto/send/pong_message_body.dart';
 import 'package:telnyx_webrtc/model/verto/send/disable_push_body.dart';
 
-
 /// Callback for when the socket receives a message
 typedef OnSocketMessageReceived = void Function(TelnyxMessage message);
 
@@ -64,24 +63,24 @@ class TelnyxClient {
       switch (message.socketMethod) {
         case SocketMethod.invite:
           {
-            _logger.i(
+            GlobalLogger().i(
               'TelnyxClient :: onSocketMessageReceived  Override this on client side: ${message.message}',
             );
             break;
           }
         case SocketMethod.bye:
           {
-            _logger.i(
+            GlobalLogger().i(
               'TelnyxClient :: onSocketMessageReceived  Override this on client side: ${message.message}',
             );
             break;
           }
         default:
-          _logger.i(
+          GlobalLogger().i(
             'TelnyxClient :: onSocketMessageReceived  Override this on client side: ${message.message}',
           );
       }
-      _logger.i(
+      GlobalLogger().i(
         'TelnyxClient :: onSocketMessageReceived  Override this on client side: ${message.message}',
       );
     };
@@ -169,12 +168,12 @@ class TelnyxClient {
         .onConnectivityChanged
         .listen((List<ConnectivityResult> connectivityResult) {
       if (connectivityResult.contains(ConnectivityResult.mobile)) {
-        _logger.i('Mobile network available.');
+        GlobalLogger().i('Mobile network available.');
         if (activeCalls().isNotEmpty && !_isAttaching) {
           _reconnectToSocket();
         } // Mobile network available.
       } else if (connectivityResult.contains(ConnectivityResult.wifi)) {
-        _logger.i('Wi-fi is available.');
+        GlobalLogger().i('Wi-fi is available.');
         if (activeCalls().isNotEmpty && !_isAttaching) {
           _reconnectToSocket();
         }
@@ -182,22 +181,22 @@ class TelnyxClient {
         // Note for Android:
         // When both mobile and Wi-Fi are turned on system will return Wi-Fi only as active network type
       } else if (connectivityResult.contains(ConnectivityResult.ethernet)) {
-        _logger.i('Ethernet connection available.');
+        GlobalLogger().i('Ethernet connection available.');
         // Ethernet connection available.
       } else if (connectivityResult.contains(ConnectivityResult.vpn)) {
         // Vpn connection active.
         // Note for iOS and macOS:
-        _logger.i('Vpn connection active.');
+        GlobalLogger().i('Vpn connection active.');
       } else if (connectivityResult.contains(ConnectivityResult.bluetooth)) {
-        _logger.i('Bluetooth connection available.');
+        GlobalLogger().i('Bluetooth connection available.');
         // Bluetooth connection available.
       } else if (connectivityResult.contains(ConnectivityResult.other)) {
-        _logger.i(
+        GlobalLogger().i(
           'Connected to a network which is not in the above mentioned networks.',
         );
         // Connected to a network which is not in the above mentioned networks.
       } else if (connectivityResult.contains(ConnectivityResult.none)) {
-        _logger.i('No available network types');
+        GlobalLogger().i('No available network types');
         // No available network types
       }
     });
@@ -215,14 +214,14 @@ class TelnyxClient {
     CredentialConfig? credentialConfig,
     TokenConfig? tokenConfig,
   ) {
-    _logger.i(jsonEncode(pushMetaData));
+    GlobalLogger().i(jsonEncode(pushMetaData));
     _isCallFromPush = true;
 
     if (pushMetaData.isAnswer == true) {
-      _logger.i('_pendingAnswerFromPush true');
+      GlobalLogger().i('_pendingAnswerFromPush true');
       _pendingAnswerFromPush = true;
     } else {
-      _logger.i('_pendingAnswerFromPush false');
+      GlobalLogger().i('_pendingAnswerFromPush false');
     }
 
     if (pushMetaData.isDecline == true) {
@@ -263,7 +262,7 @@ class TelnyxClient {
     PushMetaData? pushMetaData,
     OnOpenCallback openCallback,
   ) {
-    _logger.i('connect() ${pushMetaData?.toJson()}');
+    GlobalLogger().i('connect() ${pushMetaData?.toJson()}');
     if (pushMetaData != null) {
       _pushMetaData = pushMetaData;
     }
@@ -271,19 +270,19 @@ class TelnyxClient {
       if (pushMetaData?.voiceSdkId != null) {
         txSocket.hostAddress =
             '$_storedHostAddress?voice_sdk_id=${pushMetaData?.voiceSdkId}';
-        _logger.i(
+        GlobalLogger().i(
           'Connecting to WebSocket with voice_sdk_id :: ${pushMetaData?.voiceSdkId}',
         );
       } else {
         txSocket.hostAddress = _storedHostAddress;
-        _logger.i('connecting to WebSocket $_storedHostAddress');
+        GlobalLogger().i('connecting to WebSocket $_storedHostAddress');
       }
       txSocket
         ..connect()
         ..onOpen = () {
           _closed = false;
           _connected = true;
-          _logger.i('Web Socket is now connected');
+          GlobalLogger().i('Web Socket is now connected');
           _onOpen();
           openCallback.call();
         }
@@ -291,14 +290,14 @@ class TelnyxClient {
           _onMessage(data);
         }
         ..onClose = (int closeCode, String closeReason) {
-          _logger.i('Closed [$closeCode, $closeReason]!');
+          GlobalLogger().i('Closed [$closeCode, $closeReason]!');
           _connected = false;
           _onClose(true, closeCode, closeReason);
         };
     } catch (e, string) {
-      _logger.e('${e.toString()} :: $string');
+      GlobalLogger().e('${e.toString()} :: $string');
       _connected = false;
-      _logger.e('WebSocket $_storedHostAddress error: $e');
+      GlobalLogger().e('WebSocket $_storedHostAddress error: $e');
     }
   }
 
@@ -311,24 +310,24 @@ class TelnyxClient {
     // Now that a logger is set, we can set the log level
     _logger
       ..setLogLevel(tokenConfig.logLevel)
-      ..i('connect()')
-      ..i('connecting to WebSocket $_storedHostAddress');
+      ..log(LogLevel.info, 'connect()')
+      ..log(LogLevel.info, 'connecting to WebSocket $_storedHostAddress');
     try {
       if (_pushMetaData != null) {
         txSocket.hostAddress =
             '$_storedHostAddress?voice_sdk_id=${_pushMetaData?.voiceSdkId}';
-        _logger.i(
+        GlobalLogger().i(
           'Connecting to WebSocket with voice_sdk_id :: ${_pushMetaData?.voiceSdkId}',
         );
       } else {
         txSocket.hostAddress = _storedHostAddress;
-        _logger.i('connecting to WebSocket $_storedHostAddress');
+        GlobalLogger().i('connecting to WebSocket $_storedHostAddress');
       }
       txSocket
         ..onOpen = () {
           _closed = false;
           _connected = true;
-          _logger.i('Web Socket is now connected');
+          GlobalLogger().i('Web Socket is now connected');
           _onOpen();
           tokenLogin(tokenConfig);
         }
@@ -336,15 +335,15 @@ class TelnyxClient {
           _onMessage(data);
         }
         ..onClose = (int closeCode, String closeReason) {
-          _logger.i('Closed [$closeCode, $closeReason]!');
+          GlobalLogger().i('Closed [$closeCode, $closeReason]!');
           _connected = false;
           _onClose(true, closeCode, closeReason);
         }
         ..connect();
     } catch (e) {
-      _logger.e(e.toString());
+      GlobalLogger().e(e.toString());
       _connected = false;
-      _logger.e('WebSocket $_storedHostAddress error: $e');
+      GlobalLogger().e('WebSocket $_storedHostAddress error: $e');
     }
   }
 
@@ -358,23 +357,23 @@ class TelnyxClient {
     // Now that a logger is set, we can set the log level
     _logger
       ..setLogLevel(credentialConfig.logLevel)
-      ..i('connect()');
+      ..log(LogLevel.info, 'connect()');
     try {
       if (_pushMetaData != null) {
         txSocket.hostAddress =
             '$_storedHostAddress?voice_sdk_id=${_pushMetaData?.voiceSdkId}';
-        _logger.i(
+        GlobalLogger().i(
           'Connecting to WebSocket with voice_sdk_id :: ${_pushMetaData?.voiceSdkId}',
         );
       } else {
         txSocket.hostAddress = _storedHostAddress;
-        _logger.i('connecting to WebSocket $_storedHostAddress');
+        GlobalLogger().i('connecting to WebSocket $_storedHostAddress');
       }
       txSocket
         ..onOpen = () {
           _closed = false;
           _connected = true;
-          _logger.i('Web Socket is now connected');
+          GlobalLogger().i('Web Socket is now connected');
           _onOpen();
           credentialLogin(credentialConfig);
         }
@@ -382,15 +381,15 @@ class TelnyxClient {
           _onMessage(data);
         }
         ..onClose = (int closeCode, String closeReason) {
-          _logger.i('Closed [$closeCode, $closeReason]!');
+          GlobalLogger().i('Closed [$closeCode, $closeReason]!');
           _connected = false;
           _onClose(true, closeCode, closeReason);
         }
         ..connect();
     } catch (e) {
-      _logger.e(e.toString());
+      GlobalLogger().e(e.toString());
       _connected = false;
-      _logger.e('WebSocket $_storedHostAddress error: $e');
+      GlobalLogger().e('WebSocket $_storedHostAddress error: $e');
     }
   }
 
@@ -400,43 +399,43 @@ class TelnyxClient {
 
   /// Connects to the WebSocket with a previously provided [Config]
   void connect() {
-    _logger.i('connect()');
+    GlobalLogger().i('connect()');
     if (isConnected()) {
-      _logger.i('WebSocket $_storedHostAddress is already connected');
+      GlobalLogger().i('WebSocket $_storedHostAddress is already connected');
       return;
     }
-    _logger.i('connecting to WebSocket $_storedHostAddress');
+    GlobalLogger().i('connecting to WebSocket $_storedHostAddress');
     try {
       if (_pushMetaData != null) {
         txSocket.hostAddress =
             '$_storedHostAddress?voice_sdk_id=${_pushMetaData?.voiceSdkId}';
-        _logger.i(
+        GlobalLogger().i(
           'Connecting to WebSocket with voice_sdk_id :: ${_pushMetaData?.voiceSdkId}',
         );
       } else {
         txSocket.hostAddress = _storedHostAddress;
-        _logger.i('connecting to WebSocket $_storedHostAddress');
+        GlobalLogger().i('connecting to WebSocket $_storedHostAddress');
       }
       txSocket
         ..onOpen = () {
           _closed = false;
           _connected = true;
-          _logger.i('Web Socket is now connected');
+          GlobalLogger().i('Web Socket is now connected');
           _onOpen();
         }
         ..onMessage = (dynamic data) {
           _onMessage(data);
         }
         ..onClose = (int closeCode, String closeReason) {
-          _logger.i('Closed [$closeCode, $closeReason]!');
+          GlobalLogger().i('Closed [$closeCode, $closeReason]!');
           _connected = false;
           _onClose(true, closeCode, closeReason);
         }
         ..connect();
     } catch (e) {
-      _logger.e(e.toString());
+      GlobalLogger().e(e.toString());
       _connected = false;
-      _logger.e('WebSocket $_storedHostAddress error: $e');
+      GlobalLogger().e('WebSocket $_storedHostAddress error: $e');
     }
   }
 
@@ -474,7 +473,7 @@ class TelnyxClient {
   }
 
   void _callEnded() {
-    _logger.i('Call Ended');
+    GlobalLogger().i('Call Ended');
     _call = null;
   }
 
@@ -490,7 +489,8 @@ class TelnyxClient {
       _ringtonePath,
       _ringBackpath,
       CallHandler((state) {
-        _logger.i('Call state not overridden :Call State Changed to $state');
+        GlobalLogger()
+            .i('Call state not overridden :Call State Changed to $state');
       }),
       _callEnded,
       _debug,
@@ -595,7 +595,7 @@ class TelnyxClient {
     );
 
     final String jsonLoginMessage = jsonEncode(loginMessage);
-    _logger.i('Token Login Message $jsonLoginMessage');
+    GlobalLogger().i('Token Login Message $jsonLoginMessage');
     if (isConnected()) {
       txSocket.send(jsonLoginMessage);
     } else {
@@ -633,8 +633,9 @@ class TelnyxClient {
       final String jsonDisablePushMessage = jsonEncode(disablePushMessage);
       txSocket.send(jsonDisablePushMessage);
     } else {
-      _logger.e(
-          'No user or associated notification token found - we cannot disable push notifications');
+      GlobalLogger().e(
+        'No user or associated notification token found - we cannot disable push notifications',
+      );
     }
   }
 
@@ -716,10 +717,10 @@ class TelnyxClient {
   /// Provides the current [Call] instance associated with the [callId] otherwise returns null
   Call? getCallOrNull(String callId) {
     if (calls.containsKey(callId)) {
-      _logger.d('Invite Call found');
+      GlobalLogger().d('Invite Call found');
       return calls[callId];
     }
-    _logger.d('Invite Call not found');
+    GlobalLogger().d('Invite Call not found');
     return null;
   }
 
@@ -736,9 +737,9 @@ class TelnyxClient {
   void disconnectWithCallBack(OnCloseCallback? closeCallback) {
     _invalidateGatewayResponseTimer();
     _resetGatewayCounters();
-    _logger.i('disconnect()');
+    GlobalLogger().i('disconnect()');
     if (_closed) {
-      _logger.i('WebSocket is already closed');
+      GlobalLogger().i('WebSocket is already closed');
       closeCallback?.call(0, 'Client send disconnect');
       return;
     }
@@ -752,7 +753,7 @@ class TelnyxClient {
         closeCallback?.call(0, 'Client send disconnect');
       });
     } catch (error) {
-      _logger.e('close() | error closing the WebSocket: $error');
+      GlobalLogger().e('close() | error closing the WebSocket: $error');
     }
   }
 
@@ -760,7 +761,7 @@ class TelnyxClient {
   void disconnect() {
     _invalidateGatewayResponseTimer();
     _resetGatewayCounters();
-    _logger.i('disconnect()');
+    GlobalLogger().i('disconnect()');
     if (_closed) return;
     // Don't wait for the WebSocket 'close' event, do it now.
     _closed = true;
@@ -770,46 +771,51 @@ class TelnyxClient {
     try {
       txSocket.close();
     } catch (error) {
-      _logger.e('close() | error closing the WebSocket: $error');
+      GlobalLogger().e('close() | error closing the WebSocket: $error');
     }
   }
 
   /// WebSocket Event Handlers
   void _onOpen() {
-    _logger.i('WebSocket connected');
+    GlobalLogger().i('WebSocket connected');
   }
 
   void _onClose(bool wasClean, int code, String reason) {
-    _logger.i('WebSocket closed');
+    GlobalLogger().i('WebSocket closed');
     if (wasClean == false) {
-      _logger.i('WebSocket abrupt disconnection');
+      GlobalLogger().i('WebSocket abrupt disconnection');
     }
   }
 
   void _onMessage(dynamic data) async {
-    _logger.i('DEBUG MESSAGE: ${data.toString().trim()}');
+    GlobalLogger().i('DEBUG MESSAGE: ${data.toString().trim()}');
 
     if (data != null) {
       if (data.toString().trim().isNotEmpty) {
-        _logger.i('Received WebSocket message :: ${data.toString().trim()}');
+        GlobalLogger()
+            .i('Received WebSocket message :: ${data.toString().trim()}');
         if (data.toString().trim().contains('error')) {
           final errorJson = jsonEncode(data.toString());
-          _logger
-              .i('Received WebSocket message - Contains Error :: $errorJson');
+          _logger.log(
+            LogLevel.info,
+            'Received WebSocket message - Contains Error :: $errorJson',
+          );
           try {
             final ReceivedResult errorResult =
                 ReceivedResult.fromJson(jsonDecode(data.toString()));
             onSocketErrorReceived.call(errorResult.error!);
           } on Exception catch (e) {
-            _logger.e('Error parsing JSON: $e');
+            GlobalLogger().e('Error parsing JSON: $e');
           }
         }
 
         //Login success
         if (data.toString().trim().contains('result')) {
           final paramJson = jsonEncode(data.toString());
-          _logger
-              .i('Received WebSocket message - Contains Result :: $paramJson');
+          _logger.log(
+            LogLevel.info,
+            'Received WebSocket message - Contains Result :: $paramJson',
+          );
 
           try {
             final ReceivedResult stateMessage =
@@ -826,7 +832,7 @@ class TelnyxClient {
                 case GatewayState.reged:
                   {
                     if (!_registered) {
-                      _logger.i(
+                      GlobalLogger().i(
                         'GATEWAY REGISTERED :: ${stateMessage.toString()}',
                       );
                       _invalidateGatewayResponseTimer();
@@ -858,7 +864,7 @@ class TelnyxClient {
                           ),
                           jsonrpc: '2.0',
                         );
-                        _logger.i(
+                        GlobalLogger().i(
                           'attachCallMessage :: ${attachCallMessage.toJson()}',
                         );
                         txSocket.send(jsonEncode(attachCallMessage));
@@ -870,7 +876,7 @@ class TelnyxClient {
                   }
                 case GatewayState.failed:
                   {
-                    _logger.i(
+                    GlobalLogger().i(
                       'GATEWAY REGISTRATION FAILED :: ${stateMessage.toString()}',
                     );
                     gatewayState = GatewayState.failed;
@@ -884,20 +890,23 @@ class TelnyxClient {
                   }
                 case GatewayState.unreged:
                   {
-                    _logger.i('GATEWAY UNREGED :: ${stateMessage.toString()}');
+                    GlobalLogger()
+                        .i('GATEWAY UNREGED :: ${stateMessage.toString()}');
                     gatewayState = GatewayState.unreged;
                     break;
                   }
                 case GatewayState.register:
                   {
-                    _logger
-                        .i('GATEWAY REGISTERING :: ${stateMessage.toString()}');
+                    _logger.log(
+                      LogLevel.info,
+                      'GATEWAY REGISTERING :: ${stateMessage.toString()}',
+                    );
                     gatewayState = GatewayState.register;
                     break;
                   }
                 case GatewayState.unregister:
                   {
-                    _logger.i(
+                    GlobalLogger().i(
                       'GATEWAY UNREGISTERED :: ${stateMessage.toString()}',
                     );
                     gatewayState = GatewayState.unregister;
@@ -905,19 +914,20 @@ class TelnyxClient {
                   }
                 case GatewayState.attached:
                   {
-                    _logger.i('GATEWAY ATTACHED :: ${stateMessage.toString()}');
+                    GlobalLogger()
+                        .i('GATEWAY ATTACHED :: ${stateMessage.toString()}');
                     break;
                   }
                 default:
                   {
-                    _logger.i(
+                    GlobalLogger().i(
                       '$stateMessage',
                     );
                   }
               }
             }
           } on Exception catch (e) {
-            _logger.e('Error parsing JSON: $e');
+            GlobalLogger().e('Error parsing JSON: $e');
           }
         } else if (data.toString().trim().contains('method')) {
           //Received Telnyx Method Message
@@ -926,16 +936,16 @@ class TelnyxClient {
           final ReceivedMessage clientReadyMessage =
               ReceivedMessage.fromJson(jsonDecode(data.toString()));
           if (clientReadyMessage.voiceSdkId != null) {
-            _logger.i('VoiceSdkID :: ${clientReadyMessage.voiceSdkId}');
+            GlobalLogger().i('VoiceSdkID :: ${clientReadyMessage.voiceSdkId}');
             _pushMetaData = PushMetaData(
               callerNumber: null,
               callerName: null,
               voiceSdkId: clientReadyMessage.voiceSdkId,
             );
           } else {
-            _logger.e('VoiceSdkID not found');
+            GlobalLogger().e('VoiceSdkID not found');
           }
-          _logger.i(
+          GlobalLogger().i(
             'Received WebSocket message - Contains Method :: $messageJson',
           );
           switch (messageJson['method']) {
@@ -954,7 +964,7 @@ class TelnyxClient {
             case SocketMethod.clientReady:
               {
                 if (gatewayState != GatewayState.reged) {
-                  _logger.i('Retrieving Gateway state...');
+                  GlobalLogger().i('Retrieving Gateway state...');
                   if (_waitingForReg) {
                     _requestGatewayStatus();
                     _gatewayResponseTimer = Timer(
@@ -968,7 +978,7 @@ class TelnyxClient {
                         }
                         _registrationRetryCounter++;
                       } else {
-                        _logger.i('GATEWAY REGISTRATION TIMEOUT');
+                        GlobalLogger().i('GATEWAY REGISTRATION TIMEOUT');
                         final error = TelnyxSocketError(
                           errorCode:
                               TelnyxErrorConstants.gatewayTimeoutErrorCode,
@@ -992,7 +1002,7 @@ class TelnyxClient {
               }
             case SocketMethod.invite:
               {
-                _logger.i('INCOMING INVITATION :: $messageJson');
+                GlobalLogger().i('INCOMING INVITATION :: $messageJson');
                 final ReceivedMessage invite =
                     ReceivedMessage.fromJson(jsonDecode(data.toString()));
                 final message = TelnyxMessage(
@@ -1031,7 +1041,7 @@ class TelnyxClient {
               }
             case SocketMethod.attach:
               {
-                _logger.i('ATTACH RECEIVED :: $messageJson');
+                GlobalLogger().i('ATTACH RECEIVED :: $messageJson');
                 final ReceivedMessage invite =
                     ReceivedMessage.fromJson(jsonDecode(data.toString()));
                 final message = TelnyxMessage(
@@ -1057,14 +1067,15 @@ class TelnyxClient {
               }
             case SocketMethod.media:
               {
-                _logger.i('MEDIA RECEIVED :: $messageJson');
+                GlobalLogger().i('MEDIA RECEIVED :: $messageJson');
                 final ReceivedMessage mediaReceived =
                     ReceivedMessage.fromJson(jsonDecode(data.toString()));
                 if (mediaReceived.inviteParams?.sdp != null) {
                   final Call? mediaCall =
                       calls[mediaReceived.inviteParams?.callID];
                   if (mediaCall == null) {
-                    _logger.d('Error : Call  is null from Media Message');
+                    GlobalLogger()
+                        .d('Error : Call  is null from Media Message');
                     _sendNoCallError();
                     return;
                   }
@@ -1072,19 +1083,19 @@ class TelnyxClient {
                       .onRemoteSessionReceived(mediaReceived.inviteParams?.sdp);
                   _earlySDP = true;
                 } else {
-                  _logger.d('No SDP contained within Media Message');
+                  GlobalLogger().d('No SDP contained within Media Message');
                 }
                 break;
               }
             case SocketMethod.answer:
               {
-                _logger.i('INVITATION ANSWERED :: $messageJson');
+                GlobalLogger().i('INVITATION ANSWERED :: $messageJson');
                 final ReceivedMessage inviteAnswer =
                     ReceivedMessage.fromJson(jsonDecode(data.toString()));
                 final Call? answerCall =
                     calls[inviteAnswer.inviteParams?.callID];
                 if (answerCall == null) {
-                  _logger.d('Error : Call  is null from Answer Message');
+                  GlobalLogger().d('Error : Call  is null from Answer Message');
                   _sendNoCallError();
                   return;
                 }
@@ -1103,7 +1114,7 @@ class TelnyxClient {
                 } else if (_earlySDP) {
                   onSocketMessageReceived(message);
                 } else {
-                  _logger.d(
+                  GlobalLogger().d(
                     'No SDP provided for Answer or Media, cannot initialize call',
                   );
                   answerCall.endCall();
@@ -1114,12 +1125,12 @@ class TelnyxClient {
               }
             case SocketMethod.bye:
               {
-                _logger.i('BYE RECEIVED :: $messageJson');
+                GlobalLogger().i('BYE RECEIVED :: $messageJson');
                 final ReceivedMessage bye =
                     ReceivedMessage.fromJson(jsonDecode(data.toString()));
                 final Call? byeCall = calls[bye.inviteParams?.callID];
                 if (byeCall == null) {
-                  _logger.d('Error : Call  is null from Bye Message');
+                  GlobalLogger().d('Error : Call  is null from Bye Message');
                   _sendNoCallError();
                   return;
                 }
@@ -1134,17 +1145,18 @@ class TelnyxClient {
               }
             case SocketMethod.ringing:
               {
-                _logger.i('RINGING RECEIVED :: $messageJson');
+                GlobalLogger().i('RINGING RECEIVED :: $messageJson');
                 final ReceivedMessage ringing =
                     ReceivedMessage.fromJson(jsonDecode(data.toString()));
                 final Call? ringingCall = calls[ringing.inviteParams?.callID];
                 if (ringingCall == null) {
-                  _logger.d('Error : Call  is null from Ringing Message');
+                  GlobalLogger()
+                      .d('Error : Call  is null from Ringing Message');
                   _sendNoCallError();
                   return;
                 }
 
-                _logger.i(
+                GlobalLogger().i(
                   'Telnyx Leg ID :: ${ringing.inviteParams?.telnyxLegId.toString()}',
                 );
                 final message = TelnyxMessage(
@@ -1156,10 +1168,10 @@ class TelnyxClient {
               }
           }
         } else {
-          _logger.i('Received and ignored empty packet');
+          GlobalLogger().i('Received and ignored empty packet');
         }
       } else {
-        _logger.i('Received and ignored empty packet');
+        GlobalLogger().i('Received and ignored empty packet');
       }
     }
   }

--- a/packages/telnyx_webrtc/lib/tx_socket.dart
+++ b/packages/telnyx_webrtc/lib/tx_socket.dart
@@ -26,7 +26,7 @@ class TxSocket {
   /// Connect to the WebSocket server
   void connect() async {
     try {
-      GlobalLogger.logger.i('TxSocket :: connect : $hostAddress');
+      GlobalLogger().i('TxSocket :: connect : $hostAddress');
 
       _socket = await WebSocket.connect(hostAddress);
       _socket
@@ -52,7 +52,7 @@ class TxSocket {
   /// Send data to the WebSocket server
   void send(dynamic data) {
     _socket.add(data);
-    GlobalLogger.logger.i('TxSocket :: send : \n\n$data');
+    GlobalLogger().i('TxSocket :: send : \n\n$data');
   }
 
   /// Close the WebSocket connection

--- a/packages/telnyx_webrtc/lib/tx_socket.dart
+++ b/packages/telnyx_webrtc/lib/tx_socket.dart
@@ -1,24 +1,32 @@
 import 'dart:io';
-import 'package:logger/logger.dart';
 
+import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
+
+/// Message callback for when a message is received
 typedef OnMessageCallback = void Function(dynamic msg);
+
+/// Close callback for when the connection is closed
 typedef OnCloseCallback = void Function(int code, String reason);
+
+/// Open callback for when the connection is opened
 typedef OnOpenCallback = void Function();
 
+/// TxSocket class to handle the WebSocket connection
 class TxSocket {
+  /// Default constructor that initializes the host address and logger
   TxSocket(this.hostAddress);
 
   String hostAddress;
-  final _logger = Logger();
 
   late WebSocket _socket;
   late OnOpenCallback onOpen;
   late OnMessageCallback onMessage;
   late OnCloseCallback onClose;
 
+  /// Connect to the WebSocket server
   void connect() async {
     try {
-      _logger.i('TxSocket :: connect : $hostAddress');
+      GlobalLogger.logger.i('TxSocket :: connect : $hostAddress');
 
       _socket = await WebSocket.connect(hostAddress);
       _socket
@@ -41,11 +49,13 @@ class TxSocket {
     }
   }
 
+  /// Send data to the WebSocket server
   void send(dynamic data) {
     _socket.add(data);
-    _logger.i('TxSocket :: send : \n\n$data');
+    GlobalLogger.logger.i('TxSocket :: send : \n\n$data');
   }
 
+  /// Close the WebSocket connection
   void close() {
     _socket.close();
   }

--- a/packages/telnyx_webrtc/lib/tx_socket_web.dart
+++ b/packages/telnyx_webrtc/lib/tx_socket_web.dart
@@ -1,24 +1,33 @@
 // ignore: avoid_web_libraries_in_flutter
 import 'dart:html';
-import 'package:logger/logger.dart';
 
+import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
+
+/// Message callback for when a message is received
 typedef OnMessageCallback = void Function(dynamic msg);
+
+/// Close callback for when the connection is closed
 typedef OnCloseCallback = void Function(int code, String reason);
+
+/// Open callback for when the connection is opened
 typedef OnOpenCallback = void Function();
 
+
+/// TxSocket class to handle the WebSocket connection
 class TxSocket {
+  /// Default constructor that initializes the host address and logger
   TxSocket(this.hostAddress) {
     hostAddress = hostAddress.replaceAll('https:', 'wss:');
   }
 
   String hostAddress;
-  final _logger = Logger();
 
   late WebSocket _socket;
   late OnOpenCallback onOpen;
   late OnMessageCallback onMessage;
   late OnCloseCallback onClose;
 
+  /// Connect to the WebSocket server
   void connect() async {
     try {
       _socket = WebSocket(hostAddress);
@@ -38,15 +47,17 @@ class TxSocket {
     }
   }
 
+  /// Send data to the WebSocket server
   void send(data) {
     if (_socket.readyState == WebSocket.OPEN) {
       _socket.send(data);
-      _logger.i('TxSocket :: send : \n\n$data');
+      GlobalLogger.logger.i('TxSocket :: send : \n\n$data');
     } else {
-      _logger.i('WebSocket not connected, message $data not sent');
+      GlobalLogger.logger.d('WebSocket not connected, message $data not sent');
     }
   }
 
+  /// Close the WebSocket connection
   void close() {
     _socket.close();
   }

--- a/packages/telnyx_webrtc/lib/tx_socket_web.dart
+++ b/packages/telnyx_webrtc/lib/tx_socket_web.dart
@@ -51,9 +51,9 @@ class TxSocket {
   void send(data) {
     if (_socket.readyState == WebSocket.OPEN) {
       _socket.send(data);
-      GlobalLogger.logger.i('TxSocket :: send : \n\n$data');
+      GlobalLogger().i('TxSocket :: send : \n\n$data');
     } else {
-      GlobalLogger.logger.d('WebSocket not connected, message $data not sent');
+      GlobalLogger().d('WebSocket not connected, message $data not sent');
     }
   }
 

--- a/packages/telnyx_webrtc/lib/utils/logging/custom_logger.dart
+++ b/packages/telnyx_webrtc/lib/utils/logging/custom_logger.dart
@@ -11,19 +11,6 @@ abstract class CustomLogger {
     _logLevel = level;
   }
 
-  /// Log a message with the error log level.
-  void e(String message);
-
-  /// Log a message with the warning log level.
-  void w(String message);
-
-  /// Log a message with the debug log level.
-  void d(String message);
-
-  /// Log a message with the info log level.
-  void i(String message);
-
-  /// Log a message with the verto log level. Verto logs are logs related to the Verto protocol.
-  void v(String message);
+  /// Log a message with the specified log level.
+  void log(LogLevel level, String message);
 }
-

--- a/packages/telnyx_webrtc/lib/utils/logging/custom_logger.dart
+++ b/packages/telnyx_webrtc/lib/utils/logging/custom_logger.dart
@@ -1,0 +1,29 @@
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+
+/// Custom logger interface to allow the user to provide their own logging implementation.
+abstract class CustomLogger {
+
+  /// Log level set by the user - will filter specific logs based on the level.
+  var _logLevel = LogLevel.none;
+
+  /// Set the log level for the SDK.
+  void setLogLevel(LogLevel level) {
+    _logLevel = level;
+  }
+
+  /// Log a message with the error log level.
+  void e(String message);
+
+  /// Log a message with the warning log level.
+  void w(String message);
+
+  /// Log a message with the debug log level.
+  void d(String message);
+
+  /// Log a message with the info log level.
+  void i(String message);
+
+  /// Log a message with the verto log level. Verto logs are logs related to the Verto protocol.
+  void v(String message);
+}
+

--- a/packages/telnyx_webrtc/lib/utils/logging/default_logger.dart
+++ b/packages/telnyx_webrtc/lib/utils/logging/default_logger.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/foundation.dart';
+import 'package:telnyx_webrtc/utils/logging/custom_logger.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+
+/// Default logger implementation that will be used when no custom logger is provided
+/// This logger utilizes simple prints based on the log level set by the user.
+class DefaultLogger implements CustomLogger {
+  LogLevel _logLevel = LogLevel.info;
+
+  @override
+  void d(String message) {
+    if (_logLevel.index <= LogLevel.debug.index) {
+      if (kDebugMode) {
+        print('DEBUG: $message');
+      }
+    }
+  }
+
+  @override
+  void e(String message) {
+    if (_logLevel.index <= LogLevel.error.index) {
+      if (kDebugMode) {
+        print('ERROR: $message');
+      }
+    }
+  }
+
+  @override
+  void i(String message) {
+    if (_logLevel.index <= LogLevel.info.index) {
+      if (kDebugMode) {
+        print('INFO: $message');
+      }
+    }
+  }
+
+  @override
+  void v(String message) {
+    if (_logLevel.index <= LogLevel.verto.index) {
+      if (kDebugMode) {
+        print('VERTO: $message');
+      }
+    }
+  }
+
+  @override
+  void w(String message) {
+    if (_logLevel.index <= LogLevel.warning.index) {
+      if (kDebugMode) {
+        print('WARNING: $message');
+      }
+    }
+  }
+
+  @override
+  void setLogLevel(LogLevel level) {
+    _logLevel = level;
+  }
+}
+

--- a/packages/telnyx_webrtc/lib/utils/logging/default_logger.dart
+++ b/packages/telnyx_webrtc/lib/utils/logging/default_logger.dart
@@ -8,53 +8,17 @@ class DefaultLogger implements CustomLogger {
   LogLevel _logLevel = LogLevel.info;
 
   @override
-  void d(String message) {
-    if (_logLevel.index <= LogLevel.debug.index) {
-      if (kDebugMode) {
-        print('DEBUG: $message');
-      }
-    }
-  }
-
-  @override
-  void e(String message) {
-    if (_logLevel.index <= LogLevel.error.index) {
-      if (kDebugMode) {
-        print('ERROR: $message');
-      }
-    }
-  }
-
-  @override
-  void i(String message) {
-    if (_logLevel.index <= LogLevel.info.index) {
-      if (kDebugMode) {
-        print('INFO: $message');
-      }
-    }
-  }
-
-  @override
-  void v(String message) {
-    if (_logLevel.index <= LogLevel.verto.index) {
-      if (kDebugMode) {
-        print('VERTO: $message');
-      }
-    }
-  }
-
-  @override
-  void w(String message) {
-    if (_logLevel.index <= LogLevel.warning.index) {
-      if (kDebugMode) {
-        print('WARNING: $message');
-      }
-    }
-  }
-
-  @override
   void setLogLevel(LogLevel level) {
     _logLevel = level;
+  }
+
+  @override
+  void log(LogLevel level, String message) {
+    if (_logLevel.index <= level.index) {
+      if (kDebugMode) {
+        print('${level.name.toUpperCase()}: $message');
+      }
+    }
   }
 }
 

--- a/packages/telnyx_webrtc/lib/utils/logging/global_logger.dart
+++ b/packages/telnyx_webrtc/lib/utils/logging/global_logger.dart
@@ -1,0 +1,15 @@
+import 'package:telnyx_webrtc/utils/logging/custom_logger.dart';
+import 'package:telnyx_webrtc/utils/logging/default_logger.dart';
+
+/// Global logger class that will be used to log messages throughout the SDK
+class GlobalLogger {
+  static CustomLogger _logger = DefaultLogger();
+
+  /// Get the current logger instance
+  static CustomLogger get logger => _logger;
+
+  /// Set the logger instance
+  static set logger(CustomLogger logger) {
+    _logger = logger;
+  }
+}

--- a/packages/telnyx_webrtc/lib/utils/logging/global_logger.dart
+++ b/packages/telnyx_webrtc/lib/utils/logging/global_logger.dart
@@ -1,5 +1,6 @@
 import 'package:telnyx_webrtc/utils/logging/custom_logger.dart';
 import 'package:telnyx_webrtc/utils/logging/default_logger.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
 
 /// Global logger class that will be used to log messages throughout the SDK
 class GlobalLogger {
@@ -7,6 +8,31 @@ class GlobalLogger {
 
   /// Get the current logger instance
   static CustomLogger get logger => _logger;
+
+  /// Log a message with the info log level.
+  void i(String message) {
+    _logger.log(LogLevel.info, message);
+  }
+
+  /// Log a message with the debug log level.
+  void d(String message) {
+    _logger.log(LogLevel.debug, message);
+  }
+
+  /// Log a message with the error log level.
+  void e(String message) {
+    _logger.log(LogLevel.error, message);
+  }
+
+  /// Log a message with the warning log level.
+  void w(String message) {
+    _logger.log(LogLevel.warning, message);
+  }
+
+  /// Log a message with the verto log level. Verto logs are logs related to the Verto protocol.
+  void v(String message) {
+    _logger.log(LogLevel.verto, message);
+  }
 
   /// Set the logger instance
   static set logger(CustomLogger logger) {

--- a/packages/telnyx_webrtc/lib/utils/logging/log_level.dart
+++ b/packages/telnyx_webrtc/lib/utils/logging/log_level.dart
@@ -1,0 +1,38 @@
+/// Enum to describe the log level that the SDK should use.
+///
+/// The log level itself is implemented as an integer.
+/// Each level has a provided [priority].
+///
+/// - [LogLevel.none]: Disable logs. SDK logs will not be printed. (default)
+/// - [LogLevel.error]: Print error logs only.
+/// - [LogLevel.warning]: Print warning logs only.
+/// - [LogLevel.debug]: Print debug logs only.
+/// - [LogLevel.info]: Print info logs only.
+/// - [LogLevel.verto]: Print verto messages. Incoming and outgoing verto messages are printed.
+/// - [LogLevel.all]: All the SDK logs are printed.
+enum LogLevel {
+  /// Disable logs. SDK logs will not be printed.
+  none(8),
+  /// Print error logs only.
+  error(6),
+
+  /// Print warning logs only.
+  warning(5),
+
+  /// Print debug logs only.
+  debug(3),
+
+  /// Print info logs only.
+  info(4),
+
+  /// Print verto messages. Incoming and outgoing verto messages are printed.
+  verto(9),
+
+  /// All the SDK logs are printed.
+  all(null);
+
+  /// The priority of the log level.
+  final int? priority;
+
+  const LogLevel(this.priority);
+}

--- a/packages/telnyx_webrtc/lib/utils/preference_storage.dart
+++ b/packages/telnyx_webrtc/lib/utils/preference_storage.dart
@@ -1,32 +1,39 @@
 import 'dart:convert';
 
-import 'package:logger/logger.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:telnyx_webrtc/utils/constants.dart';
 
+import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
+
+/// Class to handle the storage of preferences
+/// such as metadata and notification settings
 class PreferencesStorage {
+  /// Key for the notification settings
   static final String notificationKey = Constants.notificationKey;
 
   static Future<Map<String, dynamic>?> getMetaData() async {
     final String metaData = await getString(notificationKey);
     if (metaData.isEmpty) {
-      print('No Metadata found');
+      GlobalLogger.logger.d('No PushMetaData found with notification key $notificationKey');
       return null;
     }
     saveMetadata('');
     return jsonDecode(metaData);
   }
 
+  /// Save the push metadata to the shared preferences
   static void saveMetadata(String metaData) {
-    Logger().i('Save meta data $metaData');
+    GlobalLogger.logger.i('Save PushMetaData $metaData');
     saveString(notificationKey, metaData);
   }
 
+  /// Save a string instance to the shared preferences
   static Future<void> saveString(String key, String data) async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.setString(key, data);
   }
 
+  /// Get a string instance from the shared preferences
   static Future<String> getString(String key) async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     final String? preferences = prefs.getString(key);
@@ -37,11 +44,13 @@ class PreferencesStorage {
     }
   }
 
+  /// Save a boolean instance to the shared preferences
   static Future<void> saveBool(bool data, String key) async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.setBool(key, data);
   }
 
+  /// Get a boolean instance from the shared preferences
   static Future<bool> getBool(String key) async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     final bool? value = prefs.getBool(key);

--- a/packages/telnyx_webrtc/lib/utils/preference_storage.dart
+++ b/packages/telnyx_webrtc/lib/utils/preference_storage.dart
@@ -14,7 +14,7 @@ class PreferencesStorage {
   static Future<Map<String, dynamic>?> getMetaData() async {
     final String metaData = await getString(notificationKey);
     if (metaData.isEmpty) {
-      GlobalLogger.logger.d('No PushMetaData found with notification key $notificationKey');
+      GlobalLogger().d('No PushMetaData found with notification key $notificationKey');
       return null;
     }
     saveMetadata('');
@@ -23,7 +23,7 @@ class PreferencesStorage {
 
   /// Save the push metadata to the shared preferences
   static void saveMetadata(String metaData) {
-    GlobalLogger.logger.i('Save PushMetaData $metaData');
+    GlobalLogger().i('Save PushMetaData $metaData');
     saveString(notificationKey, metaData);
   }
 

--- a/packages/telnyx_webrtc/lib/utils/stats/webrtc_stats_reporter.dart
+++ b/packages/telnyx_webrtc/lib/utils/stats/webrtc_stats_reporter.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
-import 'package:logger/logger.dart';
+import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
 import 'package:telnyx_webrtc/utils/stats/stats_parsing_helpers.dart';
 import 'package:telnyx_webrtc/utils/stats/stats_message.dart';
 import 'package:telnyx_webrtc/tx_socket.dart'
@@ -11,7 +11,14 @@ import 'package:telnyx_webrtc/utils/stats/webrtc_stats_event.dart';
 import 'package:telnyx_webrtc/utils/stats/webrtc_stats_tag.dart';
 import 'package:uuid/uuid.dart';
 
+/// Class to handle the reporting of WebRTC stats to the server
+/// via the provided [socket] and [peerConnection].
+/// The [callId] and [peerId] are used to identify the call and peer respectively.
+/// The stats are collected every 3 seconds and sent to the server.
+/// The stats reporting can be started and stopped using the [startStatsReporting] and [stopStatsReporting] methods.
+/// The collected stats are available in the Telnyx Portal for debugging purposes.
 class WebRTCStatsReporter {
+  /// Default constructor that initializes the WebRTCStatsReporter with the provided parameters
   WebRTCStatsReporter(
     this.socket,
     this.peerConnection,
@@ -19,7 +26,6 @@ class WebRTCStatsReporter {
     this.peerId,
   );
 
-  final Logger _logger = Logger();
   final Queue<String> _messageQueue = Queue<String>();
 
   //File? _logFile;
@@ -138,7 +144,7 @@ class WebRTCStatsReporter {
           localSdp = await peerConnection.getLocalDescription();
           remoteSdp = await peerConnection.getRemoteDescription();
         } catch (e) {
-          _logger.e('Error retrieving descriptions for Signaling State Stats: $e');
+          GlobalLogger.logger.e('Error retrieving descriptions for Signaling State Stats: $e');
         }
 
         // If both are null, just skip
@@ -324,7 +330,7 @@ class WebRTCStatsReporter {
 
           statsObject[report.id] = candidatePair;
         } else {
-          _logger.w(
+          GlobalLogger.logger.w(
             'Failed to resolve local or remote candidate for candidate-pair ${report.id}',
           );
         }
@@ -356,7 +362,7 @@ class WebRTCStatsReporter {
 
       _enqueueMessage(jsonEncode(message.toJson()));
     } catch (e) {
-      _logger.e('Error collecting stats: $e');
+      GlobalLogger.logger.e('Error collecting stats: $e');
     }
   }
 

--- a/packages/telnyx_webrtc/lib/utils/stats/webrtc_stats_reporter.dart
+++ b/packages/telnyx_webrtc/lib/utils/stats/webrtc_stats_reporter.dart
@@ -144,7 +144,7 @@ class WebRTCStatsReporter {
           localSdp = await peerConnection.getLocalDescription();
           remoteSdp = await peerConnection.getRemoteDescription();
         } catch (e) {
-          GlobalLogger.logger.e('Error retrieving descriptions for Signaling State Stats: $e');
+          GlobalLogger().e('Error retrieving descriptions for Signaling State Stats: $e');
         }
 
         // If both are null, just skip
@@ -330,7 +330,7 @@ class WebRTCStatsReporter {
 
           statsObject[report.id] = candidatePair;
         } else {
-          GlobalLogger.logger.w(
+          GlobalLogger().w(
             'Failed to resolve local or remote candidate for candidate-pair ${report.id}',
           );
         }
@@ -362,7 +362,7 @@ class WebRTCStatsReporter {
 
       _enqueueMessage(jsonEncode(message.toJson()));
     } catch (e) {
-      GlobalLogger.logger.e('Error collecting stats: $e');
+      GlobalLogger().e('Error collecting stats: $e');
     }
   }
 

--- a/packages/telnyx_webrtc/pubspec.yaml
+++ b/packages/telnyx_webrtc/pubspec.yaml
@@ -3,7 +3,7 @@ description: Enable real-time communication with WebRTC and Telnyx. Create and r
 homepage: https://telnyx.com/
 repository: https://github.com/team-telnyx/flutter-voice-sdk
 issue_tracker: https://github.com/team-telnyx/flutter-voice-sdk/issues
-version: 1.0.2
+version: 1.0.3
 
 environment:
   sdk: ">=3.0.0 <3.22.3"
@@ -13,7 +13,6 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_webrtc: ^0.12.8
-  logger: ^2.5.0
   uuid: ^4.5.1
   just_audio: ^0.9.43
   shared_preferences: ^2.4.0

--- a/packages/telnyx_webrtc/test/telnyx_client_test.dart
+++ b/packages/telnyx_webrtc/test/telnyx_client_test.dart
@@ -6,6 +6,7 @@ import 'package:mockito/mockito.dart';
 import 'package:telnyx_webrtc/config/telnyx_config.dart';
 import 'package:telnyx_webrtc/model/gateway_state.dart';
 import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
 
 import 'telnyx_client_test.mocks.dart';
 
@@ -66,6 +67,7 @@ void main() {
       sipCallerIDNumber: 'test',
       notificationToken: 'test',
       autoReconnect: false,
+      logLevel: LogLevel.info,
       debug: false,
     );
     // Give time to connect, verify isConnected() adjusts
@@ -85,6 +87,7 @@ void main() {
       sipCallerIDNumber: 'test',
       notificationToken: 'test',
       autoReconnect: false,
+      logLevel: LogLevel.info,
       debug: false,
     );
     // Give time to connect, verify isConnected() adjusts

--- a/packages/telnyx_webrtc/test/telnyx_client_test.mocks.dart
+++ b/packages/telnyx_webrtc/test/telnyx_client_test.mocks.dart
@@ -74,12 +74,12 @@ class MockTelnyxClient extends _i1.Mock implements _i4.TelnyxClient {
       super.noSuchMethod(Invocation.setter(#call, _call),
           returnValueForMissingStub: null);
   @override
-  set storedCredentialConfig(_i7.CredentialConfig? _storedCredentialConfig) =>
+  set _storedCredentialConfig(_i7.CredentialConfig? _storedCredentialConfig) =>
       super.noSuchMethod(
           Invocation.setter(#storedCredentialConfig, _storedCredentialConfig),
           returnValueForMissingStub: null);
   @override
-  set storedTokenConfig(_i7.TokenConfig? _storedTokenConfig) => super
+  set _storedTokenConfig(_i7.TokenConfig? _storedTokenConfig) => super
       .noSuchMethod(Invocation.setter(#storedTokenConfig, _storedTokenConfig),
           returnValueForMissingStub: null);
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   provider: ^6.1.2
   flutter_svg: ^2.0.17
   fluttertoast: ^8.2.11
+  logger: ^2.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
[WEBRTC-2479 - Custom Loggin Implementation.](https://telnyx.atlassian.net/browse/WEBRTC-2479)

---
<!-- Describe your changes here -->
This PR implements a feature that allows users to provide a Custom Logger to our SDK so that they can reroute or handle logs in whichever way they see fit.

This also provides a previously missing LogLevel parameter that is already available on the Android and iOS SDKs. 

## :older_man: :baby: Behaviors
### Before changes
- Logger() dependency existed on the SDK side
- Logger() used throughout the application statically regardless of a predefined log level
- User had no control over logs - the default was to log to the console with full verbosity

### After changes
- Logger() dependency removed from the SDK side
- Custom Logger abstract class created
- Default implementation of Custom Logger provided which is used when the customLogger param on connect is null for either CredentialConfig or TokenConfig
- LogLevel implemented which can be used regardless of whether or not a CustomLogger is provided (as it is used for DefaultLogger as well)
- App module now implements its own CustomLogger implementation which uses Logger() (moving the dependency from SDK side to App side for the sample)

## ✋ Manual testing
1. Launch the app and see that the CustomLogger is being used
2. Change the Credential or Token Config and provide null for customLogger - see that the default (which just prints) is being used
3. Adjust log level and see that it changes
4. If you want to go the extra mile - create your own custom logger and verify
