### PR TITLE
Refactor push notification state management in ViewModel

### DIFF
--- a/.idea/libraries/Flutter_Plugins.xml
+++ b/.idea/libraries/Flutter_Plugins.xml
@@ -26,7 +26,7 @@
       <root url="file://$USER_HOME$/Development/flutter/packages/integration_test" />
       <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/fluttertoast-8.2.11" />
       <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/flutter_webrtc-0.13.1+hotfix.1" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/flutter_callkit_incoming-2.5.2" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/flutter_callkit_incoming-2.0.4+2" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -387,7 +387,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -522,7 +522,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/RunnerDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -551,7 +551,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -156,7 +156,11 @@ class TelnyxClientViewModel with ChangeNotifier {
           break;
         case CallState.done:
           if (!kIsWeb) {
-            FlutterCallkitIncoming.endCall(currentCall?.callId ?? '');
+            if (currentCall?.callId != null || _incomingInvite != null) {
+              FlutterCallkitIncoming.endCall(
+                currentCall?.callId ?? _incomingInvite?.callID! ?? '',
+              );
+            }
           }
           break;
         case CallState.error:
@@ -268,9 +272,17 @@ class TelnyxClientViewModel with ChangeNotifier {
                 if (callFromPush) {
                   _endCallFromPush(true);
                 } else {
-                  await FlutterCallkitIncoming.endCall(
-                    currentCall?.callId ?? _incomingInvite!.callID!,
-                  );
+                  if (currentCall?.callId != null || _incomingInvite != null) {
+                    // end Call for Callkit on iOS
+                    await FlutterCallkitIncoming.endCall(
+                      currentCall?.callId ?? _incomingInvite?.callID! ?? '',
+                    );
+                  } else {
+                    final numCalls = await FlutterCallkitIncoming.activeCalls();
+                    if (numCalls.isNotEmpty) {
+                      await FlutterCallkitIncoming.endCall(numCalls.first.callID);
+                    }
+                  }
                   resetCallInfo();
                 }
               }


### PR DESCRIPTION
[ENGDESK-39787 - Refactor push notification state management in ViewModel](https://telnyx.atlassian.net/browse/ENGDESK-39787)

---
Refactored the state management logic within `TelnyxClientViewModel` related to handling contexts initiated by push notifications. The primary goal was to improve code clarity, readability, and semantic meaning.

The method `updateCallFromPush(bool value)` was ambiguous as the boolean controlled both setting the `callFromPush` flag and conditionally resetting the `callState`. This method has been renamed to `setPushCallStatus(bool isFromPush)` to better reflect its purpose.

The new method now clearly sets the `callFromPush` flag based on the `isFromPush` parameter and handles associated side effects, such as resetting the `callState` to `idle` only when exiting the push context (`isFromPush` is false).

Calls to the old method in `main.dart` (specifically within push notification handling logic like `_firebaseMessagingBackgroundHandler`, `handlePush`, and `FirebaseMessaging.onMessage`) have been updated to use `setPushCallStatus(true)`. The call in `resetCallInfo` has been updated to use `setPushCallStatus(false)`.

## :older_man: :baby: Behaviors
### Before changes
- State management for push notification context was handled by `updateCallFromPush(bool value)`.
- The purpose of the `value` parameter was ambiguous, controlling both a flag and conditional state changes.
- Logic for entering and exiting the push context was combined within this less semantically clear method.
- Readability suffered due to the overloaded nature of the method.
- PushMetaData not being cleared in the rare case of a crash. 

### After changes
- Push notification context state is managed by the more explicit `setPushCallStatus(bool isFromPush)` method.
- The method clearly sets the `callFromPush` flag.
- It explicitly handles side effects based on whether the context is from push (e.g., resetting `callState` to `idle` when `isFromPush` is false).
- Code is more readable and maintainable due to clearer method naming and responsibilities.
- Call sites in `main.dart` related to push handling now correctly use `setPushCallStatus(true)`.
- `resetCallInfo` uses `setPushCallStatus(false)` to correctly exit the push context state.
- PushMetaData being clared in the case of a caught crash 

## ✋ Manual testing
1.  **Receive Push Notification Call (Answer):**
    *   Ensure the app is in the background or terminated.
    *   Initiate an incoming call that triggers a push notification.
    *   Answer the call via the push notification/CallKit UI.
    *   **Verify:** The call connects successfully, `callFromPush` is true initially, and `callState` transitions appropriately (e.g., eventually to `ongoingCall`). `setPushCallStatus(true)` should be logged during setup.
2.  **Receive Push Notification Call (Decline):**
    *   Ensure the app is in the background or terminated.
    *   Initiate an incoming call that triggers a push notification.
    *   Decline the call via the push notification/CallKit UI.
    *   **Verify:** The call attempt is terminated cleanly on the backend (check logs if possible), the app does not connect the call, and state related to the call is reset.
3.  **Receive Direct Incoming Call (App Open):**
    *   Ensure the app is open and the client is connected/registered.
    *   Initiate an incoming call directly (no push involved).
    *   **Verify:** The standard incoming call UI appears, `callFromPush` remains false, and answering/declining works as expected.
4.  **End Call (From Push):**
    *   Establish a call that was initiated via push notification (Step 1).
    *   End the call using the in-app UI.
    *   **Verify:** The call terminates correctly, `resetCallInfo` is called, and `setPushCallStatus(false)` is logged, setting `callState` back to `idle`.
5.  **App Lifecycle (Resume after Push):**
    *   Initiate a push notification call while the app is terminated/background.
    *   Bring the app to the foreground *before* answering/declining (e.g., tap the app icon).
    *   **Verify:** The app handles the incoming push context correctly via `handlePush` or similar logic, calls `setPushCallStatus(true)`, and does *not* attempt a standard auto-login if it's already handling the push flow.