### PR TITLE
WEBRTC-2553: Flutter - Adding reconnection time out

### DIFF
--- a/lib/model/profile_model.dart
+++ b/lib/model/profile_model.dart
@@ -76,14 +76,13 @@ class Profile {
   Future<Config> toTelnyxConfig() async {
     if (isTokenLogin) {
       return TokenConfig(
-        sipToken: token,
-        sipCallerIDName: sipCallerIDName,
-        sipCallerIDNumber: sipCallerIDNumber,
-        notificationToken: await getNotificationTokenForPlatform() ?? '',
-        debug: false,
-        logLevel: LogLevel.debug,
-        customLogger: CustomSDKLogger()
-      );
+          sipToken: token,
+          sipCallerIDName: sipCallerIDName,
+          sipCallerIDNumber: sipCallerIDNumber,
+          notificationToken: await getNotificationTokenForPlatform() ?? '',
+          debug: false,
+          logLevel: LogLevel.debug,
+          customLogger: CustomSDKLogger());
     } else {
       return CredentialConfig(
         sipUser: sipUser,

--- a/lib/model/profile_model.dart
+++ b/lib/model/profile_model.dart
@@ -82,7 +82,7 @@ class Profile {
           notificationToken: await getNotificationTokenForPlatform() ?? '',
           debug: false,
           logLevel: LogLevel.debug,
-          customLogger: CustomSDKLogger());
+          customLogger: CustomSDKLogger(),);
     } else {
       return CredentialConfig(
         sipUser: sipUser,

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -405,6 +405,7 @@ class TelnyxClientViewModel with ChangeNotifier {
         debug: true,
         logLevel: LogLevel.debug,
         customLogger: CustomSDKLogger(),
+        reconnectionTimeout: 30000,
       );
     } else {
       return null;

--- a/packages/telnyx_webrtc/lib/call.dart
+++ b/packages/telnyx_webrtc/lib/call.dart
@@ -157,6 +157,10 @@ class Call {
     stopAudio();
     callHandler.changeState(CallState.done);
     callEnded();
+    
+    // Cancel any reconnection timer for this call
+    _txClient.onCallStateChangedToActive(callId);
+    
     _txClient.calls.remove(callId);
     final message = TelnyxMessage(
       socketMethod: SocketMethod.bye,

--- a/packages/telnyx_webrtc/lib/config/telnyx_config.dart
+++ b/packages/telnyx_webrtc/lib/config/telnyx_config.dart
@@ -1,4 +1,3 @@
-
 import 'package:telnyx_webrtc/utils/logging/log_level.dart';
 import 'package:telnyx_webrtc/utils/logging/custom_logger.dart';
 
@@ -46,7 +45,7 @@ class Config {
   final String? ringbackPath;
 
   /// reconnectionTimeout in milliseconds (Default 60 seconds)
-  // This is the maximum time allowed for a call to be in the RECONNECTING or Dropped state
+  // This is the maximum time allowed for a call to be in the RECONNECTING or DROPPED state
   int? reconnectionTimeout = 60000;
 }
 

--- a/packages/telnyx_webrtc/lib/config/telnyx_config.dart
+++ b/packages/telnyx_webrtc/lib/config/telnyx_config.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+
 import 'package:telnyx_webrtc/utils/logging/log_level.dart';
 import 'package:telnyx_webrtc/utils/logging/custom_logger.dart';
 
@@ -14,6 +16,7 @@ class Config {
     this.customLogger,
     this.ringTonePath,
     this.ringbackPath,
+    this.reconnectionTimeout,
   });
 
   /// Name associated with the SIP account
@@ -42,6 +45,10 @@ class Config {
 
   /// Path to the ringback file (audio to play when calling)
   final String? ringbackPath;
+
+  /// reconnectionTimeout in milliseconds (Default 60 seconds)
+  // This is the maximum time allowed for a call to be in the RECONNECTING or Dropped state
+  int? reconnectionTimeout = 60000;
 }
 
 /// Creates an instance of CredentialConfig which can be used to log in
@@ -81,6 +88,7 @@ class CredentialConfig extends Config {
     super.ringTonePath,
     super.ringbackPath,
     super.customLogger,
+    super.reconnectionTimeout,
   });
 
   /// SIP username to log in with. Either a SIP Credential from the Portal or a Generated Credential from the API
@@ -126,6 +134,7 @@ class TokenConfig extends Config {
     super.ringTonePath,
     super.ringbackPath,
     super.customLogger,
+    super.reconnectionTimeout,
   });
 
   /// Token to log in with. The token would be generated from a Generated Credential via the API

--- a/packages/telnyx_webrtc/lib/config/telnyx_config.dart
+++ b/packages/telnyx_webrtc/lib/config/telnyx_config.dart
@@ -1,4 +1,3 @@
-import 'dart:ffi';
 
 import 'package:telnyx_webrtc/utils/logging/log_level.dart';
 import 'package:telnyx_webrtc/utils/logging/custom_logger.dart';

--- a/packages/telnyx_webrtc/lib/model/call_state.dart
+++ b/packages/telnyx_webrtc/lib/model/call_state.dart
@@ -18,6 +18,8 @@ enum CallState {
   held,
 
   /// [reconnecting] The call is reconnecting - for this state a [NetworkReason] is provided.
+  /// A call will remain in this state for a maximum of 45 seconds before automatically
+  /// transitioning to [dropped] if the reconnection is not successful.
   reconnecting,
 
   /// [dropped] The call has been dropped - for this state a [NetworkReason] is provided.

--- a/packages/telnyx_webrtc/lib/model/call_state.dart
+++ b/packages/telnyx_webrtc/lib/model/call_state.dart
@@ -18,7 +18,7 @@ enum CallState {
   held,
 
   /// [reconnecting] The call is reconnecting - for this state a [NetworkReason] is provided.
-  /// A call will remain in this state for a maximum of 45 seconds before automatically
+  ///A call will remain in this state for the time specified within the configuration used to log in. The default value is 60 seconds'
   /// transitioning to [dropped] if the reconnection is not successful.
   reconnecting,
 
@@ -39,7 +39,8 @@ enum CallState {
   /// Set the reason for the call state - only valid for [reconnecting] and [dropped] states.
   CallState withReason(NetworkReason reason) {
     if (this != reconnecting && this != dropped) {
-      throw StateError('Reason can only be set for reconnecting or dropped states');
+      throw StateError(
+          'Reason can only be set for reconnecting or dropped states');
     }
     _reasons[this] = reason;
     return this;

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -404,6 +404,9 @@ class Peer {
           final Call? currentCall = _txClient.calls[callId];
           currentCall?.callHandler.changeState(CallState.active);
           onCallStateChange?.call(newSession, CallState.active);
+          
+          // Cancel any reconnection timer for this call
+          _txClient.onCallStateChangedToActive(callId);
         case RTCIceConnectionState.RTCIceConnectionStateFailed:
           peerConnection?.restartIce();
           return;

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -250,12 +250,7 @@ class TelnyxClient {
 
           // End the call
           call.endCall();
-        } else {
-          GlobalLogger().i(
-            'Reconnection timer for call ${call.callId} was cancelled',
-          );
         }
-
         // Remove the timer from the map
         _reconnectionTimers.remove(call.callId);
       },

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -127,7 +127,7 @@ class TelnyxClient {
       calls.entries.where((entry) =>
           entry.value.callState == CallState.active ||
           entry.value.callState == CallState.dropped ||
-          entry.value.callState == CallState.reconnecting),
+          entry.value.callState == CallState.reconnecting,),
     );
   }
 
@@ -136,7 +136,7 @@ class TelnyxClient {
   void onCallStateChangedToActive(String? callId) {
     if (callId != null) {
       GlobalLogger().i(
-          'Call $callId state changed to ACTIVE, cancelling reconnection timer');
+          'Call $callId state changed to ACTIVE, cancelling reconnection timer',);
       _cancelReconnectionTimer(callId);
     }
   }
@@ -238,7 +238,7 @@ class TelnyxClient {
       Duration(
           milliseconds: _storedCredentialConfig?.reconnectionTimeout ??
               _storedTokenConfig?.reconnectionTimeout ??
-              Constants.reconnectionTimeout),
+              Constants.reconnectionTimeout,),
       () {
         // Check if the call is still in the reconnecting state
         if (calls.containsKey(call.callId)) {

--- a/packages/telnyx_webrtc/lib/utils/constants.dart
+++ b/packages/telnyx_webrtc/lib/utils/constants.dart
@@ -6,6 +6,10 @@ class Constants {
   static const int retryConnectTime = 3;
   static const int gatewayResponseDelay = 3000;
   static const int reconnectTimer = 1000;
+  
+  // Reconnection timeout in milliseconds (45 seconds)
+  // This is the maximum time allowed for a call to be in the RECONNECTING state
+  static const int reconnectionTimeout = 45000;
 
   // Stats Manager constants
   static const int statsInitial = 1000;

--- a/packages/telnyx_webrtc/lib/utils/constants.dart
+++ b/packages/telnyx_webrtc/lib/utils/constants.dart
@@ -8,7 +8,7 @@ class Constants {
   static const int reconnectTimer = 1000;
 
   // Reconnection timeout in milliseconds (60 seconds)
-  // This is the maximum time allowed for a call to be in the RECONNECTING or Dropped state
+  // This is the maximum time allowed for a call to be in the RECONNECTING or DROPPED  state
   static const int reconnectionTimeout = 60000;
 
   // Stats Manager constants

--- a/packages/telnyx_webrtc/lib/utils/constants.dart
+++ b/packages/telnyx_webrtc/lib/utils/constants.dart
@@ -6,10 +6,10 @@ class Constants {
   static const int retryConnectTime = 3;
   static const int gatewayResponseDelay = 3000;
   static const int reconnectTimer = 1000;
-  
-  // Reconnection timeout in milliseconds (45 seconds)
-  // This is the maximum time allowed for a call to be in the RECONNECTING state
-  static const int reconnectionTimeout = 45000;
+
+  // Reconnection timeout in milliseconds (60 seconds)
+  // This is the maximum time allowed for a call to be in the RECONNECTING or Dropped state
+  static const int reconnectionTimeout = 60000;
 
   // Stats Manager constants
   static const int statsInitial = 1000;

--- a/packages/telnyx_webrtc/pubspec.yaml
+++ b/packages/telnyx_webrtc/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_webrtc: ^0.12.8
+  flutter_webrtc: 0.12.8
   uuid: ^4.5.1
   just_audio: ^0.9.43
   shared_preferences: ^2.4.0


### PR DESCRIPTION
## Description
Implements a reconnection timeout mechanism for the Flutter Voice SDK to prevent calls from being stuck in the RECONNECTING state indefinitely.

## Changes
- Add a 60-second timeout for calls in the RECONNECTING state
- Automatically transition to DROPPED state if reconnection fails within the timeout period
- Cancel reconnection timer when a call successfully reconnects or ends
- Update documentation to mention the reconnection timeout

## Testing
This change should be tested with the following scenarios:
1. Network switch that results in successful reconnection within the timeout period
2. Network loss that exceeds the timeout period, ensuring the call is properly dropped

## Jira Ticket
[WEBRTC-2553](https://telnyx.atlassian.net/browse/WEBRTC-2553)

[WEBRTC-2553]: https://telnyx.atlassian.net/browse/WEBRTC-2553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ