### PR TITLE
Separation of Push Logic into platform specific implementations of abstract classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ ios/Pods/
 ios/Runner/GoogleService-Info.plist
 lib/firebase_options.dart
 firebase.json
+/android/app/.cxx

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,6 +29,7 @@ android {
     compileSdkVersion 35
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -75,4 +76,5 @@ flutter {
 dependencies {
     implementation platform('com.google.firebase:firebase-bom:30.4.1')
     androidTestUtil "androidx.test:orchestrator:1.5.1"
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-feature android:name="android.hardware.camera" />
-    <uses-feature android:name="android.hardware.camera.autofocus" />
-    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
@@ -11,10 +8,21 @@
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
-   <application
+    <!-- Required for Notifications -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS"/>
+
+    <application
         android:label="@string/appName"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="telnyx_call_channel" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -94,6 +94,60 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
      flutter_local_notifications: ^<latest_version>
    ```
 
+   **Gradle Setup (for Android):**
+   The `flutter_local_notifications` plugin may require Java 8+ features. To enable support for these, you need to configure Core Library Desugaring in your Android project.
+
+   In your `android/app/build.gradle` file, ensure the following configurations are present:
+
+   ```groovy
+   // android/app/build.gradle (Groovy DSL)
+   android {
+       // ... other settings
+
+       compileOptions {
+           coreLibraryDesugaringEnabled true
+           sourceCompatibility JavaVersion.VERSION_1_8 
+           targetCompatibility JavaVersion.VERSION_1_8
+       }
+
+       kotlinOptions {
+           jvmTarget = "1.8"
+       }
+   }
+
+   dependencies {
+       coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
+   }
+   ```
+
+   For projects using **Kotlin DSL (`build.gradle.kts`):**
+   ```kotlin
+   // android/app/build.gradle.kts (Kotlin DSL)
+   android {
+       // ... other settings
+       defaultConfig {
+           // multiDexEnabled = true // Only if you explicitly need multidex for other reasons
+       }
+
+       compileOptions {
+           isCoreLibraryDesugaringEnabled = true
+           sourceCompatibility = JavaVersion.VERSION_1_8 // Or JavaVersion.VERSION_11
+           targetCompatibility = JavaVersion.VERSION_1_8 // Or JavaVersion.VERSION_11
+       }
+
+       kotlinOptions {
+           jvmTarget = JavaVersion.VERSION_1_8.toString() // Or JavaVersion.VERSION_11.toString()
+       }
+       // ... other settings
+   }
+
+   dependencies {
+       // ... other dependencies
+       coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4") // Or a newer version like 2.1.4 for Java 11
+   }
+   ```
+   *(Note: Adjust Java versions and `desugar_jdk_libs` version as needed. While `flutter_local_notifications` might show Java 11, Java 8 with `desugar_jdk_libs:2.0.4` is often sufficient. For Java 11, use `desugar_jdk_libs:2.1.4` or newer.)*
+
    Then, create the channel, typically during your app's initialization (e.g., in your `AndroidPushNotificationHandler.initialize` method):
 
    ```dart

--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -6,7 +6,7 @@ It is important to understand how push notifications work in general in relation
 
 To address this limitation, the Telnyx Voice SDK uses push notifications to inform the device of incoming calls. When you log in to the TelnyxClient and provide an APNS or FCM token, the SDK sends a push notification to your device whenever an incoming call is received. Note that this notification only indicates that an invitation is on the way.
 
-Once you respond to a push notification—for example, by tapping “Accept”—you must handle the logic to launch and reconnect to the TelnyxClient. After reconnection, the socket connection is re-established, and the backend will send the actual invitation to your device. In this scenario, it may be helpful to store the fact that the push notification was accepted so that when the invitation arrives (as soon as the socket is connected), you can automatically accept the call.
+Once you respond to a push notification—for example, by tapping "Accept"—you must handle the logic to launch and reconnect to the TelnyxClient. After reconnection, the socket connection is re-established, and the backend will send the actual invitation to your device. In this scenario, it may be helpful to store the fact that the push notification was accepted so that when the invitation arrives (as soon as the socket is connected), you can automatically accept the call.
 
 The following sections provide more detail on how to implement these steps.
 
@@ -84,7 +84,56 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 
 ```
 
-4. Use the `TelnyxClient.getPushMetaData()` method to retrieve the metadata when the app comes to the foreground. This data is only available on 1st access and becomes `null` afterward.
+4. **Create a High-Importance Notification Channel (Android 8.0+)**
+
+   For Android 8.0 (API level 26) and higher, notifications must be assigned to a channel. To ensure incoming call notifications are treated with high priority (e.g., shown as heads-up notifications), you need to create a dedicated channel with maximum importance.
+
+   First, add the `flutter_local_notifications` package to your `pubspec.yaml`:
+   ```yaml
+   dependencies:
+     flutter_local_notifications: ^<latest_version>
+   ```
+
+   Then, create the channel, typically during your app's initialization (e.g., in your `AndroidPushNotificationHandler.initialize` method):
+
+   ```dart
+   import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+   // Create high importance channel
+   const AndroidNotificationChannel channel = AndroidNotificationChannel(
+     'telnyx_call_channel', // Unique ID for the channel
+     'Incoming Calls', // User-visible name 
+     description: 'Notifications for incoming Telnyx calls.', // User-visible description
+     importance: Importance.max, // Crucial for heads-up display
+     playSound: true,
+     audioAttributesUsage: AudioAttributesUsage.notificationRingtone, // Use ringtone audio attributes
+     // Add other properties like vibration pattern if desired
+   );
+
+   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
+       FlutterLocalNotificationsPlugin();
+
+   try {
+      await flutterLocalNotificationsPlugin
+       .resolvePlatformSpecificImplementation<
+           AndroidFlutterLocalNotificationsPlugin>()
+       ?.createNotificationChannel(channel);
+      print('High importance notification channel created/updated.');
+   } catch (e) {
+      print('Failed to create notification channel: $e');
+   }
+   ```
+
+   Finally, tell the Firebase SDK to use this channel by default for incoming FCM notifications by adding the following meta-data inside the `<application>` tag in your `android/app/src/main/AndroidManifest.xml`:
+
+   ```xml
+   <meta-data
+       android:name="com.google.firebase.messaging.default_notification_channel_id"
+       android:value="telnyx_call_channel" /> 
+   ```
+   *(Note: The ID 'telnyx_call_channel' must match the ID used in the Dart code.)*
+
+5. Use the `TelnyxClient.getPushMetaData()` method to retrieve the metadata when the app comes to the foreground. This data is only available on 1st access and becomes `null` afterward.
 ```dart
     Future<void> _handlePushNotification() async {
        final  data = await TelnyxClient.getPushMetaData();
@@ -95,7 +144,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
     }
 ```
 
-5. To Handle push calls on foreground, Listen for Call Events and invoke the `handlePushNotification` method
+6. To Handle push calls on foreground, Listen for Call Events and invoke the `handlePushNotification` method
 ```dart
 FlutterCallkitIncoming.onEvent.listen((CallEvent? event) {
    switch (event!.event) {

--- a/docs-markdown/push-notification/troubleshooting.md
+++ b/docs-markdown/push-notification/troubleshooting.md
@@ -1,4 +1,3 @@
-
 This guide helps you troubleshoot common issues that prevent push notifications from being delivered in the Telnyx WebRTC Flutter SDK.
 
 ## Introduction
@@ -53,7 +52,42 @@ If your push credential contains incorrect information, push notifications will 
 - Update your push credential in the Telnyx Portal with the new key
 - Test push notifications after updating the credential
 
-### 4. Additional Android Troubleshooting Steps
+### 4. Delayed or Batched Notifications (Android 8+)
+
+**Symptom:**
+Notifications (especially for incoming calls) are not arriving immediately when the app is in the background or terminated. They might arrive in batches after some delay.
+
+**Cause:**
+Android includes power-saving features like Doze mode and App Standby that can defer background network access and job execution for apps using `normal` priority Firebase Cloud Messages (FCM).
+
+**Solutions:**
+
+1. **Create High-Importance Notification Channel (Client-Side - For Display):**
+    *   While server-side priority affects *delivery speed*, a client-side Notification Channel with `Importance.max` is crucial for ensuring the notification is *displayed* promptly as a heads-up notification once delivered (on Android 8.0+).
+    *   Make sure you have created this channel using `flutter_local_notifications` during your app initialization, as described in the [App Setup Guide](app-setup.md).
+    *   **Verification Code Snippet:**
+        ```dart
+        // Example (should be in your initialization code)
+        import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+        const AndroidNotificationChannel channel = AndroidNotificationChannel(
+          'telnyx_call_channel', 
+          'Incoming Calls', 
+          description: 'Notifications for incoming Telnyx calls.',
+          importance: Importance.max,
+          playSound: true,
+          audioAttributesUsage: AudioAttributesUsage.notificationRingtone,
+        );
+        final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
+        await flutterLocalNotificationsPlugin
+            .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
+            ?.createNotificationChannel(channel);
+        ```
+
+2. **Check `AndroidManifest.xml`:**
+    *   Ensure you have added the `<meta-data android:name="com.google.firebase.messaging.default_notification_channel_id" android:value="your_channel_id" />` tag inside your `<application>` tag, where `your_channel_id` matches the ID used when creating the channel (e.g., `telnyx_call_channel`). This helps Firebase use the correct channel if it ever displays a notification directly.
+
+### 5. Additional Android Troubleshooting Steps
 
 1. **Check Firebase Console Logs**
    - Go to the Firebase Console > Your Project > Engage > Messaging

--- a/docs-markdown/push-notification/troubleshooting.md
+++ b/docs-markdown/push-notification/troubleshooting.md
@@ -87,6 +87,60 @@ Android includes power-saving features like Doze mode and App Standby that can d
 2. **Check `AndroidManifest.xml`:**
     *   Ensure you have added the `<meta-data android:name="com.google.firebase.messaging.default_notification_channel_id" android:value="your_channel_id" />` tag inside your `<application>` tag, where `your_channel_id` matches the ID used when creating the channel (e.g., `telnyx_call_channel`). This helps Firebase use the correct channel if it ever displays a notification directly.
 
+3. **Enable Core Library Desugaring (Gradle Setup):**
+    *   If you encounter build failures like `CheckDebugAarMetadata` or runtime errors related to missing Java APIs after adding `flutter_local_notifications` or similar plugins, you likely need to enable Core Library Desugaring.
+    *   In your `android/app/build.gradle` (Groovy DSL):
+        ```groovy
+        android {
+            // ...
+            compileOptions {
+                coreLibraryDesugaringEnabled true
+                sourceCompatibility JavaVersion.VERSION_1_8 // or VERSION_11
+                targetCompatibility JavaVersion.VERSION_1_8 // or VERSION_11
+            }
+            kotlinOptions {
+                jvmTarget = "1.8" // or "11"
+            }
+            // ...
+        }
+
+        dependencies {
+            // ...
+            coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4' // Or newer, e.g., 2.1.4 for Java 11 support
+        }
+        ```
+
+    *   For projects using **Kotlin DSL (`build.gradle.kts`):**
+        ```kotlin
+        // android/app/build.gradle.kts (Kotlin DSL)
+        android {
+            // ... other settings
+            defaultConfig {
+                // multiDexEnabled = true // Only if you explicitly need multidex for other reasons
+            }
+
+            compileOptions {
+                isCoreLibraryDesugaringEnabled = true
+                sourceCompatibility = JavaVersion.VERSION_1_8 // Or JavaVersion.VERSION_11
+                targetCompatibility = JavaVersion.VERSION_1_8 // Or JavaVersion.VERSION_11
+            }
+
+            kotlinOptions {
+                jvmTarget = JavaVersion.VERSION_1_8.toString() // Or JavaVersion.VERSION_11.toString()
+            }
+            // ... other settings
+        }
+
+        dependencies {
+            // ... other dependencies
+            coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4") // Or a newer version like 2.1.4 for Java 11
+        }
+        ```
+    *   This allows your app to use Java 8+ language APIs on older Android versions. Refer to the official [Android Java 8+ support documentation](https://developer.android.com/studio/write/java8-support) and the specific plugin's documentation (like `flutter_local_notifications`) for the recommended Java version and `desugar_jdk_libs` version.
+
+4. **Foreground Service (Advanced):**
+    *   For maximum reliability, especially for critical call signaling, consider implementing an Android Foreground Service (using a plugin like `flutter_foreground_task`) to handle the incoming FCM message. This gives your background processing higher priority. Refer to Android best practices for call-related apps.
+
 ### 5. Additional Android Troubleshooting Steps
 
 1. **Check Firebase Console Logs**

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -6,31 +6,31 @@ PODS:
     - Flutter
     - FlutterMacOS
   - CryptoSwift (1.8.4)
-  - Firebase/CoreOnly (11.6.0):
-    - FirebaseCore (~> 11.6.0)
-  - Firebase/Messaging (11.6.0):
+  - Firebase/CoreOnly (11.10.0):
+    - FirebaseCore (~> 11.10.0)
+  - Firebase/Messaging (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 11.6.0)
-  - firebase_core (3.10.0):
-    - Firebase/CoreOnly (= 11.6.0)
+    - FirebaseMessaging (~> 11.10.0)
+  - firebase_core (3.13.0):
+    - Firebase/CoreOnly (= 11.10.0)
     - Flutter
-  - firebase_messaging (15.2.0):
-    - Firebase/Messaging (= 11.6.0)
+  - firebase_messaging (15.2.5):
+    - Firebase/Messaging (= 11.10.0)
     - firebase_core
     - Flutter
-  - FirebaseCore (11.6.0):
-    - FirebaseCoreInternal (~> 11.6.0)
+  - FirebaseCore (11.10.0):
+    - FirebaseCoreInternal (~> 11.10.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/Logger (~> 8.0)
-  - FirebaseCoreInternal (11.6.0):
+  - FirebaseCoreInternal (11.10.0):
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseInstallations (11.6.0):
-    - FirebaseCore (~> 11.6.0)
+  - FirebaseInstallations (11.10.0):
+    - FirebaseCore (~> 11.10.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseMessaging (11.6.0):
-    - FirebaseCore (~> 11.6.0)
+  - FirebaseMessaging (11.10.0):
+    - FirebaseCore (~> 11.10.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleDataTransport (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
@@ -42,6 +42,8 @@ PODS:
   - flutter_callkit_incoming (0.0.1):
     - CryptoSwift
     - Flutter
+  - flutter_local_notifications (0.0.1):
+    - Flutter
   - flutter_webrtc (0.12.6):
     - Flutter
     - WebRTC-SDK (= 125.6422.06)
@@ -50,28 +52,28 @@ PODS:
   - GoogleDataTransport (10.1.0):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - GoogleUtilities/AppDelegateSwizzler (8.0.2):
+  - GoogleUtilities/AppDelegateSwizzler (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (8.0.2):
+  - GoogleUtilities/Environment (8.1.0):
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Logger (8.0.2):
+  - GoogleUtilities/Logger (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (8.0.2):
+  - GoogleUtilities/Network (8.1.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (8.0.2)":
+  - "GoogleUtilities/NSData+zlib (8.1.0)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (8.0.2)
-  - GoogleUtilities/Reachability (8.0.2):
+  - GoogleUtilities/Privacy (8.1.0)
+  - GoogleUtilities/Reachability (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/UserDefaults (8.0.2):
+  - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - integration_test (0.0.1):
@@ -105,6 +107,7 @@ DEPENDENCIES:
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - Flutter (from `Flutter`)
   - flutter_callkit_incoming (from `.symlinks/plugins/flutter_callkit_incoming/ios`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_webrtc (from `.symlinks/plugins/flutter_webrtc/ios`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
@@ -142,6 +145,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_callkit_incoming:
     :path: ".symlinks/plugins/flutter_callkit_incoming/ios"
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_webrtc:
     :path: ".symlinks/plugins/flutter_webrtc/ios"
   fluttertoast:
@@ -164,19 +169,20 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   connectivity_plus: 18382e7311ba19efcaee94442b23b32507b20695
   CryptoSwift: e64e11850ede528a02a0f3e768cec8e9d92ecb90
-  Firebase: 374a441a91ead896215703a674d58cdb3e9d772b
-  firebase_core: feb37e79f775c2bd08dd35e02d83678291317e10
-  firebase_messaging: e2f0ba891b1509668c07f5099761518a5af8fe3c
-  FirebaseCore: 48b0dd707581cf9c1a1220da68223fb0a562afaa
-  FirebaseCoreInternal: d98ab91e2d80a56d7b246856a8885443b302c0c2
-  FirebaseInstallations: efc0946fc756e4d22d8113f7c761948120322e8c
-  FirebaseMessaging: e1aca1fcc23e8b9eddb0e33f375ff90944623021
+  Firebase: 1fe1c0a7d9aaea32efe01fbea5f0ebd8d70e53a2
+  firebase_core: 432718558359a8c08762151b5f49bb0f093eb6e0
+  firebase_messaging: 3b99522baf7480dfb4b7683d2b34e842d577c362
+  FirebaseCore: 8344daef5e2661eb004b177488d6f9f0f24251b7
+  FirebaseCoreInternal: ef4505d2afb1d0ebbc33162cb3795382904b5679
+  FirebaseInstallations: 9980995bdd06ec8081dfb6ab364162bdd64245c3
+  FirebaseMessaging: 2b9f56aa4ed286e1f0ce2ee1d413aabb8f9f5cb9
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_callkit_incoming: 417dd1b46541cdd5d855ad795ccbe97d1c18155e
+  flutter_local_notifications: ff50f8405aaa0ccdc7dcfb9022ca192e8ad9688f
   flutter_webrtc: 90260f83024b1b96d239a575ea4e3708e79344d1
   fluttertoast: 21eecd6935e7064cc1fcb733a4c5a428f3f24f0f
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
-  GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
+  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   just_audio: baa7252489dbcf47a4c7cc9ca663e9661c99aafa
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -391,6 +391,7 @@
 				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Telnyx Flutter WebRTC";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -526,6 +527,7 @@
 				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Telnyx Flutter WebRTC";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -555,6 +557,7 @@
 				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Telnyx Flutter WebRTC";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		135FA323EDB6D5E8001C6D54 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CFFB3DF27F678D9B424E79F /* Pods_Runner.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		1AA255B1BB3527ABEC1572DF /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09F13E249448D724CE73394E /* Pods_Runner.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
@@ -31,12 +31,15 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		00840219CB2060E6B0B5413E /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		09F13E249448D724CE73394E /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		37B49B97290170A80086DB1B /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B4E36002C349A0700444B48 /* RunnerDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RunnerDebug.entitlements; sourceTree = "<group>"; };
-		5CFFB3DF27F678D9B424E79F /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		44E34500112A995500ACD91A /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		6D2F827D7B5E13C0B70EE270 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -47,10 +50,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		98EC1B2E93C32D7ADBB72015 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		A4D57EC35B129AAA761B8C7A /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		C8ED0D02538B68578D8D1042 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
-		FA0BEF4AF939E3DE2BCCA72C /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,7 +58,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				135FA323EDB6D5E8001C6D54 /* Pods_Runner.framework in Frameworks */,
+				1AA255B1BB3527ABEC1572DF /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -68,9 +68,9 @@
 		02D7F10D7C6F93EB207FB009 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				FA0BEF4AF939E3DE2BCCA72C /* Pods-Runner.debug.xcconfig */,
-				98EC1B2E93C32D7ADBB72015 /* Pods-Runner.release.xcconfig */,
-				C8ED0D02538B68578D8D1042 /* Pods-Runner.profile.xcconfig */,
+				6D2F827D7B5E13C0B70EE270 /* Pods-Runner.debug.xcconfig */,
+				44E34500112A995500ACD91A /* Pods-Runner.release.xcconfig */,
+				00840219CB2060E6B0B5413E /* Pods-Runner.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -94,7 +94,7 @@
 				97C146EF1CF9000F007C117D /* Products */,
 				02D7F10D7C6F93EB207FB009 /* Pods */,
 				A4D57EC35B129AAA761B8C7A /* GoogleService-Info.plist */,
-				CBE71126D084C269D02A37C1 /* Frameworks */,
+				B2AD577E331C1EDE6EAE75A0 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -123,10 +123,10 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
-		CBE71126D084C269D02A37C1 /* Frameworks */ = {
+		B2AD577E331C1EDE6EAE75A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				5CFFB3DF27F678D9B424E79F /* Pods_Runner.framework */,
+				09F13E249448D724CE73394E /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -138,15 +138,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				B5AB4BE14A0D25E53081B52B /* [CP] Check Pods Manifest.lock */,
+				0832AB94B6DF1FB68FCD274B /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				A1475818425A23F1E7B3B3F6 /* [CP] Embed Pods Frameworks */,
-				5EDC773E6809F8D1E499AACB /* [CP] Copy Pods Resources */,
+				1E2B814BDE9DDBC848EAF2A3 /* [CP] Embed Pods Frameworks */,
+				AB20DBCF037BA2DCC1A7422B /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -206,72 +206,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
-			);
-			name = "Thin Binary";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
-		};
-		5EDC773E6809F8D1E499AACB /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9740EEB61CF901F6004384FC /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		A1475818425A23F1E7B3B3F6 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B5AB4BE14A0D25E53081B52B /* [CP] Check Pods Manifest.lock */ = {
+		0832AB94B6DF1FB68FCD274B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -291,6 +226,71 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		1E2B814BDE9DDBC848EAF2A3 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
+			);
+			name = "Thin Binary";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		9740EEB61CF901F6004384FC /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		AB20DBCF037BA2DCC1A7422B /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -387,7 +387,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -522,7 +522,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/RunnerDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -551,7 +551,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -9,7 +9,7 @@ import WebRTC
 @main
 @objc class AppDelegate: FlutterAppDelegate, PKPushRegistryDelegate, CallkitIncomingAppDelegate {
     func onAccept(_ call: flutter_callkit_incoming.Call, _ action: CXAnswerCallAction) {
-        print("onRunner ::  Accept")
+        print("[iOS_PUSH_DEBUG] AppDelegate - onAccept called by CallKit for call ID: \\(call.uuid)")
         action.fulfill()
         
     }
@@ -99,8 +99,7 @@ import WebRTC
         
         // Handle incoming pushes
         func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {
-            print("didReceiveIncomingPushWith")
-            print("Payload \(payload.dictionaryPayload)")
+            print("[iOS_PUSH_DEBUG] AppDelegate - didReceiveIncomingPushWith payload: \\(payload.dictionaryPayload)")
             guard type == .voIP else { return }
             
             if let metadata = payload.dictionaryPayload["metadata"] as? [String: Any] {
@@ -128,9 +127,11 @@ import WebRTC
                 //data.iconName = ...
                 data.uuid = uuid!.uuidString
                 data.nameCaller = caller
+                print("[iOS_PUSH_DEBUG] AppDelegate - Before SwiftFlutterCallkitIncomingPlugin.sharedInstance?.showCallkitIncoming. Data: \\(data)")
                 SwiftFlutterCallkitIncomingPlugin.sharedInstance?.showCallkitIncoming(data, fromPushKit: true)
 
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                   print("[iOS_PUSH_DEBUG] AppDelegate - Calling completion() for didReceiveIncomingPushWith")
                    completion()
                 }
             }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,7 +23,6 @@ import 'package:telnyx_flutter_webrtc/firebase_options.dart';
 
 final logger = Logger();
 final txClientViewModel = TelnyxClientViewModel();
-const CALL_MISSED_TIMEOUT = 30;
 
 class AppInitializer {
   static final AppInitializer _instance = AppInitializer._internal();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,8 +23,6 @@ import 'package:telnyx_flutter_webrtc/firebase_options.dart';
 
 final logger = Logger();
 final txClientViewModel = TelnyxClientViewModel();
-const MOCK_USER = '<MOCK_USER>';
-const MOCK_PASSWORD = '<MOCK_PASSWORD>';
 const CALL_MISSED_TIMEOUT = 30;
 
 class AppInitializer {
@@ -131,7 +129,7 @@ Future<void> main() async {
 }
 
 Future<void> handlePush(Map<dynamic, dynamic> data) async {
-  logger.i('[iOS_PUSH_DEBUG] handlePush: Started. Raw data: $data');
+  logger.i('[handlePush] Started. Raw data: $data');
   txClientViewModel.setPushCallStatus(true);
   PushMetaData? pushMetaData;
   if (defaultTargetPlatform == TargetPlatform.android) {
@@ -139,10 +137,10 @@ Future<void> handlePush(Map<dynamic, dynamic> data) async {
   } else if (Platform.isIOS) {
     pushMetaData = PushMetaData.fromJson(data);
   }
-  logger.i('[iOS_PUSH_DEBUG] handlePush: Before txClientViewModel.getConfig()');
+  logger.i('[handlePush] Before txClientViewModel.getConfig()');
   final config = await txClientViewModel.getConfig();
   logger.i(
-      '[iOS_PUSH_DEBUG] handlePush: Created PushMetaData: ${pushMetaData?.toJson()}');
+      '[handlePush] Created PushMetaData: ${pushMetaData?.toJson()}');
   txClientViewModel
     ..handlePushNotification(
       pushMetaData!,
@@ -150,7 +148,7 @@ Future<void> handlePush(Map<dynamic, dynamic> data) async {
       config is TokenConfig ? config : null,
     )
     ..observeResponses();
-  logger.i('actionCallIncoming :: Received Incoming Call! Handle Push');
+  logger.i('[handlePush] Processing complete. Call state should update soon.');
 }
 
 class MyApp extends StatefulWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,6 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
-import 'package:telnyx_flutter_webrtc/service/notification_service.dart';
 import 'package:telnyx_flutter_webrtc/utils/background_detector.dart';
 import 'package:telnyx_flutter_webrtc/view/screen/home_screen.dart';
 import 'package:telnyx_flutter_webrtc/view/telnyx_client_view_model.dart';
@@ -17,7 +16,8 @@ import 'package:telnyx_webrtc/model/push_notification.dart';
 import 'package:telnyx_flutter_webrtc/utils/theme.dart';
 import 'package:telnyx_webrtc/config/telnyx_config.dart';
 import 'package:telnyx_flutter_webrtc/service/platform_push_service.dart';
-import 'package:telnyx_flutter_webrtc/service/android_push_notification_handler.dart' show androidBackgroundMessageHandler;
+import 'package:telnyx_flutter_webrtc/service/android_push_notification_handler.dart'
+    show androidBackgroundMessageHandler;
 
 import 'package:telnyx_flutter_webrtc/firebase_options.dart';
 
@@ -50,22 +50,6 @@ class AppInitializer {
           options: kIsWeb ? DefaultFirebaseOptions.currentPlatform : null,
         );
         logger.i('[AppInitializer] Firebase Core Initialized successfully.');
-
-        // Testing:
-        final FirebaseMessaging messaging = FirebaseMessaging.instance;
-
-        final NotificationSettings settings = await messaging.requestPermission(
-          alert: true,
-          announcement: true,
-          badge: true,
-          carPlay: true,
-          criticalAlert: true,
-          provisional: true,
-          sound: true,
-        );
-
-        logger.i('User granted permission: ${settings.authorizationStatus}');
-
       } catch (e) {
         logger.e('[AppInitializer] Firebase Core Initialization failed: $e');
       }
@@ -79,13 +63,13 @@ class AppInitializer {
   }
 }
 
-
 // Android Only - Push Notifications
 // This global function remains as an entry point for Firebase background messages on Android.
 // It will now delegate to the annotated top-level function in android_push_notification_handler.dart.
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  logger.i('[Background Notification]. Received background message: ${message.data}');
+  logger.i(
+      '[Background Notification]. Received background message: ${message.data}');
   await androidBackgroundMessageHandler(message);
 }
 
@@ -97,7 +81,8 @@ Future<void> main() async {
     // Catch Flutter framework errors
     FlutterError.onError = (FlutterErrorDetails details) {
       FlutterError.presentError(details);
-      logger.e('Caught Flutter error: ${details.exception}', stackTrace: details.stack);
+      logger.e('Caught Flutter error: ${details.exception}',
+          stackTrace: details.stack);
       PlatformPushService.handler.clearPushData();
     };
 
@@ -105,7 +90,7 @@ Future<void> main() async {
     PlatformDispatcher.instance.onError = (error, stack) {
       logger.e('Caught Platform error: $error', stackTrace: stack);
       PlatformPushService.handler.clearPushData();
-      return true; 
+      return true;
     };
 
     if (!AppInitializer()._isInitialized) {
@@ -116,26 +101,27 @@ Future<void> main() async {
     final config = await txClientViewModel.getConfig();
     runApp(
       BackgroundDetector(
-         skipWeb: true,
-         onLifecycleEvent: (AppLifecycleState state) {
-           if (state == AppLifecycleState.resumed) {
-             logger.i('[BackgroundDetector] We are in the foreground, CONNECTING');
-             // Check if we are from push, if we are do nothing, reconnection will happen there in handlePush. Otherwise connect
-             if (!txClientViewModel.callFromPush) {
-               if (config != null && config is CredentialConfig) {
-                 txClientViewModel.login(config);
-               } else if (config != null && config is TokenConfig) {
-                 txClientViewModel.loginWithToken(config);
-               }
-             }
-           } else if (state == AppLifecycleState.paused) {
-             logger.i(
-               '[BackgroundDetector] We are in the background, DISCONNECTING',
-             );
-             txClientViewModel.disconnect();
-           }
-         },
-         child: const MyApp(),
+        skipWeb: true,
+        onLifecycleEvent: (AppLifecycleState state) {
+          if (state == AppLifecycleState.resumed) {
+            logger
+                .i('[BackgroundDetector] We are in the foreground, CONNECTING');
+            // Check if we are from push, if we are do nothing, reconnection will happen there in handlePush. Otherwise connect
+            if (!txClientViewModel.callFromPush) {
+              if (config != null && config is CredentialConfig) {
+                txClientViewModel.login(config);
+              } else if (config != null && config is TokenConfig) {
+                txClientViewModel.loginWithToken(config);
+              }
+            }
+          } else if (state == AppLifecycleState.paused) {
+            logger.i(
+              '[BackgroundDetector] We are in the background, DISCONNECTING',
+            );
+            txClientViewModel.disconnect();
+          }
+        },
+        child: const MyApp(),
       ),
     );
   }, (error, stack) {
@@ -155,7 +141,8 @@ Future<void> handlePush(Map<dynamic, dynamic> data) async {
   }
   logger.i('[iOS_PUSH_DEBUG] handlePush: Before txClientViewModel.getConfig()');
   final config = await txClientViewModel.getConfig();
-  logger.i('[iOS_PUSH_DEBUG] handlePush: Created PushMetaData: ${pushMetaData?.toJson()}');
+  logger.i(
+      '[iOS_PUSH_DEBUG] handlePush: Created PushMetaData: ${pushMetaData?.toJson()}');
   txClientViewModel
     ..handlePushNotification(
       pushMetaData!,
@@ -182,15 +169,18 @@ class _MyAppState extends State<MyApp> {
     // Platform-specific logic for handling initial push data when app starts.
     // For Android, this checks if the app was launched from a terminated state by a notification.
     // For iOS, this is less critical as CallKit events usually drive the flow after launch.
-      PlatformPushService.handler.getInitialPushData().then((data) {
-        if (data != null) {
-          PlatformPushService.handler.processIncomingCallAction(data, isAnswer: false /* Or true if applicable */);
-        } else {
-          logger.i('[_MyAppState] Android: No initial push data found.');
-        }
-      }).catchError((e) {
-        logger.e('[_MyAppState] Android: Error fetching initial push data: $e');
-      });
+    PlatformPushService.handler.getInitialPushData().then((data) {
+      if (data != null) {
+        final Map<dynamic, dynamic> mutablePayload = Map.from(data);
+        final answer = mutablePayload['isAnswer'] = true;
+        PlatformPushService.handler.processIncomingCallAction(data,
+            isAnswer: answer, isDecline: !answer);
+      } else {
+        logger.i('[_MyAppState] Android: No initial push data found.');
+      }
+    }).catchError((e) {
+      logger.e('[_MyAppState] Android: Error fetching initial push data: $e');
+    });
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
-import 'dart:async'; // Required for runZonedGuarded
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:ui'; // Required for PlatformDispatcher
+import 'dart:ui';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,21 +7,17 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_callkit_incoming/entities/call_event.dart';
-import 'package:flutter_callkit_incoming/flutter_callkit_incoming.dart';
 import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
 import 'package:telnyx_flutter_webrtc/utils/background_detector.dart';
 import 'package:telnyx_flutter_webrtc/view/screen/home_screen.dart';
 import 'package:telnyx_flutter_webrtc/view/telnyx_client_view_model.dart';
-import 'package:telnyx_flutter_webrtc/service/notification_service.dart';
 import 'package:logger/logger.dart';
 import 'package:provider/provider.dart';
 import 'package:telnyx_webrtc/model/push_notification.dart';
-import 'package:telnyx_webrtc/telnyx_client.dart';
-import 'package:telnyx_webrtc/model/telnyx_message.dart';
-import 'package:telnyx_webrtc/model/socket_method.dart';
 import 'package:telnyx_flutter_webrtc/utils/theme.dart';
 import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_flutter_webrtc/service/platform_push_service.dart';
+import 'package:telnyx_flutter_webrtc/service/android_push_notification_handler.dart' show androidBackgroundMessageHandler;
 import 'package:telnyx_webrtc/model/telnyx_socket_error.dart';
 
 import 'package:telnyx_flutter_webrtc/firebase_options.dart';
@@ -47,295 +43,41 @@ class AppInitializer {
   Future<void> initialize() async {
     if (!_isInitialized) {
       _isInitialized = true;
-      if (!kIsWeb) {
-        logger.i('FlutterCallkitIncoming :: Initializing listening for events');
-        FlutterCallkitIncoming.onEvent.listen((CallEvent? event) async {
-          logger.i('onEvent :: ${event?.event} :: ${event?.body}');
-          switch (event!.event) {
-            case Event.actionCallIncoming:
-              // retrieve the push metadata from extras
-              if (event.body['extra']['metadata'] == null) {
-                logger.i('actionCallIncoming :: Push Data is null!');
-                return;
-              }
-              logger.i(
-                "ZZZ received push Call for iOS (actionCallIncoming): ${event.body['extra']['metadata']}",
-              );
-              // No connection or handlePush call here.
-              // CallKit's native UI is already shown by this point.
-              // We wait for user action (Accept/Decline).
-              break;
-            case Event.actionCallStart:
-              logger.i('actionCallStart :: call start');
-              break;
-            case Event.actionCallAccept:
-              logger.i('[iOS_PUSH_DEBUG] Event.actionCallAccept received. Metadata: ${event.body?['extra']?['metadata']}');
-              if (txClientViewModel.incomingInvitation != null) {
-                logger.i('[iOS_PUSH_DEBUG] Event.actionCallAccept: ViewModel has existing incomingInvitation.');
-                logger.i('Accepted Call Directly because of incomingInvitation');
-                await txClientViewModel.accept();
-              } else {
-                final metadata = event.body['extra']['metadata'];
-                if (metadata == null) {
-                   // This case should ideally not happen if CallKit sends metadata on accept.
-                  logger.i('Accepted Call Directly - Metadata missing in actionCallAccept event.');
-                  await txClientViewModel.accept(); // Accept without push context
-                } else {
-                  logger.i(
-                    '[iOS_PUSH_DEBUG] Event.actionCallAccept: Metadata present. Preparing to call global handlePush. Metadata: $metadata',
-                  );
-                  var decodedMetadata = metadata;
-                  if (metadata is String) {
-                    try {
-                      decodedMetadata = jsonDecode(metadata);
-                    } catch (e) {
-                      logger.e('Error decoding metadata JSON in actionCallAccept: $e. Attempting direct accept.');
-                      await txClientViewModel.accept(); // Fallback
-                      return;
-                    }
-                  }
-                  // Pass the acceptance intent and data to the global handlePush
-                  final Map<dynamic, dynamic> data = Map<dynamic, dynamic>.from(decodedMetadata as Map);
-                  data['isAnswer'] = true;
-                  logger.i('[iOS_PUSH_DEBUG] Event.actionCallAccept: Calling global handlePush with augmented data: $data');
-                  await handlePush(data);
-                }
-              }
-              break;
-            case Event.actionCallDecline:
-              final metadata = event.body['extra']['metadata'];
-              if (txClientViewModel.incomingInvitation != null || txClientViewModel.currentCall != null) {
-                // If the main client already has an active call or invite, let it handle the decline.
-                // This could happen if the app was already open and connected when CallKit decline comes.
-                logger.i('Main client has existing call/invite. Using txClientViewModel.endCall() for decline.');
-                txClientViewModel.endCall();
-              } else if (metadata == null) {
-                logger.i('Decline Call Directly (no metadata from CallKit event and no active call/invite in ViewModel).');
-                // Potentially a no-op if there's nothing to decline, or CallKit might handle UI.
-                // Consider if ending all CallKit calls is appropriate if no specific ID is known:
-                // FlutterCallkitIncoming.endAllCalls(); 
-              } else {
-                // This is a decline from a CallKit push, and the main ViewModel doesn't have an active session for it.
-                // Use a temporary client to handle this decline.
-                logger.i(
-                  'Received CallKit decline event with metadata: $metadata. Using temporary client for decline.',
-                );
-                var decodedMetadata = metadata;
-                if (metadata is String) {
-                  try {
-                    decodedMetadata = jsonDecode(metadata);
-                  } catch (e) {
-                    logger.e('Error decoding metadata JSON in actionCallDecline: $e. Cannot proceed with temporary client decline.');
-                    return;
-                  }
-                }
+      logger.i('[AppInitializer] Initializing...');
 
-                final Map<dynamic, dynamic> eventData = Map<dynamic, dynamic>.from(decodedMetadata as Map);
-                eventData['isDecline'] = true; // Ensure decline intent
-
-                final PushMetaData pushMetaData;
-                try {
-                  pushMetaData = PushMetaData.fromJson(eventData);
-                } catch (e) {
-                    logger.e('Error creating PushMetaData from eventData for temporary client decline: $e');
-                    return;
-                }
-
-                final tempDeclineClient = TelnyxClient();
-
-                tempDeclineClient..onSocketMessageReceived = (TelnyxMessage message) {
-                  switch (message.socketMethod) {
-                    case SocketMethod.bye:
-                      logger.i('Temporary client (iOS decline) received BYE, disconnecting.');
-                      tempDeclineClient.disconnect();
-                      break;
-                    default:
-                      logger.i('Temporary client (iOS decline) received message: ${message.socketMethod}');
-                  }
-                }
-
-                ..onSocketErrorReceived = (TelnyxSocketError error) {
-                    logger.e('Temporary client (iOS decline) received error: ${error.errorCode} :: ${error.errorMessage}');
-                    tempDeclineClient.disconnect(); // Attempt to cleanup on error too
-                };
-
-                // getConfig() might rely on txClientViewModel, or it might be static/retrievable independently.
-                // For this example, assuming it can be fetched.
-                // If getConfig is problematic here, the credentials/token would need to be passed differently or stored accessibly.
-                final config = await txClientViewModel.getConfig();
-
-                logger.i('Temporary client (iOS decline) attempting to handlePushNotification. Config :: $config');
-                tempDeclineClient.handlePushNotification(
-                  pushMetaData,
-                  config is CredentialConfig ? config : null,
-                  config is TokenConfig ? config : null,
-                );
-              }
-              break;
-            case Event.actionCallEnded:
-              txClientViewModel.endCall();
-              logger.i('actionCallEnded :: call ended');
-              break;
-            case Event.actionCallTimeout:
-              txClientViewModel.endCall();
-              logger.i('Decline Call');
-              break;
-            case Event.actionCallCallback:
-              logger.i('actionCallCallback :: call callback');
-              break;
-            case Event.actionCallToggleHold:
-              logger.i('actionCallToggleHold :: call hold');
-              break;
-            case Event.actionCallToggleMute:
-              logger.i('actionCallToggleMute :: call mute');
-              break;
-            case Event.actionCallToggleDmtf:
-              logger.i('actionCallToggleDmtf :: call dmtf');
-              break;
-            case Event.actionCallToggleGroup:
-              logger.i('actionCallToggleGroup :: call group');
-              break;
-            case Event.actionCallToggleAudioSession:
-              logger.i('actionCallToggleAudioSession :: call audio session');
-              break;
-            case Event.actionDidUpdateDevicePushTokenVoip:
-              logger.i('actionDidUpdateDevicePushTokenVoip :: call push token');
-              break;
-            case Event.actionCallCustom:
-              logger.i('actionCallCustom :: call custom');
-              break;
-          }
-        });
-      }
-
-      /// Firebase
-      await Firebase.initializeApp(
-        options: kIsWeb ? DefaultFirebaseOptions.currentPlatform : null,
-      );
-      if (!kIsWeb && Platform.isAndroid) {
-        FirebaseMessaging.onBackgroundMessage(
-          _firebaseMessagingBackgroundHandler,
+      // Initialize Firebase first, ensuring it's ready before platform handlers use it.
+      logger.i('[AppInitializer] Initializing Firebase Core...');
+      try {
+        await Firebase.initializeApp(
+          options: kIsWeb ? DefaultFirebaseOptions.currentPlatform : null,
         );
-      } else {
-        logger
-            .i('Web or iOS - Skipping Firebase Messaging onBackgroundMessage');
+        logger.i('[AppInitializer] Firebase Core Initialized successfully.');
+      } catch (e) {
+        logger.e('[AppInitializer] Firebase Core Initialization failed: $e');
+        // Decide how to handle failure - maybe rethrow or prevent handler init?
       }
+      
+      // Delegate to platform-specific push handler for initialization
+      // This will set up FCM listeners, CallKit listeners, etc.
+      logger.i('[AppInitializer] Initializing Platform Push Service Handler...');
+      await PlatformPushService.handler.initialize();
+      logger.i('[AppInitializer] Platform Push Service Handler Initialized.');
 
-      if (defaultTargetPlatform == TargetPlatform.android) {
-        ///await askForNotificationPermission();
-        await FirebaseMessaging.instance
-            .setForegroundNotificationPresentationOptions(
-          alert: true,
-          badge: true,
-          sound: true,
-        );
-      }
+      logger.i('[AppInitializer] Initialization complete.');
     } else {
-      logger.i('AppInitializer :: Already Initialized');
+      logger.i('[AppInitializer] Already initialized.');
     }
   }
 }
 
-var fromBackground = false;
 
 // Android Only - Push Notifications
+// This global function remains as an entry point for Firebase background messages on Android.
+// It will now delegate to the annotated top-level function in android_push_notification_handler.dart.
 @pragma('vm:entry-point')
-Future _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  await Firebase.initializeApp(
-    options: kIsWeb ? DefaultFirebaseOptions.currentPlatform : null,
-  );
-  logger.i('Handling a background message ${message.toMap().toString()}');
-  await NotificationService.showNotification(message);
-  FlutterCallkitIncoming.onEvent.listen((CallEvent? event) async {
-    switch (event!.event) {
-      case Event.actionCallIncoming:
-        logger
-            .i('actionCallIncoming :: Received Incoming Call! from background');
-        break;
-      case Event.actionCallStart:
-        break;
-      case Event.actionCallAccept:
-        logger.i(
-          'actionCallAccept :: _firebaseMessagingBackgroundHandler call accepted',
-        );
-        TelnyxClient.setPushMetaData(
-          message.data,
-          isAnswer: true,
-          isDecline: false,
-        );
-        break;
-      case Event.actionCallDecline:
-        /*
-        * When the user declines the call from the push notification, the app will no longer be visible, and we have to
-        * handle the endCall user here.
-        *
-        * */
-        logger.i('actionCallDecline :: call declined');
-        String? token;
-        PushMetaData? pushMetaData;
-        final telnyxClient = TelnyxClient();
-
-        telnyxClient.onSocketMessageReceived = (TelnyxMessage message) {
-          switch (message.socketMethod) {
-            case SocketMethod.bye:
-              {
-                // make sure to disconnect the telnyxclient on Bye for Decline
-                // Only disconnect the socket when the call was ended from push notifications
-                logger.i('TelnyxClient :: onSocketMessageReceived :: BYE');
-                telnyxClient.disconnect();
-                break;
-              }
-            default:
-              logger.i('TelnyxClient :: onSocketMessageReceived   $message');
-          }
-          logger.i('TelnyxClient :: onSocketMessageReceived : $message');
-        };
-
-        pushMetaData =
-            PushMetaData.fromJson(jsonDecode(message.data['metadata']!));
-        // Set the pushMetaData to decline
-        pushMetaData.isDecline = true;
-        token = (await FirebaseMessaging.instance.getToken())!;
-        final config = await txClientViewModel.getConfig();
-        telnyxClient.handlePushNotification(
-          pushMetaData,
-          config is CredentialConfig ? config : null,
-          config is TokenConfig ? config : null,
-        );
-        break;
-      case Event.actionDidUpdateDevicePushTokenVoip:
-        // TODO: Handle this case.
-        break;
-      case Event.actionCallEnded:
-        // TODO: Handle this case.
-        break;
-      case Event.actionCallTimeout:
-        // TODO: Handle this case.
-        break;
-      case Event.actionCallCallback:
-        // TODO: Handle this case.
-        break;
-      case Event.actionCallToggleHold:
-        // TODO: Handle this case.
-        break;
-      case Event.actionCallToggleMute:
-        // TODO: Handle this case.
-        break;
-      case Event.actionCallToggleDmtf:
-        // TODO: Handle this case.
-        break;
-      case Event.actionCallToggleGroup:
-        // TODO: Handle this case.
-        break;
-      case Event.actionCallToggleAudioSession:
-        // TODO: Handle this case.
-        break;
-      case Event.actionCallCustom:
-        // TODO: Handle this case.
-        break;
-    }
-  });
-  txClientViewModel.setPushCallStatus(true);
+Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  // Delegate to the new top-level annotated function
+  await androidBackgroundMessageHandler(message);
 }
 
 @pragma('vm:entry-point')
@@ -347,13 +89,13 @@ Future<void> main() async {
     FlutterError.onError = (FlutterErrorDetails details) {
       FlutterError.presentError(details);
       logger.e('Caught Flutter error: ${details.exception}', stackTrace: details.stack);
-      TelnyxClient.clearPushMetaData();
+      PlatformPushService.handler.clearPushData();
     };
 
     // Catch other platform errors (e.g., Dart errors outside Flutter)
     PlatformDispatcher.instance.onError = (error, stack) {
       logger.e('Caught Platform error: $error', stackTrace: stack);
-      TelnyxClient.clearPushMetaData();
+      PlatformPushService.handler.clearPushData();
       return true; 
     };
 
@@ -380,7 +122,6 @@ Future<void> main() async {
              logger.i(
                'We are in the background setting fromBackground == true, DISCONNECTING',
              );
-             fromBackground = true;
              txClientViewModel.disconnect();
            }
          },
@@ -389,7 +130,7 @@ Future<void> main() async {
     );
   }, (error, stack) {
     logger.e('Caught Zoned error: $error', stackTrace: stack);
-    TelnyxClient.clearPushMetaData();
+    PlatformPushService.handler.clearPushData();
   });
 }
 
@@ -404,7 +145,6 @@ Future<void> handlePush(Map<dynamic, dynamic> data) async {
   }
   logger.i('[iOS_PUSH_DEBUG] handlePush: Before txClientViewModel.getConfig()');
   final config = await txClientViewModel.getConfig();
-  logger.i('[iOS_PUSH_DEBUG] handlePush: After txClientViewModel.getConfig(). Config: $config');
   logger.i('[iOS_PUSH_DEBUG] handlePush: Created PushMetaData: ${pushMetaData?.toJson()}');
   txClientViewModel
     ..handlePushNotification(
@@ -427,55 +167,43 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
+    logger.i('[_MyAppState] initState called.');
 
-    if (defaultTargetPlatform == TargetPlatform.android) {
-      // Android Only - Push Notifications
-      FirebaseMessaging.onMessage.listen((RemoteMessage message) {
-        logger.i('OnMessage :: Notification Message: ${message.data}');
-        final DateTime nowTime = DateTime.now();
-        final Duration difference = nowTime.difference(message.sentTime!);
-
-        logger
-            .i('OnMessage :: Notification difference: ${difference.inSeconds}');
-        if (difference.inSeconds > CALL_MISSED_TIMEOUT) {
-          logger.i('OnMessage :: Notification Message: Missed Call');
-          // You can simulate a missed call here
-          NotificationService.showMissedCallNotification(message);
-          return;
+    // Platform-specific logic for handling initial push data when app starts.
+    // For Android, this checks if the app was launched from a terminated state by a notification.
+    // For iOS, this is less critical as CallKit events usually drive the flow after launch.
+    if (!kIsWeb && Platform.isAndroid) {
+      PlatformPushService.handler.getInitialPushData().then((data) {
+        if (data != null) {
+          logger.i('[_MyAppState] Android: Found initial push data: $data. Processing...');
+          // Determine if this initial push should be treated as an "answer" implicitly.
+          // This depends on how Android notifications are structured and if they imply an accept.
+          // For now, let's assume it should be processed as an incoming call that might need answering.
+          // The `isAnswer` flag would typically come from a user action on the notification if it has action buttons.
+          // If just tapping the notification body, `isAnswer` is likely false initially.
+          PlatformPushService.handler.processIncomingCallAction(data, isAnswer: false /* Or true if applicable */);
+        } else {
+          logger.i('[_MyAppState] Android: No initial push data found.');
         }
-
-        logger.i('OnMessage Time :: Notification Message: ${message.sentTime}');
-        TelnyxClient.setPushMetaData(message.data);
-        NotificationService.showNotification(message);
-        txClientViewModel.setPushCallStatus(true);
-      });
-      FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
-        logger.i('onMessageOpenedApp :: Notification Message: ${message.data}');
+      }).catchError((e) {
+        logger.e('[_MyAppState] Android: Error fetching initial push data: $e');
       });
     }
 
-    try {
-      if (defaultTargetPlatform == TargetPlatform.android) {
-        // Handle Push when app comes from background :: Only for Android
-        TelnyxClient.getPushData().then((data) {
-          // whenever you open the app from the terminate state by clicking on Notification message,
-          if (data != null) {
-            handlePush(data);
-            logger.i(
-              'getPushData : getInitialMessage :: Notification Message: $data',
-            );
-          } else {
-            logger.d('getPushData : No data');
-          }
-        });
-      } else if (!kIsWeb && Platform.isIOS && !txClientViewModel.callFromPush) {
-        logger.i('iOS :: connect');
-      } else {
-        logger.i('Web :: connect');
-      }
-    } catch (e) {
-      logger.e('Error: $e');
-    }
+    // Foreground FCM message listening for Android is now handled by AndroidPushNotificationHandler.initialize().
+    // iOS CallKit event listening is handled by IOSPushNotificationHandler.initialize().
+
+    // Original connection logic if not from push (now part of BackgroundDetector or specific user actions)
+    // This part needs careful review. The original code had: 
+    // } else if (!kIsWeb && Platform.isIOS && !txClientViewModel.callFromPush) {
+    //   logger.i('iOS :: connect');
+    // } else {
+    //   logger.i('Web :: connect');
+    // }
+    // This suggests a default connection attempt. This might now be better handled
+    // by the BackgroundDetector's onAppResumed, or a manual login button if no auto-login is desired.
+    // For now, removing this explicit connect from here as push/resume flows should cover it.
+    logger.i('[_MyAppState] initState completed.');
   }
 
   @override

--- a/lib/service/android_push_notification_handler.dart
+++ b/lib/service/android_push_notification_handler.dart
@@ -37,6 +37,16 @@ Future<void> androidBackgroundMessageHandler(RemoteMessage message) async {
     return;
   }
 
+  // Check if the message is a missed call notification
+  if (message.data['message'] != null &&
+      message.data['message'].toString().toLowerCase() == 'missed call!') {
+    _backgroundLogger.i(
+      '[AndroidBackgroundHandler] Missed call notification, not showing CallKit.',
+    );
+    await NotificationService.showMissedCallNotification(message);
+    return;
+  }
+
   // Show the notification first
   await NotificationService.showNotification(message);
 

--- a/lib/service/android_push_notification_handler.dart
+++ b/lib/service/android_push_notification_handler.dart
@@ -1,0 +1,257 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
+import 'package:logger/logger.dart';
+import 'package:telnyx_flutter_webrtc/main.dart'; // For logger, txClientViewModel, handlePush, CALL_MISSED_TIMEOUT
+import 'package:telnyx_flutter_webrtc/service/notification_service.dart';
+import 'package:telnyx_flutter_webrtc/service/push_notification_handler.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/model/push_notification.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:flutter_callkit_incoming/flutter_callkit_incoming.dart';
+import 'package:flutter_callkit_incoming/entities/call_event.dart';
+import 'package:telnyx_webrtc/model/socket_method.dart';
+import 'package:telnyx_webrtc/model/telnyx_message.dart';
+import 'package:telnyx_webrtc/model/telnyx_socket_error.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+import 'package:telnyx_flutter_webrtc/utils/custom_sdk_logger.dart';
+
+
+// Define logger at the top level for access by the background handler function
+final _backgroundLogger = Logger(); 
+
+// --- Static utility methods to fetch config --- 
+// (Keep _getBackgroundCredentialConfig, _getBackgroundTokenConfig, _getBackgroundTelnyxConfig as static helpers)
+// Static utility methods to fetch config from SharedPreferences for background isolate
+Future<CredentialConfig?> _getBackgroundCredentialConfig() async {
+  final prefs = await SharedPreferences.getInstance();
+  final sipUser = prefs.getString('sipUser');
+  final sipPassword = prefs.getString('sipPassword');
+  final sipName = prefs.getString('sipName');
+  final sipNumber = prefs.getString('sipNumber');
+  final notificationToken = prefs.getString('notificationToken');
+
+  if (sipUser != null && sipPassword != null && sipName != null && sipNumber != null) {
+    return CredentialConfig(
+      sipCallerIDName: sipName,
+      sipCallerIDNumber: sipNumber,
+      sipUser: sipUser,
+      sipPassword: sipPassword,
+      notificationToken: notificationToken, 
+      logLevel: LogLevel.all,
+      customLogger: CustomSDKLogger(),
+      debug: false, 
+    );
+  }
+  return null;
+}
+
+Future<TokenConfig?> _getBackgroundTokenConfig() async {
+  final prefs = await SharedPreferences.getInstance();
+  final token = prefs.getString('token');
+  final sipName = prefs.getString('sipName');
+  final sipNumber = prefs.getString('sipNumber');
+  final notificationToken = prefs.getString('notificationToken');
+
+  if (token != null && sipName != null && sipNumber != null) {
+    return TokenConfig(
+      sipCallerIDName: sipName,
+      sipCallerIDNumber: sipNumber,
+      sipToken: token,
+      notificationToken: notificationToken,
+      logLevel: LogLevel.all,
+      customLogger: CustomSDKLogger(),
+      debug: false, 
+    );
+  }
+  return null;
+}
+
+Future<Object?> _getBackgroundTelnyxConfig() async { 
+  Object? config = await _getBackgroundCredentialConfig();
+  config ??= await _getBackgroundTokenConfig();
+  return config;
+}
+// --- End of static config helpers ---
+
+
+// --- Top-level Background Message Handler ---
+// This function MUST be annotated with @pragma('vm:entry-point')
+@pragma('vm:entry-point')
+Future<void> androidBackgroundMessageHandler(RemoteMessage message) async {
+  // Ensure Firebase is initialized for this isolate
+  await Firebase.initializeApp();
+  _backgroundLogger.i('[AndroidBackgroundHandler] Received background message: ${message.data}');
+  
+  // Show the notification first
+  await NotificationService.showNotification(message);
+
+  // Setup CallKit listener for background actions
+  FlutterCallkitIncoming.onEvent.listen((CallEvent? event) async {
+    _backgroundLogger.i('[AndroidBackgroundHandler] CallKit event: ${event?.event}');
+    switch (event!.event) {
+      case Event.actionCallDecline:
+        _backgroundLogger.i('[AndroidBackgroundHandler] Call declined via CallKit from background.');
+        if (message.data['metadata'] != null) {
+          try {
+            final Map<String, dynamic> metadataMap = jsonDecode(message.data['metadata']);
+            final PushMetaData pushMetaData = PushMetaData.fromJson(metadataMap)..isDecline = true;
+            final tempDeclineClient = TelnyxClient();
+            tempDeclineClient
+              ..onSocketMessageReceived = (TelnyxMessage msg) {
+                if (msg.socketMethod == SocketMethod.bye) {
+                  _backgroundLogger.i('[AndroidBackgroundHandler] Temp client received BYE, disconnecting.');
+                  tempDeclineClient.disconnect();
+                }
+              }
+              ..onSocketErrorReceived = (TelnyxSocketError error) {
+                _backgroundLogger.e('[AndroidBackgroundHandler] Temp client error: ${error.errorMessage}');
+                tempDeclineClient.disconnect();
+              };
+              
+            final config = await _getBackgroundTelnyxConfig();
+            if (config != null) {
+              _backgroundLogger.i('[AndroidBackgroundHandler] Found config for decline.');
+              tempDeclineClient.handlePushNotification(
+                pushMetaData,
+                config is CredentialConfig ? config : null,
+                config is TokenConfig ? config : null,
+              );
+            } else {
+              _backgroundLogger.e('[AndroidBackgroundHandler] Could not retrieve config from SharedPreferences. Cannot decline call.');
+            }
+          } catch (e) {
+             _backgroundLogger.e('[AndroidBackgroundHandler] Error processing decline: $e');
+          }
+        } else {
+           _backgroundLogger.i('[AndroidBackgroundHandler] No metadata for decline action.');
+        }
+        break;
+      case Event.actionCallAccept:
+        _backgroundLogger.i('[AndroidBackgroundHandler] Call accepted via CallKit from background.');
+        // Store the accept intent for when the main app processes the initial data
+        TelnyxClient.setPushMetaData(message.data, isAnswer: true, isDecline: false);
+        break;
+      default:
+        break;
+    }
+  });
+}
+// --- End of Top-level Background Message Handler ---
+
+
+/// Android specific implementation of [PushNotificationHandler].
+/// Note: The background handling logic is now in the top-level [androidBackgroundMessageHandler].
+class AndroidPushNotificationHandler implements PushNotificationHandler {
+  // Use a logger instance for the class methods (foreground)
+  final _logger = Logger();
+
+  @override
+  Future<void> initialize() async {
+    _logger.i('[PushNotificationHandler-Android] Initialize');
+    // Setup foreground message listener
+    FirebaseMessaging.onMessage.listen((RemoteMessage message) {
+      _logger.i('[PushNotificationHandler-Android] onMessage: Received foreground message: ${message.data}');
+      if (message.notification?.title != null && message.notification!.title!.contains('Missed')) {
+        _logger.i('[PushNotificationHandler-Android] onMessage: Missed call notification');
+        NotificationService.showMissedCallNotification(message);
+        return;
+      }
+      NotificationService.showNotification(message);
+      TelnyxClient.setPushMetaData(message.data); // Sets it for later retrieval if needed
+    });
+
+    // Setup message opened app listener
+    FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
+      _logger.i('[PushNotificationHandler-Android] onMessageOpenedApp: Message data: ${message.data}');
+    });
+
+    // Set background message handler in main isolate initialization
+    // This points to the new top-level annotated function
+    FirebaseMessaging.onBackgroundMessage(androidBackgroundMessageHandler);
+
+    // Set foreground presentation options
+    await FirebaseMessaging.instance.setForegroundNotificationPresentationOptions(
+      alert: true,
+      badge: true,
+      sound: true,
+    );
+  }
+
+  @override
+  Future<void> processIncomingCallAction(Map<dynamic, dynamic> payload, {bool isAnswer = false, bool isDecline = false}) async {
+    _logger.i('[PushNotificationHandler-Android] processIncomingCallAction. Payload: $payload, Answer: $isAnswer, Decline: $isDecline');
+    // This method will be called from _MyAppState after getInitialPushData
+    // or potentially from onMessageOpenedApp if specific action is needed there.
+    final Map<dynamic, dynamic> mutablePayload = Map.from(payload);
+    if (isAnswer) mutablePayload['isAnswer'] = true;
+    if (isDecline) mutablePayload['isDecline'] = true;
+
+    await handlePush(mutablePayload);
+  }
+  
+  @override
+  Future<void> displayIncomingCallUi(Map<dynamic, dynamic> payload) async {
+    _logger.i('[PushNotificationHandler-Android] displayIncomingCallUi: Calling NotificationService.showNotification. Payload: $payload');
+    // For Android, NotificationService.showNotification creates the system notification which acts as the incoming call UI.
+    // Ensure the payload structure matches what showNotification expects (likely message.data format).
+    // Creating a RemoteMessage. This might need adjustment if the payload structure differs.
+    try {
+      final remoteMessage = RemoteMessage(data: Map<String, String>.from(payload.map((key, value) => MapEntry(key.toString(), value.toString()))));
+      await NotificationService.showNotification(remoteMessage);
+    } catch (e) {
+       _logger.e('[PushNotificationHandler-Android] displayIncomingCallUi: Error creating RemoteMessage or showing notification: $e');
+    }
+  }
+
+  @override
+  Future<String?> getPushToken() async {
+    _logger.i('[PushNotificationHandler-Android] getPushToken');
+    return FirebaseMessaging.instance.getToken();
+  }
+
+  @override
+  Future<Map<String, dynamic>?> getInitialPushData() async {
+    _logger.i('[PushNotificationHandler-Android] getInitialPushData');
+    final RemoteMessage? initialMessage = await FirebaseMessaging.instance.getInitialMessage();
+    if (initialMessage != null) {
+      _logger.i('[PushNotificationHandler-Android] getInitialPushData: Found initial message: ${initialMessage.data}');
+      // TelnyxClient.setPushMetaData(initialMessage.data); // Ensure this is set before processIncomingCallAction
+      return initialMessage.data;
+    }
+    // Fallback to getPushData from TelnyxClient for consistency with old flow, though getInitialMessage is preferred for FCM.
+    return TelnyxClient.getPushData(); 
+  }
+
+  @override
+  Future<void> showMissedCallNotification(Map<dynamic, dynamic> payload) async {
+    _logger.i('[PushNotificationHandler-Android] showMissedCallNotification. Payload: $payload');
+    // Assuming payload is message.data for FCM
+    await NotificationService.showMissedCallNotification(RemoteMessage(data: Map<String,String>.from(payload.map((key, value) => MapEntry(key.toString(), value.toString())))));
+  }
+
+  @override
+  void clearPushData() {
+    _logger.i('[PushNotificationHandler-Android] clearPushData');
+    TelnyxClient.clearPushMetaData();
+  }
+
+  @override
+  bool isFirebaseInitialized() {
+    // Android handler's initialize() method ensures Firebase is setup for foreground.
+    // The androidBackgroundMessageHandler also calls Firebase.initializeApp().
+    // So, if handler is used, we can assume it tries to init Firebase.
+    // A more robust check would be `Firebase.apps.isNotEmpty`, but that might require
+    // ensuring Firebase is init before this check is made if called very early.
+    // For simplicity here, if this handler is active, it means init was attempted.
+    // However, the background isolate is separate.
+    // This check is more for the main isolate context.
+    final bool initialized = Firebase.apps.isNotEmpty;
+    _logger.i('[PushNotificationHandler-Android] isFirebaseInitialized: Returning $initialized');
+    return initialized;
+  }
+} 

--- a/lib/service/android_push_notification_handler.dart
+++ b/lib/service/android_push_notification_handler.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:flutter/foundation.dart';
 import 'package:logger/logger.dart';
 import 'package:telnyx_flutter_webrtc/main.dart'; // For logger, txClientViewModel, handlePush, CALL_MISSED_TIMEOUT
 import 'package:telnyx_flutter_webrtc/service/notification_service.dart';
@@ -16,81 +15,25 @@ import 'package:telnyx_webrtc/model/socket_method.dart';
 import 'package:telnyx_webrtc/model/telnyx_message.dart';
 import 'package:telnyx_webrtc/model/telnyx_socket_error.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:telnyx_webrtc/utils/logging/log_level.dart';
-import 'package:telnyx_flutter_webrtc/utils/custom_sdk_logger.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-
+import 'package:telnyx_flutter_webrtc/utils/config_helper.dart';
 
 // Define logger at the top level for access by the background handler function
-final _backgroundLogger = Logger(); 
+final _backgroundLogger = Logger();
 
-// --- Static utility methods to fetch config --- 
-// (Keep _getBackgroundCredentialConfig, _getBackgroundTokenConfig, _getBackgroundTelnyxConfig as static helpers)
-// Static utility methods to fetch config from SharedPreferences for background isolate
-Future<CredentialConfig?> _getBackgroundCredentialConfig() async {
-  final prefs = await SharedPreferences.getInstance();
-  final sipUser = prefs.getString('sipUser');
-  final sipPassword = prefs.getString('sipPassword');
-  final sipName = prefs.getString('sipName');
-  final sipNumber = prefs.getString('sipNumber');
-  final notificationToken = prefs.getString('notificationToken');
-
-  if (sipUser != null && sipPassword != null && sipName != null && sipNumber != null) {
-    return CredentialConfig(
-      sipCallerIDName: sipName,
-      sipCallerIDNumber: sipNumber,
-      sipUser: sipUser,
-      sipPassword: sipPassword,
-      notificationToken: notificationToken, 
-      logLevel: LogLevel.all,
-      customLogger: CustomSDKLogger(),
-      debug: false, 
-    );
-  }
-  return null;
-}
-
-Future<TokenConfig?> _getBackgroundTokenConfig() async {
-  final prefs = await SharedPreferences.getInstance();
-  final token = prefs.getString('token');
-  final sipName = prefs.getString('sipName');
-  final sipNumber = prefs.getString('sipNumber');
-  final notificationToken = prefs.getString('notificationToken');
-
-  if (token != null && sipName != null && sipNumber != null) {
-    return TokenConfig(
-      sipCallerIDName: sipName,
-      sipCallerIDNumber: sipNumber,
-      sipToken: token,
-      notificationToken: notificationToken,
-      logLevel: LogLevel.all,
-      customLogger: CustomSDKLogger(),
-      debug: false, 
-    );
-  }
-  return null;
-}
-
-Future<Object?> _getBackgroundTelnyxConfig() async { 
-  Object? config = await _getBackgroundCredentialConfig();
-  config ??= await _getBackgroundTokenConfig();
-  return config;
-}
-// --- End of static config helpers ---
-
-
-// --- Top-level Background Message Handler ---
-// This function MUST be annotated with @pragma('vm:entry-point')
+// This function MUST be annotated with @pragma('vm:entry-point') and be a top level function
 @pragma('vm:entry-point')
 Future<void> androidBackgroundMessageHandler(RemoteMessage message) async {
-  _backgroundLogger.i('[AndroidBackgroundHandler] Received background message: ${message.data}');
+  _backgroundLogger.i(
+    '[AndroidBackgroundHandler] Received background message: ${message.data}',
+  );
 
   // Ensure Firebase is initialized for this isolate
   try {
     await Firebase.initializeApp();
   } catch (e) {
-    _backgroundLogger.e('[AndroidBackgroundHandler] Firebase initialization failed: $e');
+    _backgroundLogger
+        .e('[AndroidBackgroundHandler] Firebase initialization failed: $e');
     return;
   }
 
@@ -99,60 +42,78 @@ Future<void> androidBackgroundMessageHandler(RemoteMessage message) async {
 
   // Setup CallKit listener for background actions
   FlutterCallkitIncoming.onEvent.listen((CallEvent? event) async {
-    _backgroundLogger.i('[AndroidBackgroundHandler] CallKit event: ${event?.event}');
+    _backgroundLogger
+        .i('[AndroidBackgroundHandler] CallKit event: ${event?.event}');
     switch (event!.event) {
       case Event.actionCallDecline:
-        _backgroundLogger.i('[AndroidBackgroundHandler] Call declined via CallKit from background.');
+        _backgroundLogger.i(
+          '[AndroidBackgroundHandler] Call declined via CallKit from background.',
+        );
         if (message.data['metadata'] != null) {
           try {
-            final Map<String, dynamic> metadataMap = jsonDecode(message.data['metadata']);
-            final PushMetaData pushMetaData = PushMetaData.fromJson(metadataMap)..isDecline = true;
+            final Map<String, dynamic> metadataMap =
+                jsonDecode(message.data['metadata']);
+            final PushMetaData pushMetaData = PushMetaData.fromJson(metadataMap)
+              ..isDecline = true;
             final tempDeclineClient = TelnyxClient();
             tempDeclineClient
               ..onSocketMessageReceived = (TelnyxMessage msg) {
                 if (msg.socketMethod == SocketMethod.bye) {
-                  _backgroundLogger.i('[AndroidBackgroundHandler] Temp client received BYE, disconnecting.');
+                  _backgroundLogger.i(
+                    '[AndroidBackgroundHandler] Temp client received BYE, disconnecting.',
+                  );
                   tempDeclineClient.disconnect();
                 }
               }
               ..onSocketErrorReceived = (TelnyxSocketError error) {
-                _backgroundLogger.e('[AndroidBackgroundHandler] Temp client error: ${error.errorMessage}');
+                _backgroundLogger.e(
+                  '[AndroidBackgroundHandler] Temp client error: ${error.errorMessage}',
+                );
                 tempDeclineClient.disconnect();
               };
-              
-            final config = await _getBackgroundTelnyxConfig();
+
+            // Use the ConfigHelper to get the config
+            final config = await ConfigHelper.getTelnyxConfigFromPrefs();
             if (config != null) {
-              _backgroundLogger.i('[AndroidBackgroundHandler] Found config for decline.');
+              _backgroundLogger
+                  .i('[AndroidBackgroundHandler] Found config for decline.');
               tempDeclineClient.handlePushNotification(
                 pushMetaData,
                 config is CredentialConfig ? config : null,
                 config is TokenConfig ? config : null,
               );
             } else {
-              _backgroundLogger.e('[AndroidBackgroundHandler] Could not retrieve config from SharedPreferences. Cannot decline call.');
+              _backgroundLogger.e(
+                '[AndroidBackgroundHandler] Could not retrieve config from SharedPreferences. Cannot decline call.',
+              );
             }
           } catch (e) {
-             _backgroundLogger.e('[AndroidBackgroundHandler] Error processing decline: $e');
+            _backgroundLogger
+                .e('[AndroidBackgroundHandler] Error processing decline: $e');
           }
         } else {
-           _backgroundLogger.i('[AndroidBackgroundHandler] No metadata for decline action.');
+          _backgroundLogger
+              .i('[AndroidBackgroundHandler] No metadata for decline action.');
         }
         break;
       case Event.actionCallAccept:
-        _backgroundLogger.i('[AndroidBackgroundHandler] Call accepted via CallKit from background.');
+        _backgroundLogger.i(
+          '[AndroidBackgroundHandler] Call accepted via CallKit from background.',
+        );
         // Store the accept intent for when the main app processes the initial data
-        TelnyxClient.setPushMetaData(message.data, isAnswer: true, isDecline: false);
+        TelnyxClient.setPushMetaData(
+          message.data,
+          isAnswer: true,
+          isDecline: false,
+        );
         break;
       default:
         break;
     }
   });
 }
-// --- End of Top-level Background Message Handler ---
-
 
 /// Android specific implementation of [PushNotificationHandler].
-/// Note: The background handling logic is now in the top-level [androidBackgroundMessageHandler].
 class AndroidPushNotificationHandler implements PushNotificationHandler {
   // Use a logger instance for the class methods (foreground)
   final _logger = Logger();
@@ -167,171 +128,240 @@ class AndroidPushNotificationHandler implements PushNotificationHandler {
       'Incoming Calls', // name
       description: 'Notifications for incoming Telnyx calls.',
       importance: Importance.max, // Crucial for heads-up display
-      playSound: true, // Ensure sound plays (adjust as needed)
-      // Add other properties like sound, vibration pattern if desired
+      playSound: true,
+      audioAttributesUsage: AudioAttributesUsage.notificationRingtone,
     );
 
     final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
         FlutterLocalNotificationsPlugin();
 
     try {
-       await flutterLocalNotificationsPlugin
-        .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
-        ?.createNotificationChannel(channel);
-       _logger.i('[PushNotificationHandler-Android] High importance notification channel created/updated.');
+      await flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>()
+          ?.createNotificationChannel(channel);
+      _logger.i(
+        '[PushNotificationHandler-Android] High importance notification channel created/updated.',
+      );
     } catch (e) {
-       _logger.e('[PushNotificationHandler-Android] Failed to create notification channel: $e');
+      _logger.e(
+        '[PushNotificationHandler-Android] Failed to create notification channel: $e',
+      );
     }
 
     // Setup foreground message listener
     FirebaseMessaging.onMessage.listen((RemoteMessage message) {
-      _logger.i('[PushNotificationHandler-Android] onMessage: Received foreground message: ${message.data}');
-      if (message.data['message'] != null && message.data['message'].toString().toLowerCase() == 'missed call!') {
-        _logger.i('[PushNotificationHandler-Android] onMessage: Missed call notification');
+      _logger.i(
+        '[PushNotificationHandler-Android] onMessage: Received foreground message: ${message.data}',
+      );
+      if (message.data['message'] != null &&
+          message.data['message'].toString().toLowerCase() == 'missed call!') {
+        _logger.i(
+          '[PushNotificationHandler-Android] onMessage: Missed call notification',
+        );
         NotificationService.showMissedCallNotification(message);
         return;
       }
       NotificationService.showNotification(message);
-      TelnyxClient.setPushMetaData(message.data); // Sets it for later retrieval if needed
+      TelnyxClient.setPushMetaData(
+        message.data,
+      ); // Sets it for later retrieval if needed
     });
 
     // Setup message opened app listener
     FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
-      _logger.i('[PushNotificationHandler-Android] onMessageOpenedApp: Message data: ${message.data}');
+      _logger.i(
+        '[PushNotificationHandler-Android] onMessageOpenedApp: Message data: ${message.data}',
+      );
     });
 
     // Set foreground presentation options
-    await FirebaseMessaging.instance.setForegroundNotificationPresentationOptions(
+    await FirebaseMessaging.instance
+        .setForegroundNotificationPresentationOptions(
       alert: true,
       badge: true,
       sound: true,
     );
 
-    // Add CallKit listener for Android foreground/active state interactions
     // This catches events from notifications created by NotificationService
-    _logger.i('[PushNotificationHandler-Android] Setting up CallKit event listener...');
+    _logger.i(
+      '[PushNotificationHandler-Android] Setting up CallKit event listener...',
+    );
     FlutterCallkitIncoming.onEvent.listen((CallEvent? event) async {
-      _logger.i('[PushNotificationHandler-Android] onEvent: ${event?.event} :: ${event?.body}');
-      // Use similar logic as iOS handler for Accept/Decline actions from CallKit UI
+      _logger.i(
+        '[PushNotificationHandler-Android] onEvent: ${event?.event} :: ${event?.body}',
+      );
       switch (event!.event) {
         case Event.actionCallAccept:
-          _logger.i('[PushNotificationHandler-Android] actionCallAccept: Received. Metadata: ${event.body?['extra']?['metadata']}');
+          _logger.i(
+            '[PushNotificationHandler-Android] actionCallAccept: Received. Metadata: ${event.body?['extra']?['metadata']}',
+          );
           if (txClientViewModel.incomingInvitation != null) {
-            _logger.i('[PushNotificationHandler-Android] actionCallAccept: ViewModel has existing incomingInvitation. Accepting directly.');
+            _logger.i(
+              '[PushNotificationHandler-Android] actionCallAccept: ViewModel has existing incomingInvitation. Accepting directly.',
+            );
             await txClientViewModel.accept();
           } else {
             final metadata = event.body['extra']?['metadata'];
             if (metadata == null) {
-              _logger.i('[PushNotificationHandler-Android] actionCallAccept: Metadata missing. Accepting without push context.');
+              _logger.i(
+                '[PushNotificationHandler-Android] actionCallAccept: Metadata missing. Accepting without push context.',
+              );
               await txClientViewModel.accept();
             } else {
-              _logger.i('[PushNotificationHandler-Android] actionCallAccept: Metadata present. Calling processIncomingCallAction. Metadata: $metadata');
+              _logger.i(
+                '[PushNotificationHandler-Android] actionCallAccept: Metadata present. Calling processIncomingCallAction. Metadata: $metadata',
+              );
               var decodedMetadata = metadata;
               if (metadata is String) {
                 try {
                   decodedMetadata = jsonDecode(metadata);
                 } catch (e) {
-                  _logger.e('[PushNotificationHandler-Android] actionCallAccept: Error decoding metadata JSON: $e. Attempting direct accept.');
+                  _logger.e(
+                    '[PushNotificationHandler-Android] actionCallAccept: Error decoding metadata JSON: $e. Attempting direct accept.',
+                  );
                   await txClientViewModel.accept(); // Fallback
                   return;
                 }
               }
               // Call the handler's method to process the action, which will augment and call handlePush
-              await processIncomingCallAction(decodedMetadata as Map<dynamic, dynamic>, isAnswer: true);
+              await processIncomingCallAction(
+                decodedMetadata as Map<dynamic, dynamic>,
+                isAnswer: true,
+              );
             }
           }
           break;
 
         case Event.actionCallDecline:
-          _logger.i('[PushNotificationHandler-Android] actionCallDecline: Received. Metadata: ${event.body?['extra']?['metadata']}');
+          _logger.i(
+            '[PushNotificationHandler-Android] actionCallDecline: Received. Metadata: ${event.body?['extra']?['metadata']}',
+          );
           final metadata = event.body['extra']?['metadata'];
-          if (txClientViewModel.incomingInvitation != null || txClientViewModel.currentCall != null) {
-             _logger.i('[PushNotificationHandler-Android] actionCallDecline: Main client has existing call/invite. Using txClientViewModel.endCall().');
+          if (txClientViewModel.incomingInvitation != null ||
+              txClientViewModel.currentCall != null) {
+            _logger.i(
+              '[PushNotificationHandler-Android] actionCallDecline: Main client has existing call/invite. Using txClientViewModel.endCall().',
+            );
             txClientViewModel.endCall();
           } else if (metadata == null) {
-             _logger.i('[PushNotificationHandler-Android] actionCallDecline: No metadata and no active call/invite in ViewModel.');
-             // Maybe end the callkit call? 
-             // FlutterCallkitIncoming.endCall(event.body['id']); // Requires getting ID from event
+            _logger.i(
+              '[PushNotificationHandler-Android] actionCallDecline: No metadata and no active call/invite in ViewModel.',
+            );
+            await FlutterCallkitIncoming.endCall(event.body['id']);
           } else {
-             _logger.i('[PushNotificationHandler-Android] actionCallDecline: Metadata present. Using temporary client for decline. Metadata: $metadata');
-             // Use temporary client logic (same as iOS)
+            _logger.i(
+              '[PushNotificationHandler-Android] actionCallDecline: Metadata present. Using temporary client for decline. Metadata: $metadata',
+            );
+            // Use temporary client logic (same as iOS)
             var decodedMetadata = metadata;
-             if (metadata is String) {
-               try {
-                 decodedMetadata = jsonDecode(metadata);
-               } catch (e) {
-                 _logger.e('[PushNotificationHandler-Android] actionCallDecline: Error decoding metadata JSON: $e.');
-                 return;
-               }
-             }
-             final Map<dynamic, dynamic> eventData = Map<dynamic, dynamic>.from(decodedMetadata as Map);
-             final PushMetaData pushMetaData = PushMetaData.fromJson(eventData)..isDecline = true;
-             final tempDeclineClient = TelnyxClient();
-             tempDeclineClient
+            if (metadata is String) {
+              try {
+                decodedMetadata = jsonDecode(metadata);
+              } catch (e) {
+                _logger.e(
+                  '[PushNotificationHandler-Android] actionCallDecline: Error decoding metadata JSON: $e.',
+                );
+                return;
+              }
+            }
+            final Map<dynamic, dynamic> eventData =
+                Map<dynamic, dynamic>.from(decodedMetadata as Map);
+            final PushMetaData pushMetaData = PushMetaData.fromJson(eventData)
+              ..isDecline = true;
+            final tempDeclineClient = TelnyxClient();
+            tempDeclineClient
               ..onSocketMessageReceived = (TelnyxMessage msg) {
-                 if (msg.socketMethod == SocketMethod.bye) {
-                   _logger.i('[PushNotificationHandler-Android] actionCallDecline: Temp client received BYE, disconnecting.');
-                   tempDeclineClient.disconnect();
-                 }
-               }
+                if (msg.socketMethod == SocketMethod.bye) {
+                  _logger.i(
+                    '[PushNotificationHandler-Android] actionCallDecline: Temp client received BYE, disconnecting.',
+                  );
+                  tempDeclineClient.disconnect();
+                }
+              }
               ..onSocketErrorReceived = (TelnyxSocketError error) {
-                 _logger.e('[PushNotificationHandler-Android] actionCallDecline: Temp client error: ${error.errorMessage}');
-                 tempDeclineClient.disconnect();
-             };
-             final config = await _getBackgroundTelnyxConfig(); // Use background config getter
-             _logger.i('[PushNotificationHandler-Android] actionCallDecline: Temp client attempting handlePushNotification.');
-             if (config != null) {
-               tempDeclineClient.handlePushNotification(
-                 pushMetaData,
-                 config is CredentialConfig ? config : null,
-                 config is TokenConfig ? config : null,
-               );
-             } else {
-               _logger.e('[PushNotificationHandler-Android] actionCallDecline: Could not get config for temp client.');
-             }
+                _logger.e(
+                  '[PushNotificationHandler-Android] actionCallDecline: Temp client error: ${error.errorMessage}',
+                );
+                tempDeclineClient.disconnect();
+              };
+            // Use the ConfigHelper to get the config
+            final config = await ConfigHelper.getTelnyxConfigFromPrefs();
+            _logger.i(
+              '[PushNotificationHandler-Android] actionCallDecline: Temp client attempting handlePushNotification.',
+            );
+            if (config != null) {
+              tempDeclineClient.handlePushNotification(
+                pushMetaData,
+                config is CredentialConfig ? config : null,
+                config is TokenConfig ? config : null,
+              );
+            } else {
+              _logger.e(
+                '[PushNotificationHandler-Android] actionCallDecline: Could not get config for temp client.',
+              );
+            }
           }
           break;
 
         // Handle other events like ended, timeout if needed from foreground CallKit interactions
-         case Event.actionCallEnded:
-           _logger.i('[PushNotificationHandler-Android] actionCallEnded: Call ended event from CallKit.');
-           txClientViewModel.endCall();
-           break;
-         case Event.actionCallTimeout:
-           _logger.i('[PushNotificationHandler-Android] actionCallTimeout: Call timeout event from CallKit.');
-           txClientViewModel.endCall(); 
-           break;
+        case Event.actionCallEnded:
+          _logger.i(
+            '[PushNotificationHandler-Android] actionCallEnded: Call ended event from CallKit.',
+          );
+          txClientViewModel.endCall();
+          break;
+        case Event.actionCallTimeout:
+          _logger.i(
+            '[PushNotificationHandler-Android] actionCallTimeout: Call timeout event from CallKit.',
+          );
+          txClientViewModel.endCall();
+          break;
 
         default:
-          _logger.i('[PushNotificationHandler-Android] Unhandled CallKit event in foreground: ${event.event}');
+          _logger.i(
+            '[PushNotificationHandler-Android] Unhandled CallKit event in foreground: ${event.event}',
+          );
           break;
       }
     });
   }
 
   @override
-  Future<void> processIncomingCallAction(Map<dynamic, dynamic> payload, {bool isAnswer = false, bool isDecline = false}) async {
-    _logger.i('[PushNotificationHandler-Android] processIncomingCallAction. Payload: $payload, Answer: $isAnswer, Decline: $isDecline');
-    // This method will be called from _MyAppState after getInitialPushData
-    // or potentially from onMessageOpenedApp if specific action is needed there.
+  Future<void> processIncomingCallAction(
+    Map<dynamic, dynamic> payload, {
+    bool isAnswer = false,
+    bool isDecline = false,
+  }) async {
+    _logger.i(
+      '[PushNotificationHandler-Android] processIncomingCallAction. Payload: $payload, Answer: $isAnswer, Decline: $isDecline',
+    );
     final Map<dynamic, dynamic> mutablePayload = Map.from(payload);
     if (isAnswer) mutablePayload['isAnswer'] = true;
     if (isDecline) mutablePayload['isDecline'] = true;
 
     await handlePush(mutablePayload);
   }
-  
+
   @override
   Future<void> displayIncomingCallUi(Map<dynamic, dynamic> payload) async {
-    _logger.i('[PushNotificationHandler-Android] displayIncomingCallUi: Calling NotificationService.showNotification. Payload: $payload');
+    _logger.i(
+      '[PushNotificationHandler-Android] displayIncomingCallUi: Calling NotificationService.showNotification. Payload: $payload',
+    );
     // For Android, NotificationService.showNotification creates the system notification which acts as the incoming call UI.
-    // Ensure the payload structure matches what showNotification expects (likely message.data format).
-    // Creating a RemoteMessage. This might need adjustment if the payload structure differs.
     try {
-      final remoteMessage = RemoteMessage(data: Map<String, String>.from(payload.map((key, value) => MapEntry(key.toString(), value.toString()))));
+      final remoteMessage = RemoteMessage(
+        data: Map<String, String>.from(
+          payload.map(
+            (key, value) => MapEntry(key.toString(), value.toString()),
+          ),
+        ),
+      );
       await NotificationService.showNotification(remoteMessage);
     } catch (e) {
-       _logger.e('[PushNotificationHandler-Android] displayIncomingCallUi: Error creating RemoteMessage or showing notification: $e');
+      _logger.e(
+        '[PushNotificationHandler-Android] displayIncomingCallUi: Error creating RemoteMessage or showing notification: $e',
+      );
     }
   }
 
@@ -344,21 +374,31 @@ class AndroidPushNotificationHandler implements PushNotificationHandler {
   @override
   Future<Map<String, dynamic>?> getInitialPushData() async {
     _logger.i('[PushNotificationHandler-Android] getInitialPushData');
-    final RemoteMessage? initialMessage = await FirebaseMessaging.instance.getInitialMessage();
+    final RemoteMessage? initialMessage =
+        await FirebaseMessaging.instance.getInitialMessage();
     if (initialMessage != null) {
-      _logger.i('[PushNotificationHandler-Android] getInitialPushData: Found initial message: ${initialMessage.data}');
-      //await processIncomingCallAction(initialMessage.data, isAnswer: false, isDecline: false);
+      _logger.i(
+        '[PushNotificationHandler-Android] getInitialPushData: Found initial message: ${initialMessage.data}',
+      );
       return initialMessage.data;
     }
     // Fallback to getPushData from TelnyxClient for consistency with old flow, though getInitialMessage is preferred for FCM.
-    return TelnyxClient.getPushData(); 
+    return TelnyxClient.getPushData();
   }
 
   @override
   Future<void> showMissedCallNotification(Map<dynamic, dynamic> payload) async {
-    _logger.i('[PushNotificationHandler-Android] showMissedCallNotification. Payload: $payload');
-    // Assuming payload is message.data for FCM
-    await NotificationService.showMissedCallNotification(RemoteMessage(data: Map<String,String>.from(payload.map((key, value) => MapEntry(key.toString(), value.toString())))));
+    _logger.i(
+      '[PushNotificationHandler-Android] showMissedCallNotification. Payload: $payload',
+    );
+    await NotificationService.showMissedCallNotification(
+      RemoteMessage(
+        data: Map<String, String>.from(
+          payload
+              .map((key, value) => MapEntry(key.toString(), value.toString())),
+        ),
+      ),
+    );
   }
 
   @override
@@ -369,16 +409,10 @@ class AndroidPushNotificationHandler implements PushNotificationHandler {
 
   @override
   bool isFirebaseInitialized() {
-    // Android handler's initialize() method ensures Firebase is setup for foreground.
-    // The androidBackgroundMessageHandler also calls Firebase.initializeApp().
-    // So, if handler is used, we can assume it tries to init Firebase.
-    // A more robust check would be `Firebase.apps.isNotEmpty`, but that might require
-    // ensuring Firebase is init before this check is made if called very early.
-    // For simplicity here, if this handler is active, it means init was attempted.
-    // However, the background isolate is separate.
-    // This check is more for the main isolate context.
     final bool initialized = Firebase.apps.isNotEmpty;
-    _logger.i('[PushNotificationHandler-Android] isFirebaseInitialized: Returning $initialized');
+    _logger.i(
+      '[PushNotificationHandler-Android] isFirebaseInitialized: Returning $initialized',
+    );
     return initialized;
   }
-} 
+}

--- a/lib/service/ios_push_notification_handler.dart
+++ b/lib/service/ios_push_notification_handler.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_callkit_incoming/entities/call_event.dart';
+import 'package:flutter_callkit_incoming/flutter_callkit_incoming.dart';
+import 'package:logger/logger.dart';
+import 'package:telnyx_flutter_webrtc/main.dart'; // For logger, txClientViewModel, handlePush
+import 'package:telnyx_flutter_webrtc/service/push_notification_handler.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/model/push_notification.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_webrtc/model/telnyx_message.dart';
+import 'package:telnyx_webrtc/model/socket_method.dart';
+import 'package:telnyx_webrtc/model/telnyx_socket_error.dart';
+import 'package:firebase_core/firebase_core.dart';
+
+/// iOS specific implementation of [PushNotificationHandler].
+class IOSPushNotificationHandler implements PushNotificationHandler {
+  final _logger = Logger();
+
+  @override
+  Future<void> initialize() async {
+    _logger.i('[PushNotificationHandler-iOS] Initialize');
+    // Native AppDelegate.swift handles showing CallKit UI initially.
+    // This listener handles events coming from CallKit interactions.
+    FlutterCallkitIncoming.onEvent.listen((CallEvent? event) async {
+      _logger.i('[PushNotificationHandler-iOS] onEvent: ${event?.event} :: ${event?.body}');
+      switch (event!.event) {
+        case Event.actionCallIncoming:
+          // This event means CallKit UI is shown. Metadata is from AppDelegate.
+          if (event.body['extra']?['metadata'] == null) {
+            _logger.i('[PushNotificationHandler-iOS] actionCallIncoming: Push Data is null!');
+            return;
+          }
+          _logger.i(
+            "[PushNotificationHandler-iOS] actionCallIncoming: Received from CallKit. Metadata: ${event.body['extra']['metadata']}",
+          );
+          break;
+
+        case Event.actionCallAccept:
+          _logger.i('[PushNotificationHandler-iOS] actionCallAccept: Received. Metadata: ${event.body?['extra']?['metadata']}');
+          if (txClientViewModel.incomingInvitation != null) {
+            _logger.i('[PushNotificationHandler-iOS] actionCallAccept: ViewModel has existing incomingInvitation. Accepting directly.');
+            await txClientViewModel.accept();
+          } else {
+            final metadata = event.body['extra']?['metadata'];
+            if (metadata == null) {
+              _logger.i('[PushNotificationHandler-iOS] actionCallAccept: Metadata missing. Accepting without push context.');
+              await txClientViewModel.accept();
+            } else {
+              _logger.i('[PushNotificationHandler-iOS] actionCallAccept: Metadata present. Calling processIncomingCallAction. Metadata: $metadata');
+              var decodedMetadata = metadata;
+              if (metadata is String) {
+                try {
+                  decodedMetadata = jsonDecode(metadata);
+                } catch (e) {
+                  _logger.e('[PushNotificationHandler-iOS] actionCallAccept: Error decoding metadata JSON: $e. Attempting direct accept.');
+                  await txClientViewModel.accept(); // Fallback
+                  return;
+                }
+              }
+              await processIncomingCallAction(decodedMetadata as Map<dynamic, dynamic>, isAnswer: true);
+            }
+          }
+          break;
+
+        case Event.actionCallDecline:
+          _logger.i('[PushNotificationHandler-iOS] actionCallDecline: Received. Metadata: ${event.body?['extra']?['metadata']}');
+          final metadata = event.body['extra']?['metadata'];
+          if (txClientViewModel.incomingInvitation != null || txClientViewModel.currentCall != null) {
+            _logger.i('[PushNotificationHandler-iOS] actionCallDecline: Main client has existing call/invite. Using txClientViewModel.endCall().');
+            txClientViewModel.endCall();
+          } else if (metadata == null) {
+            _logger.i('[PushNotificationHandler-iOS] actionCallDecline: No metadata and no active call/invite in ViewModel.');
+          } else {
+            _logger.i('[PushNotificationHandler-iOS] actionCallDecline: Metadata present. Using temporary client for decline. Metadata: $metadata');
+            var decodedMetadata = metadata;
+            if (metadata is String) {
+              try {
+                decodedMetadata = jsonDecode(metadata);
+              } catch (e) {
+                _logger.e('[PushNotificationHandler-iOS] actionCallDecline: Error decoding metadata JSON: $e.');
+                return;
+              }
+            }
+            // Using temporary client logic as established
+            final Map<dynamic, dynamic> eventData = Map<dynamic, dynamic>.from(decodedMetadata as Map);
+            final PushMetaData pushMetaData = PushMetaData.fromJson(eventData)..isDecline = true;
+            final tempDeclineClient = TelnyxClient();
+            tempDeclineClient..onSocketMessageReceived = (TelnyxMessage msg) {
+              if (msg.socketMethod == SocketMethod.bye) {
+                _logger.i('[PushNotificationHandler-iOS] actionCallDecline: Temp client received BYE, disconnecting.');
+                tempDeclineClient.disconnect();
+              }
+            }
+            ..onSocketErrorReceived = (TelnyxSocketError error) {
+                _logger.e('[PushNotificationHandler-iOS] actionCallDecline: Temp client error: ${error.errorMessage}');
+                tempDeclineClient.disconnect();
+            };
+            final config = await txClientViewModel.getConfig();
+            _logger.i('[PushNotificationHandler-iOS] actionCallDecline: Temp client attempting to handlePushNotification. Config :: $config');
+            tempDeclineClient.handlePushNotification(
+              pushMetaData,
+              config is CredentialConfig ? config : null,
+              config is TokenConfig ? config : null,
+            );
+          }
+          break;
+
+        case Event.actionCallEnded:
+          _logger.i('[PushNotificationHandler-iOS] actionCallEnded: Call ended event from CallKit.');
+          txClientViewModel.endCall();
+          break;
+
+        case Event.actionCallTimeout:
+          _logger.i('[PushNotificationHandler-iOS] actionCallTimeout: Call timeout event from CallKit.');
+          txClientViewModel.endCall();
+          break;
+        default:
+          _logger.i('[PushNotificationHandler-iOS] Unhandled CallKit event: ${event.event}');
+          break;
+      }
+    });
+  }
+
+  @override
+  Future<void> processIncomingCallAction(Map<dynamic, dynamic> payload, {bool isAnswer = false, bool isDecline = false}) async {
+    _logger.i('[PushNotificationHandler-iOS] processIncomingCallAction. Payload: $payload, Answer: $isAnswer, Decline: $isDecline');
+    final Map<dynamic, dynamic> mutablePayload = Map.from(payload);
+    if (isAnswer) mutablePayload['isAnswer'] = true;
+    if (isDecline) mutablePayload['isDecline'] = true;
+    // This will call the global handlePush which then calls txClientViewModel.handlePushNotification
+    await handlePush(mutablePayload);
+  }
+
+  @override
+  Future<void> displayIncomingCallUi(Map<dynamic, dynamic> payload) async {
+    _logger.i('[PushNotificationHandler-iOS] displayIncomingCallUi: Primarily handled by native AppDelegate.swift. Payload: $payload');
+    // Native AppDelegate.swift calls SwiftFlutterCallkitIncomingPlugin.sharedInstance?.showCallkitIncoming
+  }
+
+  @override
+  Future<String?> getPushToken() async {
+    _logger.i('[PushNotificationHandler-iOS] getPushToken');
+    if (Platform.isIOS) {
+      return await FlutterCallkitIncoming.getDevicePushTokenVoIP();
+    }
+    return null;
+  }
+
+  @override
+  Future<Map<String, dynamic>?> getInitialPushData() async {
+    _logger.i('[PushNotificationHandler-iOS] getInitialPushData: Not typically used in the same way as Android. CallKit events drive the flow.');
+    // iOS flow is primarily driven by CallKit events after app launch.
+    // No direct equivalent to FCM's getInitialMessage for VoIP pushes in this context.
+    return null;
+  }
+
+  @override
+  Future<void> showMissedCallNotification(Map<dynamic, dynamic> payload) async {
+    _logger.i('[PushNotificationHandler-iOS] showMissedCallNotification: Not implemented for iOS in this handler. Relies on CallKits native missed call handling. Payload: $payload');
+    // iOS CallKit handles its own missed call notifications/badges typically.
+  }
+
+  @override
+  void clearPushData() {
+    _logger.i('[PushNotificationHandler-iOS] clearPushData');
+    TelnyxClient.clearPushMetaData(); // Uses the static TelnyxClient method
+  }
+
+  @override
+  bool isFirebaseInitialized() {
+    // iOS part of this app does not directly use Firebase for VoIP push notifications (it uses CallKit/PushKit).
+    // Firebase might be used for other purposes, but from this handler's perspective for push,
+    // it doesn't manage Firebase initialization itself in the same way Android FCM flow does.
+    // If Firebase is initialized globally (e.g. for Analytics), checking Firebase.apps.isNotEmpty could be valid.
+    // For this refactor, returning true to prevent re-init by AppInitializer if global init is done.
+    // Or false if this handler should not imply anything about Firebase state.
+    // Let's assume for now that if AppInitializer calls Firebase.initializeApp for iOS (e.g. for other services),
+    // then this handler doesn't need to prompt another one. This is a bit of a nuanced point depending on overall Firebase usage.
+    // If Firebase is NOT used at all on iOS by the app, this should be false.
+    // Given DefaultFirebaseOptions are present, it might be used.
+    bool initialized = Firebase.apps.isNotEmpty; // Check if any app is initialized
+    _logger.i('[PushNotificationHandler-iOS] isFirebaseInitialized: Returning $initialized');
+    return initialized;
+    // return true; // Simpler: if iOS uses Firebase for anything, assume it's handled by general App Init.
+  }
+} 

--- a/lib/service/ios_push_notification_handler.dart
+++ b/lib/service/ios_push_notification_handler.dart
@@ -137,7 +137,6 @@ class IOSPushNotificationHandler implements PushNotificationHandler {
   @override
   Future<void> displayIncomingCallUi(Map<dynamic, dynamic> payload) async {
     _logger.i('[PushNotificationHandler-iOS] displayIncomingCallUi: Primarily handled by native AppDelegate.swift. Payload: $payload');
-    // Native AppDelegate.swift calls SwiftFlutterCallkitIncomingPlugin.sharedInstance?.showCallkitIncoming
   }
 
   @override
@@ -175,15 +174,8 @@ class IOSPushNotificationHandler implements PushNotificationHandler {
     // Firebase might be used for other purposes, but from this handler's perspective for push,
     // it doesn't manage Firebase initialization itself in the same way Android FCM flow does.
     // If Firebase is initialized globally (e.g. for Analytics), checking Firebase.apps.isNotEmpty could be valid.
-    // For this refactor, returning true to prevent re-init by AppInitializer if global init is done.
-    // Or false if this handler should not imply anything about Firebase state.
-    // Let's assume for now that if AppInitializer calls Firebase.initializeApp for iOS (e.g. for other services),
-    // then this handler doesn't need to prompt another one. This is a bit of a nuanced point depending on overall Firebase usage.
-    // If Firebase is NOT used at all on iOS by the app, this should be false.
-    // Given DefaultFirebaseOptions are present, it might be used.
-    bool initialized = Firebase.apps.isNotEmpty; // Check if any app is initialized
+    final bool initialized = Firebase.apps.isNotEmpty; // Check if any app is initialized
     _logger.i('[PushNotificationHandler-iOS] isFirebaseInitialized: Returning $initialized');
     return initialized;
-    // return true; // Simpler: if iOS uses Firebase for anything, assume it's handled by general App Init.
   }
 } 

--- a/lib/service/notification_service.dart
+++ b/lib/service/notification_service.dart
@@ -9,122 +9,144 @@ import 'package:telnyx_flutter_webrtc/utils/background_detector.dart';
 import 'package:uuid/uuid.dart';
 import 'package:logger/logger.dart';
 import 'package:telnyx_webrtc/model/push_notification.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
 
 class NotificationService {
   static Future showNotification(RemoteMessage message) async {
-    Logger().i('Received Incoming NotificationService! from background ${message.data}');
+    final logger = Logger()
+    ..i('NotificationService.showNotification: Received message: ${message.data}');
 
-    final data = message.data.containsKey('extra') ? jsonDecode(message.data['extra']) : {};
-    final alert = data['aps']?['alert'] ?? 'No alert';
+    try {
+      // Use a default map if metadata is missing or invalid
+      final Map<String, dynamic> metadataMap = message.data.containsKey('metadata')
+          ? jsonDecode(message.data['metadata'] ?? '{}') 
+          : {}; 
+      final metadata = PushMetaData.fromJson(metadataMap); 
 
-    if (alert == 'Missed call!') {
-      Logger().i('Missed call notification, do not show call kit');
-      return;
+      // Check for the actual call ID from Telnyx metadata (using camelCase)
+      final String? telnyxCallId = metadata.callId;
+
+      if (telnyxCallId == null || telnyxCallId.isEmpty) {
+        logger.e('NotificationService.showNotification: Missing or empty callId in metadata. Cannot show CallKit notification.'); // Corrected log
+        return; // Cannot proceed without a valid ID
+      }
+
+      // Optional: Check for missed call message early (though usually handled by caller)
+      if (message.data.containsKey('message') && message.data['message'] == 'Missed call!') {
+         logger.i('NotificationService.showNotification: Received a message flagged as "Missed call!", aborting showing incoming UI.');
+         return;
+      }
+
+      logger.i('NotificationService.showNotification: Showing CallKit incoming UI for call ID: $telnyxCallId');
+      BackgroundDetector.ignore = true;
+      final CallKitParams callKitParams = CallKitParams(
+        id: telnyxCallId,
+        nameCaller: metadata.callerName,
+        appName: 'Telnyx Flutter Voice',
+        handle: metadata.callerNumber,
+        type: 0, // 0 for audio call, 1 for video call
+        textAccept: 'Accept',
+        textDecline: 'Decline',
+        duration: 30000,
+        extra: message.data,
+        headers: <String, dynamic>{'platform': 'flutter'},
+        android: const AndroidParams(
+          isCustomNotification: true,
+          isShowLogo: false,
+          ringtonePath: 'system_ringtone_default',
+          backgroundColor: '#0955fa',
+          actionColor: '#4CAF50',
+          textColor: '#ffffff',
+          incomingCallNotificationChannelName: 'Incoming Call',
+          missedCallNotificationChannelName: 'Missed Call',
+        ),
+        ios: const IOSParams(
+          iconName: 'CallKitLogo',
+          handleType: 'generic',
+          supportsVideo: false,
+          maximumCallGroups: 2,
+          maximumCallsPerCallGroup: 1,
+          audioSessionMode: 'default',
+          audioSessionActive: true,
+          audioSessionPreferredSampleRate: 44100.0,
+          audioSessionPreferredIOBufferDuration: 0.005,
+          supportsDTMF: true,
+          supportsHolding: true,
+          supportsGrouping: false,
+          supportsUngrouping: false,
+          ringtonePath: 'system_ringtone_default',
+        ),
+      );
+
+      await FlutterCallkitIncoming.showCallkitIncoming(callKitParams);
+      logger.i('NotificationService.showNotification: CallKit incoming UI displayed for $telnyxCallId.');
+
+    } catch (e) {
+      logger.e('NotificationService.showNotification: Error processing notification: $e');
+      TelnyxClient.clearPushMetaData();
     }
-
-    final metadata = PushMetaData.fromJson(jsonDecode(message.data['metadata']));
-    final currentUuid = const Uuid().v4();
-
-    BackgroundDetector.ignore = true;
-    final CallKitParams callKitParams = CallKitParams(
-      id: currentUuid,
-      nameCaller: metadata.callerName,
-      appName: 'Telnyx Flutter Voice',
-      handle: metadata.callerNumber,
-      type: 0,
-      textAccept: 'Accept',
-      textDecline: 'Decline',
-      missedCallNotification: const NotificationParams(
-        showNotification: true,
-        isShowCallback: true,
-        subtitle: 'Missed call',
-        callbackText: 'Call back',
-      ),
-      duration: 30000,
-      extra: message.data,
-      headers: <String, dynamic>{'platform': 'flutter'},
-      android: const AndroidParams(
-        isCustomNotification: true,
-        isShowLogo: false,
-        ringtonePath: 'system_ringtone_default',
-        backgroundColor: '#0955fa',
-        actionColor: '#4CAF50',
-        textColor: '#ffffff',
-        incomingCallNotificationChannelName: 'Incoming Call',
-        missedCallNotificationChannelName: 'Missed Call',
-      ),
-      ios: const IOSParams(
-        iconName: 'CallKitLogo',
-        handleType: 'generic',
-        supportsVideo: false,
-        maximumCallGroups: 2,
-        maximumCallsPerCallGroup: 1,
-        audioSessionMode: 'default',
-        audioSessionActive: true,
-        audioSessionPreferredSampleRate: 44100.0,
-        audioSessionPreferredIOBufferDuration: 0.005,
-        supportsDTMF: true,
-        supportsHolding: true,
-        supportsGrouping: false,
-        supportsUngrouping: false,
-        ringtonePath: 'system_ringtone_default',
-      ),
-    );
-
-    await FlutterCallkitIncoming.showCallkitIncoming(callKitParams);
   }
 
   static Future showMissedCallNotification(RemoteMessage message) async {
-    Logger().i('Received Incoming NotificationService! from background');
-    final metadata =
-        PushMetaData.fromJson(jsonDecode(message.data['metadata']));
-    final currentUuid = const Uuid().v4();
+    final logger = Logger()
+    ..i('NotificationService.showMissedCallNotification: Received message: ${message.data}');
+    
+    try {
+      final Map<String, dynamic> metadataMap = message.data.containsKey('metadata') 
+          ? jsonDecode(message.data['metadata'] ?? '{}') 
+          : {};
+      final metadata = PushMetaData.fromJson(metadataMap);
+      final String? telnyxCallId = metadata.callId;
 
-    final CallKitParams callKitParams = CallKitParams(
-      id: currentUuid,
-      nameCaller: metadata.callerName,
-      appName: 'Telnyx Flutter Voice',
-      handle: metadata.callerNumber,
-      type: 0,
-      textAccept: 'Accept',
-      textDecline: 'Decline',
-      missedCallNotification: const NotificationParams(
-        showNotification: true,
-        isShowCallback: true,
-        subtitle: 'Missed call',
-        callbackText: 'Call back',
-      ),
-      duration: 30000,
-      extra: message.data,
-      headers: <String, dynamic>{'platform': 'flutter'},
-      android: const AndroidParams(
-        isCustomNotification: true,
-        isShowLogo: false,
-        ringtonePath: 'system_ringtone_default',
-        backgroundColor: '#0955fa',
-        actionColor: '#4CAF50',
-        textColor: '#ffffff',
-        incomingCallNotificationChannelName: 'Incoming Call',
-        missedCallNotificationChannelName: 'Missed Call',
-      ),
-      ios: const IOSParams(
-        iconName: 'CallKitLogo',
-        handleType: 'generic',
-        supportsVideo: false,
-        maximumCallGroups: 2,
-        maximumCallsPerCallGroup: 1,
-        audioSessionMode: 'default',
-        audioSessionActive: true,
-        audioSessionPreferredSampleRate: 44100.0,
-        audioSessionPreferredIOBufferDuration: 0.005,
-        supportsDTMF: true,
-        supportsHolding: true,
-        supportsGrouping: false,
-        supportsUngrouping: false,
-        ringtonePath: 'system_ringtone_default',
-      ),
-    );
+      if (telnyxCallId == null || telnyxCallId.isEmpty) {
+        logger.e('NotificationService.showMissedCallNotification: Missing or empty callId in metadata. Cannot process missed call accurately.'); // Corrected log
+        return;
+      }
 
-    await FlutterCallkitIncoming.showMissCallNotification(callKitParams);
+      logger.i('NotificationService.showMissedCallNotification: Ending potentially active incoming CallKit UI for ID: $telnyxCallId');
+      await FlutterCallkitIncoming.endCall(telnyxCallId); 
+      logger.i('NotificationService.showMissedCallNotification: endCall sent for ID: $telnyxCallId');
+
+      // Now, show the specific missed call notification (e.g., for system logs/recents)
+      final String missedCallEntryUuid = const Uuid().v4(); 
+      logger.i('NotificationService.showMissedCallNotification: Showing missed call notification entry with UUID: $missedCallEntryUuid for original call ID: $telnyxCallId');
+
+      final CallKitParams callKitParams = CallKitParams(
+        id: missedCallEntryUuid, // ID for the missed call notification/log entry
+        nameCaller: metadata.callerName,
+        appName: 'Telnyx Flutter Voice',
+        handle: metadata.callerNumber,
+        type: 0,
+        missedCallNotification: const NotificationParams(
+          showNotification: true,
+          isShowCallback: true,
+          subtitle: 'Missed call',
+          callbackText: 'Call back',
+        ),
+        duration: 0, 
+        extra: message.data,
+        headers: <String, dynamic>{'platform': 'flutter'},
+        android: const AndroidParams(
+          isCustomNotification: true,
+          isShowLogo: false,
+          backgroundColor: '#EF5350',
+          actionColor: '#0955fa',
+          textColor: '#ffffff',
+          incomingCallNotificationChannelName: 'Incoming Call',
+          missedCallNotificationChannelName: 'Missed Call', 
+        ),
+        ios: const IOSParams(
+          iconName: 'CallKitLogo',
+          handleType: 'generic',
+          supportsVideo: false,
+        ),
+      );
+
+      await FlutterCallkitIncoming.showMissCallNotification(callKitParams);
+      logger.i('NotificationService.showMissedCallNotification: showMissCallNotification called for UUID $missedCallEntryUuid.');
+
+    } catch (e) {
+      logger.e('NotificationService.showMissedCallNotification: Error processing missed call notification: $e');
+    }
   }
 }

--- a/lib/service/notification_service.dart
+++ b/lib/service/notification_service.dart
@@ -107,7 +107,7 @@ class NotificationService {
       await FlutterCallkitIncoming.endCall(telnyxCallId); 
       logger.i('NotificationService.showMissedCallNotification: endCall sent for ID: $telnyxCallId');
 
-      // Now, show the specific missed call notification (e.g., for system logs/recents)
+      // Now, show the specific missed call notification (e.g., for system logs / recents)
       final String missedCallEntryUuid = const Uuid().v4(); 
       logger.i('NotificationService.showMissedCallNotification: Showing missed call notification entry with UUID: $missedCallEntryUuid for original call ID: $telnyxCallId');
 

--- a/lib/service/platform_push_service.dart
+++ b/lib/service/platform_push_service.dart
@@ -1,0 +1,36 @@
+import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:logger/logger.dart';
+import 'package:telnyx_flutter_webrtc/service/push_notification_handler.dart';
+import 'package:telnyx_flutter_webrtc/service/android_push_notification_handler.dart';
+import 'package:telnyx_flutter_webrtc/service/ios_push_notification_handler.dart';
+
+/// Service locator for providing the appropriate [PushNotificationHandler]
+/// based on the current platform.
+class PlatformPushService {
+  static PushNotificationHandler? _handler;
+
+  /// Gets the singleton instance of the platform-specific [PushNotificationHandler].
+  ///
+  /// This factory method determines the platform (Android, iOS, Web)
+  /// and returns the corresponding handler implementation.
+  static PushNotificationHandler get handler {
+    _handler ??= _createHandler();
+    return _handler!;
+  }
+
+  static PushNotificationHandler _createHandler() {
+    if (kIsWeb) {
+      return WebPushNotificationHandler();
+    } else if (Platform.isAndroid) {
+      return AndroidPushNotificationHandler();
+    } else if (Platform.isIOS) {
+      return IOSPushNotificationHandler();
+    } else {
+      // Fallback for unsupported platforms, defaults to Web/No-op behavior.
+      // Consider logging a warning for unsupported platforms.
+      Logger().w('Warning: Unsupported platform for push notifications. Using WebPushNotificationHandler.');
+      return WebPushNotificationHandler();
+    }
+  }
+} 

--- a/lib/service/push_notification_handler.dart
+++ b/lib/service/push_notification_handler.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/foundation.dart';
+import 'package:logger/logger.dart';
+
+final _logger = Logger();
+
+/// Abstract class defining the contract for platform-specific push notification handling.
+abstract class PushNotificationHandler {
+  /// Initializes platform-specific push notification listeners and setup.
+  /// This is typically called once during app initialization.
+  Future<void> initialize();
+
+  /// Processes an incoming call-related push notification payload.
+  ///
+  /// This method is intended to be called when a push notification's content
+  /// indicates an incoming call that requires action (e.g., user accepts or declines
+  /// from a notification or CallKit UI).
+  ///
+  /// [payload] The raw payload data from the push notification (e.g., FCM data, CallKit extras).
+  /// [isAnswer] True if the user's action implies answering the call.
+  /// [isDecline] True if the user's action implies declining the call.
+  Future<void> processIncomingCallAction(Map<dynamic, dynamic> payload, {bool isAnswer = false, bool isDecline = false});
+
+  /// (iOS specific) Displays the native incoming call UI (CallKit).
+  /// For other platforms, this might be a no-op or log a message.
+  ///
+  /// [payload] The data needed to display the call, typically including caller name, number, call ID.
+  Future<void> displayIncomingCallUi(Map<dynamic, dynamic> payload);
+
+  /// Retrieves the platform-specific push token (FCM for Android, VoIP for iOS).
+  Future<String?> getPushToken();
+
+  /// (Android specific) Retrieves push data if the app was launched from a terminated state
+  /// by a notification tap. Returns null if no such data exists.
+  Future<Map<String, dynamic>?> getInitialPushData();
+
+  /// (Android specific) Displays a missed call notification.
+  Future<void> showMissedCallNotification(Map<dynamic, dynamic> payload);
+
+  /// Clears any stored push metadata or state.
+  /// This is often called on errors or when disconnecting to ensure a clean state.
+  void clearPushData();
+
+  /// Checks if Firebase has been initialized for the current platform context.
+  /// This is useful to avoid re-initializing Firebase unnecessarily.
+  bool isFirebaseInitialized();
+}
+
+/// Web implementation of [PushNotificationHandler].
+/// Push notifications are typically not handled in the same way on web,
+/// so most methods are no-ops or log informational messages.
+class WebPushNotificationHandler implements PushNotificationHandler {
+  @override
+  Future<void> initialize() async {
+    if (kDebugMode) {
+      _logger.i('[PushNotificationHandler-Web] Initialize: No push notification setup for web.');
+    }
+  }
+
+  @override
+  Future<void> processIncomingCallAction(Map<dynamic, dynamic> payload, {bool isAnswer = false, bool isDecline = false}) async {
+    if (kDebugMode) {
+      _logger.i('[PushNotificationHandler-Web] processIncomingCallAction: Not applicable for web. Payload: $payload, Answer: $isAnswer, Decline: $isDecline');
+    }
+  }
+
+  @override
+  Future<void> displayIncomingCallUi(Map<dynamic, dynamic> payload) async {
+    if (kDebugMode) {
+      _logger.i('[PushNotificationHandler-Web] displayIncomingCallUi: Not applicable for web. Payload: $payload');
+    }
+  }
+
+  @override
+  Future<String?> getPushToken() async {
+    if (kDebugMode) {
+      _logger.i('[PushNotificationHandler-Web] getPushToken: Not applicable for web.');
+    }
+    return null;
+  }
+
+  @override
+  Future<Map<String, dynamic>?> getInitialPushData() async {
+    if (kDebugMode) {
+      _logger.i('[PushNotificationHandler-Web] getInitialPushData: Not applicable for web.');
+    }
+    return null;
+  }
+
+  @override
+  Future<void> showMissedCallNotification(Map<dynamic, dynamic> payload) async {
+     if (kDebugMode) {
+      _logger.i('[PushNotificationHandler-Web] showMissedCallNotification: Not applicable for web. Payload $payload');
+    }
+  }
+
+  @override
+  void clearPushData() {
+    if (kDebugMode) {
+      _logger.i('[PushNotificationHandler-Web] clearPushData: Not applicable for web.');
+    }
+  }
+
+  @override
+  bool isFirebaseInitialized() {
+    // Firebase is typically initialized separately for web if needed.
+    // Or, if initialized by a central spot, this could check Firebase.apps.isNotEmpty.
+    // For this refactor, assuming web might initialize it via options in main AppInitializer if needed.
+    if (kDebugMode) {
+      _logger.i('[PushNotificationHandler-Web] isFirebaseInitialized: Returning false (web has specific init if used).');
+    }
+    return false;
+  }
+} 

--- a/lib/utils/config_helper.dart
+++ b/lib/utils/config_helper.dart
@@ -1,0 +1,80 @@
+import 'package:logger/logger.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+import 'package:telnyx_flutter_webrtc/utils/custom_sdk_logger.dart';
+
+/// A utility class to help with retrieving stored configuration.
+class ConfigHelper {
+
+  /// Retrieves stored Credential configuration from SharedPreferences.
+  /// Returns null if required fields are missing.
+  static Future<CredentialConfig?> getCredentialConfigFromPrefs() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final sipUser = prefs.getString('sipUser');
+      final sipPassword = prefs.getString('sipPassword');
+      final sipName = prefs.getString('sipName');
+      final sipNumber = prefs.getString('sipNumber');
+      final notificationToken = prefs.getString('notificationToken');
+
+      if (sipUser != null && sipPassword != null && sipName != null && sipNumber != null) {
+        return CredentialConfig(
+          sipCallerIDName: sipName,
+          sipCallerIDNumber: sipNumber,
+          sipUser: sipUser,
+          sipPassword: sipPassword,
+          notificationToken: notificationToken,
+          logLevel: LogLevel.all, 
+          customLogger: CustomSDKLogger(), 
+          debug: false,
+          reconnectionTimeout: 30000,
+        );
+      }
+    } catch (e) {
+      Logger().e('[ConfigHelper] Error reading CredentialConfig from Prefs: $e');
+    }
+    return null;
+  }
+
+  /// Retrieves stored Token configuration from SharedPreferences.
+  /// Returns null if required fields are missing.
+  static Future<TokenConfig?> getTokenConfigFromPrefs() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final token = prefs.getString('token');
+      final sipName = prefs.getString('sipName');
+      final sipNumber = prefs.getString('sipNumber');
+      final notificationToken = prefs.getString('notificationToken');
+
+      if (token != null && sipName != null && sipNumber != null) {
+        return TokenConfig(
+          sipCallerIDName: sipName,
+          sipCallerIDNumber: sipNumber,
+          sipToken: token,
+          notificationToken: notificationToken,
+          logLevel: LogLevel.all,
+          customLogger: CustomSDKLogger(),
+          debug: false,
+        );
+      }
+    } catch (e) {
+      Logger().e('[ConfigHelper] Error reading TokenConfig from Prefs: $e');
+    }
+    return null;
+  }
+  
+  /// Retrieves either Credential or Token configuration from SharedPreferences.
+  /// Prefers CredentialConfig if available.
+  /// Returns null if neither configuration can be fully retrieved.
+  static Future<Object?> getTelnyxConfigFromPrefs() async { 
+    try {
+      Object? config = await getCredentialConfigFromPrefs();
+      config ??= await getTokenConfigFromPrefs();
+      return config;
+    } catch (e) {
+      Logger().e('[ConfigHelper] Error reading TelnyxConfig from Prefs: $e');
+      return null;
+    }
+  }
+} 

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -305,7 +305,7 @@ class TelnyxClientViewModel with ChangeNotifier {
                     if (numCalls.isNotEmpty) {
                       final String? callKitId = numCalls.first['id'] as String?;
                       if (callKitId != null && callKitId.isNotEmpty) {
-                        await FlutterCallkitIncoming.endCall(callKitId);
+                         await FlutterCallkitIncoming.endCall(callKitId);
                       } else {
                         logger.w(
                             'Could not find call ID in active CallKit calls map.');

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -22,6 +22,7 @@ import 'package:telnyx_webrtc/telnyx_client.dart';
 import 'package:telnyx_webrtc/model/push_notification.dart';
 import 'package:telnyx_webrtc/model/call_state.dart';
 import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+import 'package:telnyx_flutter_webrtc/utils/config_helper.dart';
 
 enum CallStateStatus {
   disconnected,
@@ -457,60 +458,11 @@ class TelnyxClientViewModel with ChangeNotifier {
 
   bool waitingForInvite = false;
 
-  Future<Config?> getConfig() async {
-    final config = await _getCredentialConfig();
-    if (config != null) {
-      return config;
-    } else {
-      return await _getTokenConfig();
-    }
-  }
-
-  Future<CredentialConfig?> _getCredentialConfig() async {
-    final prefs = await SharedPreferences.getInstance();
-    final sipUser = prefs.getString('sipUser');
-    final sipPassword = prefs.getString('sipPassword');
-    final sipName = prefs.getString('sipName');
-    final sipNumber = prefs.getString('sipNumber');
-    final notificationToken = prefs.getString('notificationToken');
-    if (sipUser != null &&
-        sipPassword != null &&
-        sipName != null &&
-        sipNumber != null) {
-      return CredentialConfig(
-        sipCallerIDName: sipName,
-        sipCallerIDNumber: sipNumber,
-        sipUser: sipUser,
-        sipPassword: sipPassword,
-        notificationToken: notificationToken,
-        debug: false,
-        logLevel: LogLevel.all,
-        customLogger: CustomSDKLogger(),
-        reconnectionTimeout: 30000,
-      );
-    } else {
-      return null;
-    }
-  }
-
-  Future<TokenConfig?> _getTokenConfig() async {
-    final prefs = await SharedPreferences.getInstance();
-    final token = prefs.getString('token');
-    final sipName = prefs.getString('sipName');
-    final sipNumber = prefs.getString('sipNumber');
-    final notificationToken = prefs.getString('notificationToken');
-    if (token != null && sipName != null && sipNumber != null) {
-      return TokenConfig(
-        sipCallerIDName: sipName,
-        sipCallerIDNumber: sipNumber,
-        sipToken: token,
-        notificationToken: notificationToken,
-        debug: false,
-        logLevel: LogLevel.all,
-      );
-    } else {
-      return null;
-    }
+  /// Returns the stored CredentialConfig or TokenConfig, preferring Credential.
+  /// Uses [ConfigHelper] for retrieval.
+  Future<Object?> getConfig() async {
+    logger.i('[TelnyxClientViewModel] getConfig: Using ConfigHelper...');
+    return ConfigHelper.getTelnyxConfigFromPrefs();
   }
 
   Future<void> accept({

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -399,6 +399,7 @@ class TelnyxClientViewModel with ChangeNotifier {
     CredentialConfig? credentialConfig,
     TokenConfig? tokenConfig,
   ) {
+    logger.i('[iOS_PUSH_DEBUG] TelnyxClientViewModel.handlePushNotification: Called with PushMetaData: ${pushMetaData.toJson()}');
     _telnyxClient.handlePushNotification(
       pushMetaData,
       credentialConfig,
@@ -511,10 +512,10 @@ class TelnyxClientViewModel with ChangeNotifier {
     Map<dynamic, dynamic>? pushData,
   }) async {
     logger.i(
-      'Accept called. acceptFromPush: $acceptFromPush, _incomingInvite exists: ${_incomingInvite != null}, callState: $callState',
+      '[iOS_PUSH_DEBUG] TelnyxClientViewModel.accept: Called. acceptFromPush: $acceptFromPush, _incomingInvite exists: ${_incomingInvite != null}, callState: $callState. pushData: $pushData',
     );
     await FlutterCallkitIncoming.activeCalls().then((value) {
-      logger.i('${value.length} Active Calls before accept $value');
+      logger.i('[iOS_PUSH_DEBUG] TelnyxClientViewModel.accept: ${value.length} Active CallKit calls before accept $value');
     });
 
     // Prevent processing if already connecting or ongoing
@@ -549,7 +550,7 @@ class TelnyxClientViewModel with ChangeNotifier {
 
   // Private helper to contain the actual acceptance steps
   Future<void> _performAccept(IncomingInviteParams invite) async {
-    logger.i('Performing accept actions for call ${invite.callID}');
+    logger.i('[iOS_PUSH_DEBUG] TelnyxClientViewModel._performAccept: Performing accept actions for call ${invite.callID}, caller: ${invite.callerIdName}/${invite.callerIdNumber}');
     // Set state definitively before async gaps
     callState = CallStateStatus.connectingToCall;
     waitingForInvite = false; // Ensure this is reset

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -278,21 +278,21 @@ class TelnyxClient {
     CredentialConfig? credentialConfig,
     TokenConfig? tokenConfig,
   ) {
-    GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.handlePushNotification: Called. PushMetaData: ${jsonEncode(pushMetaData.toJson())}');
+    GlobalLogger().i('TelnyxClient.handlePushNotification: Called. PushMetaData: ${jsonEncode(pushMetaData.toJson())}');
     _isCallFromPush = true;
 
     if (pushMetaData.isAnswer == true) {
-      GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.handlePushNotification: _pendingAnswerFromPush will be set to true');
+      GlobalLogger().i('TelnyxClient.handlePushNotification: _pendingAnswerFromPush will be set to true');
       _pendingAnswerFromPush = true;
     } else {
-      GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.handlePushNotification: _pendingAnswerFromPush remains false');
+      GlobalLogger().i('TelnyxClient.handlePushNotification: _pendingAnswerFromPush remains false');
     }
 
     if (pushMetaData.isDecline == true) {
-      GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.handlePushNotification: _pendingDeclineFromPush will be set to true');
+      GlobalLogger().i('TelnyxClient.handlePushNotification: _pendingDeclineFromPush will be set to true');
       _pendingDeclineFromPush = true;
     } else {
-      GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.handlePushNotification: _pendingDeclineFromPush remains false');
+      GlobalLogger().i('TelnyxClient.handlePushNotification: _pendingDeclineFromPush remains false');
     }
 
     _connectWithCallBack(pushMetaData, () {
@@ -334,7 +334,7 @@ class TelnyxClient {
     PushMetaData? pushMetaData,
     OnOpenCallback openCallback,
   ) {
-    GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient._connectWithCallBack: Called. PushMetaData: ${pushMetaData?.toJson()}');
+    GlobalLogger().i('TelnyxClient._connectWithCallBack: Called. PushMetaData: ${pushMetaData?.toJson()}');
     if (pushMetaData != null) {
       _pushMetaData = pushMetaData;
     }
@@ -347,14 +347,14 @@ class TelnyxClient {
         );
       } else {
         txSocket.hostAddress = _storedHostAddress;
-        GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient._connectWithCallBack: connecting to WebSocket $_storedHostAddress');
+        GlobalLogger().i('TelnyxClient._connectWithCallBack: connecting to WebSocket $_storedHostAddress');
       }
       txSocket
         ..connect()
         ..onOpen = () {
           _closed = false;
           _connected = true;
-          GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient._connectWithCallBack (via _onOpen): Web Socket is now connected');
+          GlobalLogger().i('TelnyxClient._connectWithCallBack (via _onOpen): Web Socket is now connected');
           _onOpen();
           openCallback.call();
         }
@@ -378,7 +378,7 @@ class TelnyxClient {
     // First check if there is a custom logger set within the config - if so, we set it here
     _logger = tokenConfig.customLogger ?? DefaultLogger();
     GlobalLogger.logger = _logger;
-    GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.connectWithToken: Attempting to connect.');
+    GlobalLogger().i('TelnyxClient.connectWithToken: Attempting to connect.');
 
     // Now that a logger is set, we can set the log level
     _logger
@@ -400,7 +400,7 @@ class TelnyxClient {
         ..onOpen = () {
           _closed = false;
           _connected = true;
-          GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.connectWithToken (via _onOpen): Web Socket is now connected');
+          GlobalLogger().i('TelnyxClient.connectWithToken (via _onOpen): Web Socket is now connected');
           _onOpen();
           tokenLogin(tokenConfig);
         }
@@ -426,7 +426,7 @@ class TelnyxClient {
     // Use custom logger if provided or fallback to default.
     _logger = credentialConfig.customLogger ?? DefaultLogger();
     GlobalLogger.logger = _logger;
-    GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.connectWithCredential: Attempting to connect.');
+    GlobalLogger().i('TelnyxClient.connectWithCredential: Attempting to connect.');
 
     // Now that a logger is set, we can set the log level
     _logger
@@ -447,7 +447,7 @@ class TelnyxClient {
         ..onOpen = () {
           _closed = false;
           _connected = true;
-          GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.connectWithCredential (via _onOpen): Web Socket is now connected');
+          GlobalLogger().i('TelnyxClient.connectWithCredential (via _onOpen): Web Socket is now connected');
           _onOpen();
           credentialLogin(credentialConfig);
         }
@@ -865,7 +865,7 @@ class TelnyxClient {
 
   /// WebSocket Event Handlers
   void _onOpen() {
-    GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient._onOpen: WebSocket connected event triggered.');
+    GlobalLogger().i('TelnyxClient._onOpen: WebSocket connected event triggered.');
   }
 
   void _onClose(bool wasClean, int code, String reason) {
@@ -876,7 +876,7 @@ class TelnyxClient {
   }
 
   void _onMessage(dynamic data) async {
-    GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient._onMessage: RAW WebSocket data received: ${data?.toString()?.trim()}');
+    GlobalLogger().i('TelnyxClient._onMessage: RAW WebSocket data received: ${data?.toString()?.trim()}');
 
     if (data != null) {
       if (data.toString().trim().isNotEmpty) {

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -278,18 +278,21 @@ class TelnyxClient {
     CredentialConfig? credentialConfig,
     TokenConfig? tokenConfig,
   ) {
-    GlobalLogger().i(jsonEncode(pushMetaData));
+    GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.handlePushNotification: Called. PushMetaData: ${jsonEncode(pushMetaData.toJson())}');
     _isCallFromPush = true;
 
     if (pushMetaData.isAnswer == true) {
-      GlobalLogger().i('_pendingAnswerFromPush true');
+      GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.handlePushNotification: _pendingAnswerFromPush will be set to true');
       _pendingAnswerFromPush = true;
     } else {
-      GlobalLogger().i('_pendingAnswerFromPush false');
+      GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.handlePushNotification: _pendingAnswerFromPush remains false');
     }
 
     if (pushMetaData.isDecline == true) {
+      GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.handlePushNotification: _pendingDeclineFromPush will be set to true');
       _pendingDeclineFromPush = true;
+    } else {
+      GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.handlePushNotification: _pendingDeclineFromPush remains false');
     }
 
     _connectWithCallBack(pushMetaData, () {
@@ -331,7 +334,7 @@ class TelnyxClient {
     PushMetaData? pushMetaData,
     OnOpenCallback openCallback,
   ) {
-    GlobalLogger().i('connect() ${pushMetaData?.toJson()}');
+    GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient._connectWithCallBack: Called. PushMetaData: ${pushMetaData?.toJson()}');
     if (pushMetaData != null) {
       _pushMetaData = pushMetaData;
     }
@@ -344,14 +347,14 @@ class TelnyxClient {
         );
       } else {
         txSocket.hostAddress = _storedHostAddress;
-        GlobalLogger().i('connecting to WebSocket $_storedHostAddress');
+        GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient._connectWithCallBack: connecting to WebSocket $_storedHostAddress');
       }
       txSocket
         ..connect()
         ..onOpen = () {
           _closed = false;
           _connected = true;
-          GlobalLogger().i('Web Socket is now connected');
+          GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient._connectWithCallBack (via _onOpen): Web Socket is now connected');
           _onOpen();
           openCallback.call();
         }
@@ -375,6 +378,7 @@ class TelnyxClient {
     // First check if there is a custom logger set within the config - if so, we set it here
     _logger = tokenConfig.customLogger ?? DefaultLogger();
     GlobalLogger.logger = _logger;
+    GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.connectWithToken: Attempting to connect.');
 
     // Now that a logger is set, we can set the log level
     _logger
@@ -396,7 +400,7 @@ class TelnyxClient {
         ..onOpen = () {
           _closed = false;
           _connected = true;
-          GlobalLogger().i('Web Socket is now connected');
+          GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.connectWithToken (via _onOpen): Web Socket is now connected');
           _onOpen();
           tokenLogin(tokenConfig);
         }
@@ -422,6 +426,7 @@ class TelnyxClient {
     // Use custom logger if provided or fallback to default.
     _logger = credentialConfig.customLogger ?? DefaultLogger();
     GlobalLogger.logger = _logger;
+    GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.connectWithCredential: Attempting to connect.');
 
     // Now that a logger is set, we can set the log level
     _logger
@@ -442,7 +447,7 @@ class TelnyxClient {
         ..onOpen = () {
           _closed = false;
           _connected = true;
-          GlobalLogger().i('Web Socket is now connected');
+          GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient.connectWithCredential (via _onOpen): Web Socket is now connected');
           _onOpen();
           credentialLogin(credentialConfig);
         }
@@ -860,7 +865,7 @@ class TelnyxClient {
 
   /// WebSocket Event Handlers
   void _onOpen() {
-    GlobalLogger().i('WebSocket connected');
+    GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient._onOpen: WebSocket connected event triggered.');
   }
 
   void _onClose(bool wasClean, int code, String reason) {
@@ -871,7 +876,7 @@ class TelnyxClient {
   }
 
   void _onMessage(dynamic data) async {
-    GlobalLogger().i('DEBUG MESSAGE: ${data.toString().trim()}');
+    GlobalLogger().i('[iOS_PUSH_DEBUG] TelnyxClient._onMessage: RAW WebSocket data received: ${data?.toString()?.trim()}');
 
     if (data != null) {
       if (data.toString().trim().isNotEmpty) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,9 +12,10 @@ dependencies:
     sdk: flutter
 
   cupertino_icons: ^1.0.2
-  firebase_messaging: ^15.1.6
-  firebase_core: ^3.8.1
-  flutter_callkit_incoming: 2.0.4+2
+  firebase_messaging: ^15.2.5
+  firebase_core: ^3.13.0
+  flutter_callkit_incoming: ^2.5.2
+  flutter_local_notifications: ^19.1.0
   shared_preferences: ^2.2.3
   permission_handler: ^11.3.1
   connectivity_plus: ^6.1.0


### PR DESCRIPTION
[WEBRTC-2670 - Refactor Push Handling & Enhance Android Notifications](https://telnyx.atlassian.net/browse/WEBRTC-2670)

---
This pull request introduces a significant refactoring of the push notification handling logic to improve clarity, maintainability, and platform-specific accuracy. It also enhances Android notification reliability and user experience by implementing notification channels and improving missed/stale call handling.

## :older_man: :baby: Behaviors

### Before changes
*   Push notification logic for different platforms (Android FCM, iOS CallKit) was heavily intertwined within `main.dart` and `AppInitializer`.
*   Platform-specific checks were scattered, making the overall flow harder to follow and maintain.
*   Android notifications did not explicitly use high-importance channels, potentially leading to inconsistent heads-up behavior.
*   Handling of missed calls or stale notifications was less robust; an incoming call UI might persist even if the call was already missed or timed out.

### After changes
*   **Separation of Push Handling:**
    *   Introduced an abstract class `PushNotificationHandler` defining a common interface for push notification operations.
    *   Created platform-specific implementations: `AndroidPushNotificationHandler`, `IOSPushNotificationHandler`, and `WebPushNotificationHandler`.
    *   A `PlatformPushService` factory now provides the correct handler based on the current platform.
    *   Platform-specific initialisation (FCM listeners, CallKit event listeners) and push processing logic are now encapsulated within their respective handlers, making `main.dart` and `AppInitializer` leaner.
    *   Shared logic for processing push data once augmented with user intent (e.g., `handlePush` in `main.dart`) is still utilized by the handlers, interacting with the central `TelnyxClientViewModel`.
*   **Android Notification Channels:**
    *   `AndroidPushNotificationHandler` now creates a dedicated high-importance notification channel (`telnyx_call_channel` with `Importance.max`) using `flutter_local_notifications` during initialisation.
    *   `AndroidManifest.xml` has been updated to set this channel as the default for FCM messages, aiming to improve the consistency and prominence of incoming call notifications on Android 8.0+.
*   **Improved Missed/Stale Call Handling:**
    *   `NotificationService.showNotification` now uses the Telnyx `callId` from the push metadata as the unique identifier for `flutter_callkit_incoming`.
    *   A check for stale notifications has been added: if a notification's `sentTime` is older than `_CALL_MISSED_TIMEOUT_SECONDS`, `showMissedCallNotification` is called instead of showing the incoming call UI.
    *   `NotificationService.showMissedCallNotification` now first calls `FlutterCallkitIncoming.endCall(telnyxCallId)` using the original `callId` to ensure any active incoming call UI for that specific call is dismissed before displaying the missed call notification.
    *   The logic also explicitly checks for "Missed call!" messages within `showNotification` to prevent showing an incoming UI for a call already marked as missed.

## ✋ Manual testing
1.  **Android - App Terminated:**
    *   Send an incoming call push. Verify the call notification appears promptly with "Accept"/"Decline".
    *   Accept the call. Verify connection and audio.
    *   Send another incoming call push. Decline the call from the notification. Verify the call is declined and the notification is dismissed.
    *   Send an incoming call, wait for >30 seconds (or configured timeout), then allow the "Missed call!" push to arrive (or simulate a stale notification). Verify the incoming call UI does not appear, and a missed call notification is shown instead.
2.  **Android - App Backgrounded:**
    *   Repeat the "App Terminated" test cases.
3.  **Android - App Foreground:**
    *   Receive an incoming call. Verify it's handled via direct socket `INVITE` and the UI updates correctly (no push notification should be processed for the call itself, but `flutter_callkit_incoming` will show its UI).
    *   While a call notification is showing (from a backgrounded state, then foregrounded), if a "Missed call!" message for the *same call ID* arrives, verify the original notification is dismissed and the missed call UI is shown.
4.  **iOS - App Terminated:**
    *   Send an incoming call VoIP push. Verify CallKit UI appears.
    *   Accept the call. Verify connection and audio.
    *   Send another incoming call VoIP push. Decline the call from CallKit. Verify the call is declined.
    *   (Simulate Stale/Missed if backend supports sending "Missed Call!" push for iOS or test timeout behavior): If a call is missed/timed out, verify appropriate CallKit logging/behavior.
5.  **iOS - App Backgrounded:**
    *   Repeat the "App Terminated" test cases.
6.  **iOS - App Foreground:**
    *   Receive an incoming call. Verify CallKit UI appears and direct socket `INVITE` is handled.
7.  **General:**
    *   Verify logging in all handlers (`[PushNotificationHandler-Android]`, `[PushNotificationHandler-iOS]`, `[handlePush]`) reflects the correct flows.
    *   Test the "Logout" and "Disable Push Notifications" options to ensure they still function with the refactored config and push handling.