### PR TITLE
WEBRTC-2637: [Flutter] WebRTC Stats Exposure on Call Level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ ios/Pods/
 ios/Runner/GoogleService-Info.plist
 lib/firebase_options.dart
 firebase.json
+android/.idea/caches/deviceStreaming.xml
+android/.idea/material_theme_project_new.xml

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Enable Telnyx real-time communication services on Flutter applications (Android 
 - [x] Hold calls
 - [x] Mute calls
 - [x] Dual Tone Multi Frequency
+- [x] Call quality metrics monitoring
 
 ## Usage
 
@@ -43,6 +44,67 @@ on the iOS platform, you need to add the microphone permission to your Info.plis
     <key>NSMicrophoneUsageDescription</key>
     <string>$(PRODUCT_NAME) Microphone Usage!</string>
 ```
+
+## Call Quality Metrics
+
+The SDK provides real-time call quality metrics through the `onCallQualityChange` callback on the `Call` object. This allows you to monitor call quality in real-time and provide feedback to users.
+
+### Enabling Call Quality Metrics
+
+To enable call quality metrics, set the `debug` parameter to `true` when creating or answering a call:
+
+```dart
+// When making a call
+call.newInvite(
+    callerName: "John Doe",
+    callerNumber: "+1234567890",
+    destinationNumber: "+1987654321",
+    clientState: "some-state",
+    debug: true
+);
+
+// When answering a call
+call.acceptCall(
+    callId: callId,
+    destinationNumber: "destination",
+    debug: true
+);
+
+// Listen for call quality metrics
+call.onCallQualityChange = (metrics) {
+    // Access metrics.jitter, metrics.rtt, metrics.mos, metrics.quality
+    print("Call quality: ${metrics.quality}");
+    print("MOS score: ${metrics.mos}");
+    print("Jitter: ${metrics.jitter * 1000} ms");
+    print("Round-trip time: ${metrics.rtt * 1000} ms");
+};
+```
+
+### CallQualityMetrics Properties
+
+The `CallQualityMetrics` object provides the following properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `jitter` | double | Jitter in seconds (multiply by 1000 for milliseconds) |
+| `rtt` | double | Round-trip time in seconds (multiply by 1000 for milliseconds) |
+| `mos` | double | Mean Opinion Score (1.0-5.0) |
+| `quality` | CallQuality | Call quality rating based on MOS |
+| `inboundAudio` | Map<String, dynamic>? | Inbound audio statistics |
+| `outboundAudio` | Map<String, dynamic>? | Outbound audio statistics |
+
+### CallQuality Enum
+
+The `CallQuality` enum provides the following values:
+
+| Value | MOS Range | Description |
+|-------|-----------|-------------|
+| `excellent` | MOS > 4.2 | Excellent call quality |
+| `good` | 4.1 <= MOS <= 4.2 | Good call quality |
+| `fair` | 3.7 <= MOS <= 4.0 | Fair call quality |
+| `poor` | 3.1 <= MOS <= 3.6 | Poor call quality |
+| `bad` | MOS <= 3.0 | Bad call quality |
+| `unknown` | N/A | Unable to calculate quality |
 
 ## Basic Usage
 

--- a/lib/model/profile_model.dart
+++ b/lib/model/profile_model.dart
@@ -91,7 +91,7 @@ class Profile {
         sipCallerIDName: sipCallerIDName,
         sipCallerIDNumber: sipCallerIDNumber,
         notificationToken: await getNotificationTokenForPlatform() ?? '',
-        debug: true,
+        debug: false,
         logLevel: LogLevel.all,
         customLogger: CustomSDKLogger(),
       );

--- a/lib/model/profile_model.dart
+++ b/lib/model/profile_model.dart
@@ -76,13 +76,14 @@ class Profile {
   Future<Config> toTelnyxConfig() async {
     if (isTokenLogin) {
       return TokenConfig(
-          sipToken: token,
-          sipCallerIDName: sipCallerIDName,
-          sipCallerIDNumber: sipCallerIDNumber,
-          notificationToken: await getNotificationTokenForPlatform() ?? '',
-          debug: false,
-          logLevel: LogLevel.all,
-          customLogger: CustomSDKLogger(),);
+        sipToken: token,
+        sipCallerIDName: sipCallerIDName,
+        sipCallerIDNumber: sipCallerIDNumber,
+        notificationToken: await getNotificationTokenForPlatform() ?? '',
+        debug: false,
+        logLevel: LogLevel.all,
+        customLogger: CustomSDKLogger(),
+      );
     } else {
       return CredentialConfig(
         sipUser: sipUser,
@@ -90,7 +91,7 @@ class Profile {
         sipCallerIDName: sipCallerIDName,
         sipCallerIDNumber: sipCallerIDNumber,
         notificationToken: await getNotificationTokenForPlatform() ?? '',
-        debug: false,
+        debug: true,
         logLevel: LogLevel.all,
         customLogger: CustomSDKLogger(),
       );

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -22,6 +22,7 @@ import 'package:telnyx_webrtc/telnyx_client.dart';
 import 'package:telnyx_webrtc/model/push_notification.dart';
 import 'package:telnyx_webrtc/model/call_state.dart';
 import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+import 'package:telnyx_webrtc/model/call_quality_metrics.dart';
 
 enum CallStateStatus {
   disconnected,
@@ -46,6 +47,7 @@ class TelnyxClientViewModel with ChangeNotifier {
   CredentialConfig? _credentialConfig;
   TokenConfig? _tokenConfig;
   IncomingInviteParams? _incomingInvite;
+  CallQualityMetrics? _callQualityMetrics;
 
   String _localName = '';
   String _localNumber = '';
@@ -60,6 +62,10 @@ class TelnyxClientViewModel with ChangeNotifier {
 
   bool get speakerPhoneState {
     return _speakerPhone;
+  }
+
+  CallQualityMetrics? get callQualityMetrics {
+    return _callQualityMetrics;
   }
 
   bool get muteState {
@@ -105,6 +111,7 @@ class TelnyxClientViewModel with ChangeNotifier {
     _mute = false;
     _hold = false;
     callState = CallStateStatus.idle;
+    _callQualityMetrics = null;
     setPushCallStatus(false);
     notifyListeners();
   }
@@ -153,6 +160,8 @@ class TelnyxClientViewModel with ChangeNotifier {
           currentCall?.onCallQualityChange = (metrics) {
             // Access metrics.jitter, metrics.rtt, metrics.mos, metrics.quality
             print("Call quality: ${metrics}");
+            _callQualityMetrics = metrics;
+            notifyListeners();
           };
 
           break;

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -150,6 +150,11 @@ class TelnyxClientViewModel with ChangeNotifier {
             FlutterCallkitIncoming.setCallConnected(_incomingInvite!.callID!);
           }
 
+          currentCall?.onCallQualityChange = (metrics) {
+            // Access metrics.jitter, metrics.rtt, metrics.mos, metrics.quality
+            print("Call quality: ${metrics}");
+          };
+
           break;
         case CallState.held:
           logger.i('Held');
@@ -248,8 +253,7 @@ class TelnyxClientViewModel with ChangeNotifier {
                 logger.i(
                   'ObserveResponses :: Invite - Not from push, showing notification.',
                 );
-                callState = CallStateStatus
-                    .ongoingInvitation;
+                callState = CallStateStatus.ongoingInvitation;
                 observeCurrentCall();
                 await showNotification(_incomingInvite!);
                 notifyListeners();
@@ -259,8 +263,7 @@ class TelnyxClientViewModel with ChangeNotifier {
                 logger.i(
                   'ObserveResponses :: Invite received, was from push but NOT waiting. Monitoring state.',
                 );
-                callState = CallStateStatus
-                    .ongoingInvitation;
+                callState = CallStateStatus.ongoingInvitation;
                 observeCurrentCall();
                 notifyListeners();
               }
@@ -300,9 +303,10 @@ class TelnyxClientViewModel with ChangeNotifier {
                     if (numCalls.isNotEmpty) {
                       final String? callKitId = numCalls.first['id'] as String?;
                       if (callKitId != null && callKitId.isNotEmpty) {
-                         await FlutterCallkitIncoming.endCall(callKitId);
+                        await FlutterCallkitIncoming.endCall(callKitId);
                       } else {
-                         logger.w('Could not find call ID in active CallKit calls map.');
+                        logger.w(
+                            'Could not find call ID in active CallKit calls map.');
                       }
                     }
                   }

--- a/lib/view/widgets/call_controls/call_controls.dart
+++ b/lib/view/widgets/call_controls/call_controls.dart
@@ -6,6 +6,7 @@ import 'package:telnyx_flutter_webrtc/view/telnyx_client_view_model.dart';
 import 'package:telnyx_flutter_webrtc/view/widgets/call_controls/buttons/call_buttons.dart';
 import 'package:telnyx_flutter_webrtc/view/widgets/call_controls/call_invitation.dart';
 import 'package:telnyx_flutter_webrtc/view/widgets/call_controls/ongoing_call_controls.dart';
+import 'package:telnyx_webrtc/model/call_quality_metrics.dart';
 
 class CallControls extends StatefulWidget {
   const CallControls({super.key});
@@ -27,6 +28,10 @@ class _CallControlsState extends State<CallControls> {
   Widget build(BuildContext context) {
     final clientState = context.select<TelnyxClientViewModel, CallStateStatus>(
       (txClient) => txClient.callState,
+    );
+
+    final metrics = context.select<TelnyxClientViewModel, CallQualityMetrics?>(
+      (txClient) => txClient.callQualityMetrics,
     );
 
     return Column(
@@ -92,7 +97,56 @@ class _CallControlsState extends State<CallControls> {
           Center(
             child: OnGoingCallControls(),
           ),
+        _buildCallQualityMetrics(metrics),
       ],
+    );
+  }
+
+  Widget _buildCallQualityMetrics(CallQualityMetrics? callQualityMetrics) {
+    if (callQualityMetrics == null) return SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Card(
+        color: Color(0xFFF5F3E4), // Custom background color
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16.0), // Rounded edges
+        ),
+        child: Theme(
+          data: Theme.of(context).copyWith(
+            dividerColor: Colors.transparent, // Remove ExpansionTile divider
+          ),
+          child: ExpansionTile(
+            tilePadding:
+                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+            childrenPadding:
+                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+            title: Text(
+              'Call Quality Metrics',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            children: [
+              _buildMetricRow('Jitter', '${callQualityMetrics.jitter} ms'),
+              _buildMetricRow('RTT', '${callQualityMetrics.rtt} ms'),
+              _buildMetricRow('MOS', '${callQualityMetrics.mos}'),
+              _buildMetricRow('Quality', callQualityMetrics.quality.toString()),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMetricRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label, style: Theme.of(context).textTheme.bodyMedium),
+          Text(value, style: Theme.of(context).textTheme.bodyMedium),
+        ],
+      ),
     );
   }
 }

--- a/packages/telnyx_webrtc/lib/model/call_quality.dart
+++ b/packages/telnyx_webrtc/lib/model/call_quality.dart
@@ -1,0 +1,59 @@
+/// Represents the quality of a call based on Mean Opinion Score (MOS).
+enum CallQuality {
+  /// Excellent call quality (MOS > 4.2)
+  excellent,
+
+  /// Good call quality (4.1 <= MOS <= 4.2)
+  good,
+
+  /// Fair call quality (3.7 <= MOS <= 4.0)
+  fair,
+
+  /// Poor call quality (3.1 <= MOS <= 3.6)
+  poor,
+
+  /// Bad call quality (MOS <= 3.0)
+  bad,
+
+  /// Unable to calculate quality
+  unknown;
+
+  /// Returns a string representation of the call quality.
+  @override
+  String toString() {
+    switch (this) {
+      case CallQuality.excellent:
+        return 'Excellent';
+      case CallQuality.good:
+        return 'Good';
+      case CallQuality.fair:
+        return 'Fair';
+      case CallQuality.poor:
+        return 'Poor';
+      case CallQuality.bad:
+        return 'Bad';
+      case CallQuality.unknown:
+        return 'Unknown';
+    }
+  }
+
+  /// Determines the call quality based on a Mean Opinion Score (MOS).
+  ///
+  /// @param mos The Mean Opinion Score (1.0-5.0)
+  /// @return The corresponding CallQuality
+  static CallQuality fromMos(double mos) {
+    if (mos > 4.2) {
+      return CallQuality.excellent;
+    } else if (mos >= 4.1) {
+      return CallQuality.good;
+    } else if (mos >= 3.7) {
+      return CallQuality.fair;
+    } else if (mos >= 3.1) {
+      return CallQuality.poor;
+    } else if (mos > 0) {
+      return CallQuality.bad;
+    } else {
+      return CallQuality.unknown;
+    }
+  }
+}

--- a/packages/telnyx_webrtc/lib/model/call_quality_metrics.dart
+++ b/packages/telnyx_webrtc/lib/model/call_quality_metrics.dart
@@ -1,0 +1,67 @@
+import 'package:telnyx_webrtc/model/call_quality.dart';
+
+/// Represents real-time call quality metrics derived from WebRTC statistics.
+class CallQualityMetrics {
+  /// Creates a new instance of CallQualityMetrics.
+  ///
+  /// @param jitter Jitter in seconds
+  /// @param rtt Round-trip time in seconds
+  /// @param mos Mean Opinion Score (1.0-5.0)
+  /// @param quality Call quality rating based on MOS
+  /// @param inboundAudio Optional inbound audio statistics
+  /// @param outboundAudio Optional outbound audio statistics
+  CallQualityMetrics({
+    required this.jitter,
+    required this.rtt,
+    required this.mos,
+    required this.quality,
+    this.inboundAudio,
+    this.outboundAudio,
+  });
+
+  /// Jitter in seconds (multiply by 1000 for milliseconds)
+  final double jitter;
+
+  /// Round-trip time in seconds (multiply by 1000 for milliseconds)
+  final double rtt;
+
+  /// Mean Opinion Score (1.0-5.0)
+  final double mos;
+
+  /// Call quality rating based on MOS
+  final CallQuality quality;
+
+  /// Inbound audio statistics (optional)
+  final Map<String, dynamic>? inboundAudio;
+
+  /// Outbound audio statistics (optional)
+  final Map<String, dynamic>? outboundAudio;
+
+  /// Creates a dictionary representation of the metrics.
+  ///
+  /// @return Dictionary containing the metrics
+  Map<String, dynamic> toMap() {
+    final map = <String, dynamic>{
+      'jitter': jitter,
+      'rtt': rtt,
+      'mos': mos,
+      'quality': quality.toString(),
+    };
+
+    if (inboundAudio != null) {
+      map['inboundAudio'] = inboundAudio;
+    }
+
+    if (outboundAudio != null) {
+      map['outboundAudio'] = outboundAudio;
+    }
+
+    return map;
+  }
+
+  /// Creates a string representation of the metrics.
+  @override
+  String toString() {
+    return 'CallQualityMetrics{jitter: ${jitter * 1000}ms, rtt: ${rtt * 1000}ms, mos: $mos, quality: $quality}';
+  }
+}

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -375,7 +375,11 @@ class Peer {
       _dcConstraints,
     );
 
-    await startStats(callId, peerId);
+    await startStats(
+      callId, 
+      peerId,
+      onCallQualityChange: newSession.onCallQualityChange,
+    );
 
     if (media != 'data') {
       switch (sdpSemantics) {
@@ -467,7 +471,11 @@ class Peer {
     onDataChannel?.call(session, channel);
   }
 
-  Future<bool> startStats(String callId, String peerId) async {
+  Future<bool> startStats(
+    String callId, 
+    String peerId, {
+    CallQualityCallback? onCallQualityChange,
+  }) async {
     if (_debug == false) {
       GlobalLogger().d(
         'Peer :: Stats manager will not start. Debug mode not enabled on config',
@@ -480,8 +488,13 @@ class Peer {
       return false;
     }
 
-    _statsManager =
-        WebRTCStatsReporter(_socket, peerConnection!, callId, peerId);
+    _statsManager = WebRTCStatsReporter(
+      _socket, 
+      peerConnection!, 
+      callId, 
+      peerId,
+      onCallQualityChange: onCallQualityChange,
+    );
     await _statsManager?.startStatsReporting();
 
     return true;

--- a/packages/telnyx_webrtc/lib/peer/session.dart
+++ b/packages/telnyx_webrtc/lib/peer/session.dart
@@ -9,19 +9,16 @@ class Session {
 
   /// The peer ID for this session.
   String pid;
-  
+
   /// The session ID for this session.
   String sid;
-  
+
   /// The peer connection for this session.
   RTCPeerConnection? peerConnection;
-  
+
   /// The data channel for this session.
   RTCDataChannel? dc;
-  
+
   /// List of remote ICE candidates.
   List<RTCIceCandidate> remoteCandidates = [];
-  
-  /// Callback for call quality metrics updates.
-  CallQualityCallback? onCallQualityChange;
 }

--- a/packages/telnyx_webrtc/lib/peer/session.dart
+++ b/packages/telnyx_webrtc/lib/peer/session.dart
@@ -1,11 +1,27 @@
 import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:telnyx_webrtc/model/call_quality_metrics.dart';
+import 'package:telnyx_webrtc/utils/stats/webrtc_stats_reporter.dart';
 
+/// Represents a WebRTC session.
 class Session {
+  /// Creates a new session with the specified session ID and peer ID.
   Session({required this.sid, required this.pid});
 
+  /// The peer ID for this session.
   String pid;
+  
+  /// The session ID for this session.
   String sid;
+  
+  /// The peer connection for this session.
   RTCPeerConnection? peerConnection;
+  
+  /// The data channel for this session.
   RTCDataChannel? dc;
+  
+  /// List of remote ICE candidates.
   List<RTCIceCandidate> remoteCandidates = [];
+  
+  /// Callback for call quality metrics updates.
+  CallQualityCallback? onCallQualityChange;
 }

--- a/packages/telnyx_webrtc/lib/peer/web/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/web/peer.dart
@@ -124,7 +124,8 @@ class Peer {
       _localStream!.getAudioTracks()[0].enableSpeakerphone(enable);
       GlobalLogger().d('Peer :: Speaker Enabled :: $enable');
     } else {
-      GlobalLogger().d('Peer :: No local stream :: Unable to toggle speaker mode');
+      GlobalLogger()
+          .d('Peer :: No local stream :: Unable to toggle speaker mode');
     }
   }
 
@@ -306,19 +307,23 @@ class Peer {
     try {
       // ICE candidate callback (with optional skipping logic)
       session.peerConnection?.onIceCandidate = (candidate) async {
-        GlobalLogger().i('Web Peer :: onIceCandidate in _createAnswer received: ${candidate.candidate}');
+        GlobalLogger().i(
+            'Web Peer :: onIceCandidate in _createAnswer received: ${candidate.candidate}');
         if (candidate.candidate != null) {
           final candidateString = candidate.candidate.toString();
-          final isValidCandidate = candidateString.contains('stun.telnyx.com') ||
-                                  candidateString.contains('turn.telnyx.com');
+          final isValidCandidate =
+              candidateString.contains('stun.telnyx.com') ||
+                  candidateString.contains('turn.telnyx.com');
 
           if (isValidCandidate) {
-            GlobalLogger().i('Web Peer :: Valid ICE candidate: $candidateString');
+            GlobalLogger()
+                .i('Web Peer :: Valid ICE candidate: $candidateString');
             // Only add valid candidates and reset timer
             await session.peerConnection?.addCandidate(candidate);
             _lastCandidateTime = DateTime.now();
           } else {
-            GlobalLogger().i('Web Peer :: Ignoring non-STUN/TURN candidate: $candidateString');
+            GlobalLogger().i(
+                'Web Peer :: Ignoring non-STUN/TURN candidate: $candidateString');
           }
         } else {
           GlobalLogger().i('Web Peer :: onIceCandidate: complete');
@@ -402,7 +407,8 @@ class Peer {
     required String callId,
     required String media,
   }) async {
-    GlobalLogger().i('Web Peer :: _createSession => sid=$sessionId, callId=$callId');
+    GlobalLogger()
+        .i('Web Peer :: _createSession => sid=$sessionId, callId=$callId');
 
     final newSession = session ?? Session(sid: sessionId, pid: peerId);
     if (media != 'data') {
@@ -458,18 +464,22 @@ class Peer {
     // ICE callbacks
     pc
       ..onIceCandidate = (candidate) async {
-        GlobalLogger().i('Web Peer :: onIceCandidate in _createSession received: ${candidate.candidate}');
+        GlobalLogger().i(
+            'Web Peer :: onIceCandidate in _createSession received: ${candidate.candidate}');
         if (candidate.candidate != null) {
           final candidateString = candidate.candidate.toString();
-          final isValidCandidate = candidateString.contains('stun.telnyx.com') ||
-                                  candidateString.contains('turn.telnyx.com');
+          final isValidCandidate =
+              candidateString.contains('stun.telnyx.com') ||
+                  candidateString.contains('turn.telnyx.com');
 
           if (isValidCandidate) {
-            GlobalLogger().i('Web Peer :: Valid ICE candidate: $candidateString');
+            GlobalLogger()
+                .i('Web Peer :: Valid ICE candidate: $candidateString');
             // Add valid candidates
             await pc.addCandidate(candidate);
           } else {
-            GlobalLogger().i('Web Peer :: Ignoring non-STUN/TURN candidate: $candidateString');
+            GlobalLogger().i(
+                'Web Peer :: Ignoring non-STUN/TURN candidate: $candidateString');
           }
         } else {
           GlobalLogger().i('Web Peer :: onIceCandidate: complete');
@@ -524,10 +534,12 @@ class Peer {
     RTCPeerConnection pc,
   ) async {
     if (!_debug) {
-      GlobalLogger().d('Peer :: Stats manager will NOT start; debug mode not enabled.');
+      GlobalLogger()
+          .d('Peer :: Stats manager will NOT start; debug mode not enabled.');
       return false;
     }
-    _statsManager = WebRTCStatsReporter(_socket, pc, callId, peerId);
+    _statsManager =
+        WebRTCStatsReporter(_socket, pc, callId, peerId, _txClient.isDebug());
     await _statsManager?.startStatsReporting();
     GlobalLogger().d('Peer :: Stats Manager started for callId=$callId');
     return true;
@@ -594,8 +606,10 @@ class Peer {
       (timer) {
         if (_lastCandidateTime == null) return;
 
-        final timeSinceLastCandidate = DateTime.now().difference(_lastCandidateTime!).inMilliseconds;
-        GlobalLogger().d('Time since last candidate: ${timeSinceLastCandidate}ms');
+        final timeSinceLastCandidate =
+            DateTime.now().difference(_lastCandidateTime!).inMilliseconds;
+        GlobalLogger()
+            .d('Time since last candidate: ${timeSinceLastCandidate}ms');
 
         if (timeSinceLastCandidate >= _negotiationTimeout) {
           GlobalLogger().d('Negotiation timeout reached');

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -727,6 +727,7 @@ class TelnyxClient {
     String destinationNumber,
     String clientState, {
     Map<String, String> customHeaders = const {},
+    bool debug = false,
   }) {
     final Call inviteCall = _createCall()
       ..sessionCallerName = callerName
@@ -738,7 +739,8 @@ class TelnyxClient {
     final base64State = base64.encode(utf8.encode(clientState));
     updateCall(inviteCall);
 
-    inviteCall.peerConnection = Peer(inviteCall.txSocket, _debug, this);
+    // Create the peer connection with debug enabled if requested
+    inviteCall.peerConnection = Peer(inviteCall.txSocket, debug || _debug, this);
     inviteCall.peerConnection?.invite(
       callerName,
       callerNumber,
@@ -764,6 +766,7 @@ class TelnyxClient {
     String clientState, {
     bool isAttach = false,
     Map<String, String> customHeaders = const {},
+    bool debug = false,
   }) {
     final Call answerCall = getCallOrNull(invite.callID!) ?? _createCall()
       ..callId = invite.callID
@@ -775,7 +778,10 @@ class TelnyxClient {
 
     final destinationNum = invite.callerIdNumber;
 
-    answerCall.peerConnection = Peer(txSocket, _debug, this);
+    // Create the peer connection
+    answerCall.peerConnection = Peer(txSocket, debug || _debug, this);
+    
+    // Set up the session with the callback if debug is enabled
     answerCall.peerConnection?.accept(
       callerName,
       callerNumber,

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -736,7 +736,7 @@ class TelnyxClient {
     String destinationNumber,
     String clientState, {
     Map<String, String> customHeaders = const {},
-    bool debug = true,
+    bool debug = false,
   }) {
     final Call inviteCall = _createCall()
       ..sessionCallerName = callerName

--- a/packages/telnyx_webrtc/lib/utils/stats/mos_calculator.dart
+++ b/packages/telnyx_webrtc/lib/utils/stats/mos_calculator.dart
@@ -1,0 +1,71 @@
+/// Utility class for calculating Mean Opinion Score (MOS) from WebRTC statistics.
+class MosCalculator {
+  /// Calculates the Mean Opinion Score (MOS) based on network metrics.
+  ///
+  /// This implementation uses the ITU-T G.107 E-Model to estimate MOS.
+  /// The formula is simplified for WebRTC audio calls.
+  ///
+  /// @param rtt Round-trip time in seconds
+  /// @param jitter Jitter in seconds
+  /// @param packetLoss Packet loss ratio (0.0-1.0)
+  /// @return Estimated MOS value between 1.0 and 4.5
+  static double calculateMos({
+    required double rtt,
+    required double jitter,
+    double packetLoss = 0.0,
+  }) {
+    // Convert to milliseconds for calculation
+    final rttMs = rtt * 1000;
+    final jitterMs = jitter * 1000;
+    
+    // Clamp values to reasonable ranges
+    final effectiveRtt = _clamp(rttMs, 0, 500);
+    final effectiveJitter = _clamp(jitterMs, 0, 100);
+    final effectivePacketLoss = _clamp(packetLoss, 0.0, 1.0) * 100; // Convert to percentage
+    
+    // Calculate R-factor based on ITU-T G.107 E-Model (simplified)
+    // R = 93.2 - Id - Ie
+    // where:
+    // - Id is the delay impairment factor
+    // - Ie is the equipment impairment factor (affected by packet loss and codec)
+    
+    // Delay impairment (Id)
+    final delayImpairment = 0.024 * effectiveRtt + 0.11 * (effectiveRtt - 177.3) * (effectiveRtt > 177.3 ? 1 : 0);
+    
+    // Equipment impairment (Ie)
+    // For G.711 codec: Ie = 0 + 30 * packetLoss / (packetLoss + 10)
+    // We add jitter impact as well
+    final jitterImpairment = effectiveJitter * 0.05;
+    final packetLossImpairment = 30 * effectivePacketLoss / (effectivePacketLoss + 10);
+    final equipmentImpairment = jitterImpairment + packetLossImpairment;
+    
+    // Calculate R-factor
+    final rFactor = 93.2 - delayImpairment - equipmentImpairment;
+    final clampedRFactor = _clamp(rFactor, 0, 100);
+    
+    // Convert R-factor to MOS using the standard formula
+    // For R < 0: MOS = 1
+    // For 0 <= R <= 100: MOS = 1 + 0.035*R + R*(R-60)*(100-R)*7*10^-6
+    // For R > 100: MOS = 4.5
+    
+    double mos;
+    if (clampedRFactor < 0) {
+      mos = 1.0;
+    } else if (clampedRFactor > 100) {
+      mos = 4.5;
+    } else {
+      mos = 1 + 0.035 * clampedRFactor + 
+          clampedRFactor * (clampedRFactor - 60) * (100 - clampedRFactor) * 7 * 1e-6;
+    }
+    
+    // Ensure MOS is between 1.0 and 4.5
+    return _clamp(mos, 1.0, 4.5);
+  }
+  
+  /// Clamps a value between a minimum and maximum.
+  static T _clamp<T extends num>(T value, T min, T max) {
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
+  }
+}

--- a/packages/telnyx_webrtc/lib/utils/stats/webrtc_stats_reporter.dart
+++ b/packages/telnyx_webrtc/lib/utils/stats/webrtc_stats_reporter.dart
@@ -2,7 +2,10 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:telnyx_webrtc/model/call_quality.dart';
+import 'package:telnyx_webrtc/model/call_quality_metrics.dart';
 import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
+import 'package:telnyx_webrtc/utils/stats/mos_calculator.dart';
 import 'package:telnyx_webrtc/utils/stats/stats_parsing_helpers.dart';
 import 'package:telnyx_webrtc/utils/stats/stats_message.dart';
 import 'package:telnyx_webrtc/tx_socket.dart'
@@ -10,6 +13,9 @@ import 'package:telnyx_webrtc/tx_socket.dart'
 import 'package:telnyx_webrtc/utils/stats/webrtc_stats_event.dart';
 import 'package:telnyx_webrtc/utils/stats/webrtc_stats_tag.dart';
 import 'package:uuid/uuid.dart';
+
+/// Callback for receiving call quality metrics updates
+typedef CallQualityCallback = void Function(CallQualityMetrics metrics);
 
 /// Class to handle the reporting of WebRTC stats to the server
 /// via the provided [socket] and [peerConnection].
@@ -23,8 +29,9 @@ class WebRTCStatsReporter {
     this.socket,
     this.peerConnection,
     this.callId,
-    this.peerId,
-  );
+    this.peerId, {
+    this.onCallQualityChange,
+  });
 
   final Queue<String> _messageQueue = Queue<String>();
 
@@ -39,6 +46,9 @@ class WebRTCStatsReporter {
   final RTCPeerConnection peerConnection;
   final String callId;
   final String peerId;
+  
+  /// Callback for call quality metrics updates
+  final CallQualityCallback? onCallQualityChange;
 
   /*Future<void> _initializeLogFile() async {
     try {
@@ -210,33 +220,81 @@ class WebRTCStatsReporter {
       final Map<String, dynamic> localCandidates = {};
       final Map<String, dynamic> remoteCandidates = {};
       final List<Map<String, dynamic>> unresolvedCandidatePairs = [];
+      
+      // Variables for call quality metrics
+      double jitter = 0;
+      double rtt = 0;
+      double packetLoss = 0;
+      Map<String, dynamic>? inboundAudioStats;
+      Map<String, dynamic>? outboundAudioStats;
 
       for (var report in stats) {
         switch (report.type) {
           case 'inbound-rtp':
+            final inboundValues = report.values.cast<String, dynamic>();
+            
+            // Extract jitter from inbound-rtp
+            if (inboundValues.containsKey('jitter') && 
+                inboundValues['kind'] == 'audio') {
+              jitter = (inboundValues['jitter'] as num?)?.toDouble() ?? 0;
+              
+              // Extract packet loss if available
+              if (inboundValues.containsKey('packetsLost') && 
+                  inboundValues.containsKey('totalPacketsReceived')) {
+                final packetsLost = (inboundValues['packetsLost'] as num?)?.toDouble() ?? 0;
+                final totalPackets = (inboundValues['totalPacketsReceived'] as num?)?.toDouble() ?? 1;
+                if (totalPackets > 0) {
+                  packetLoss = packetsLost / (totalPackets + packetsLost);
+                }
+              }
+              
+              inboundAudioStats = Map<String, dynamic>.from(inboundValues);
+            }
+            
             audioInboundStats.add({
-              ...report.values,
+              ...inboundValues,
               'timestamp': timestamp,
               'track': {},
             });
             statsObject[report.id] = {
-              ...report.values,
+              ...inboundValues,
               'id': report.id,
               'type': report.type,
               'timestamp': timestamp,
             };
             break;
           case 'outbound-rtp':
+            final outboundValues = report.values.cast<String, dynamic>();
+            
+            if (outboundValues['kind'] == 'audio') {
+              outboundAudioStats = Map<String, dynamic>.from(outboundValues);
+            }
+            
             audioOutboundStats.add({
-              ...report.values,
+              ...outboundValues,
               'timestamp': timestamp,
               'track': _constructTrack(
-                report.values.cast<String, dynamic>(),
+                outboundValues,
                 timestamp,
               ),
             });
             statsObject[report.id] = {
-              ...report.values,
+              ...outboundValues,
+              'id': report.id,
+              'type': report.type,
+              'timestamp': timestamp,
+            };
+            break;
+          case 'remote-inbound-rtp':
+            // Extract RTT from remote-inbound-rtp
+            final remoteInboundValues = report.values.cast<String, dynamic>();
+            if (remoteInboundValues.containsKey('roundTripTime') && 
+                remoteInboundValues['kind'] == 'audio') {
+              rtt = (remoteInboundValues['roundTripTime'] as num?)?.toDouble() ?? 0;
+            }
+            
+            statsObject[report.id] = {
+              ...remoteInboundValues,
               'id': report.id,
               'type': report.type,
               'timestamp': timestamp,
@@ -263,15 +321,16 @@ class WebRTCStatsReporter {
             statsObject[report.id] = remoteCandidate;
             break;
           case 'candidate-pair':
-            final localCandidateId = report.values['localCandidateId'];
-            final remoteCandidateId = report.values['remoteCandidateId'];
+            final candidatePairValues = report.values.cast<String, dynamic>();
+            final localCandidateId = candidatePairValues['localCandidateId'];
+            final remoteCandidateId = candidatePairValues['remoteCandidateId'];
 
             final localCandidate = localCandidates[localCandidateId];
             final remoteCandidate = remoteCandidates[remoteCandidateId];
 
             final candidatePair = {
               'id': report.id,
-              ...report.values,
+              ...candidatePairValues,
               'timestamp': timestamp,
               'type': 'candidate-pair',
             };
@@ -284,6 +343,11 @@ class WebRTCStatsReporter {
 
               // Always set the succeededConnection to the most recent candidatePair
               succeededConnection = candidatePair.cast<String, dynamic>();
+
+              // Extract RTT from candidate pair if not found in remote-inbound-rtp
+              if (rtt == 0 && candidatePairValues.containsKey('currentRoundTripTime')) {
+                rtt = (candidatePairValues['currentRoundTripTime'] as num?)?.toDouble() ?? 0;
+              }
 
               statsObject[report.id] = candidatePair;
             } else {
@@ -306,15 +370,16 @@ class WebRTCStatsReporter {
       // Process unresolved candidate-pairs
       for (final unresolved in unresolvedCandidatePairs) {
         final report = unresolved['report'];
-        final localCandidateId = report.values['localCandidateId'];
-        final remoteCandidateId = report.values['remoteCandidateId'];
+        final reportValues = report.values.cast<String, dynamic>();
+        final localCandidateId = reportValues['localCandidateId'];
+        final remoteCandidateId = reportValues['remoteCandidateId'];
 
         final localCandidate = localCandidates[localCandidateId];
         final remoteCandidate = remoteCandidates[remoteCandidateId];
 
         final candidatePair = {
           'id': report.id,
-          ...report.values,
+          ...reportValues,
           'timestamp': unresolved['timestamp'],
           'type': 'candidate-pair',
         };
@@ -334,6 +399,35 @@ class WebRTCStatsReporter {
             'Failed to resolve local or remote candidate for candidate-pair ${report.id}',
           );
         }
+      }
+
+      // Calculate MOS and call quality metrics if we have valid data
+      if (onCallQualityChange != null && (jitter > 0 || rtt > 0)) {
+        // Calculate MOS using the E-model
+        final mos = MosCalculator.calculateMos(
+          rtt: rtt,
+          jitter: jitter,
+          packetLoss: packetLoss,
+        );
+        
+        // Determine call quality based on MOS
+        final quality = CallQuality.fromMos(mos);
+        
+        // Create call quality metrics object
+        final metrics = CallQualityMetrics(
+          jitter: jitter,
+          rtt: rtt,
+          mos: mos,
+          quality: quality,
+          inboundAudio: inboundAudioStats,
+          outboundAudio: outboundAudioStats,
+        );
+        
+        // Notify via callback
+        onCallQualityChange!(metrics);
+        
+        // Log metrics (debug level to avoid excessive logging)
+        GlobalLogger().d('Call quality metrics: $metrics');
       }
 
       // Format the data


### PR DESCRIPTION
## Description

This PR adds WebRTC stats exposure on call level to the Flutter SDK, similar to the implementation in the Android and iOS SDKs.

### Features Added

- Added `CallQuality` enum to represent different quality levels (excellent, good, fair, poor, bad, unknown)
- Added `CallQualityMetrics` class to hold metrics data (jitter, RTT, MOS, quality)
- Implemented `MosCalculator` utility for calculating Mean Opinion Score based on network metrics
- Updated `WebRTCStatsReporter` to calculate and report call quality metrics
- Added `onCallQualityChange` callback to the `Call` class
- Updated call creation and answer methods to accept a debug parameter
- Added documentation in README.md

### Usage

```dart
// When making a call
call.newInvite(
    callerName: "John Doe",
    callerNumber: "+1234567890",
    destinationNumber: "+1987654321",
    clientState: "some-state",
    debug: true
);

// When answering a call
call.acceptCall(
    callId: callId,
    destinationNumber: "destination",
    debug: true
);

// Listen for call quality metrics
call.onCallQualityChange = (metrics) {
    // Access metrics.jitter, metrics.rtt, metrics.mos, metrics.quality
    print("Call quality: ${metrics.quality}");
    print("MOS score: ${metrics.mos}");
    print("Jitter: ${metrics.jitter * 1000} ms");
    print("Round-trip time: ${metrics.rtt * 1000} ms");
};
```

## Related Issues

Closes WEBRTC-2637