### PR TITLE
Fix: Outbound audio on iOS since refactor 

### DIFF
--- a/.idea/libraries/Flutter_Plugins.xml
+++ b/.idea/libraries/Flutter_Plugins.xml
@@ -2,31 +2,34 @@
   <library name="Flutter Plugins" type="FlutterPluginsLibraryType">
     <CLASSES>
       <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_web-2.4.2" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/just_audio_web-0.4.13" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/firebase_core-3.13.0" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_android-2.4.1" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_foundation-2.5.4" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/flutter_webrtc-0.13.1+hotfix.1" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/patrol-3.14.0" />
       <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/permission_handler_html-0.1.3+5" />
       <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/path_provider-2.1.5" />
       <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/path_provider_linux-2.2.1" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/path_provider_windows-2.3.0" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/permission_handler-11.3.1" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_windows-2.4.1" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_linux-2.4.1" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/firebase_core-3.10.0" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_android-2.4.1" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_foundation-2.5.4" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/firebase_messaging-15.2.5" />
       <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/connectivity_plus-6.1.2" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/fluttertoast-8.2.11" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/path_provider_windows-2.3.0" />
       <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/audio_session-0.1.23" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/firebase_core_web-2.19.0" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/firebase_messaging-15.2.0" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/firebase_messaging_web-3.10.5" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_windows-2.4.1" />
       <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/just_audio-0.9.43" />
       <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/path_provider_foundation-2.4.1" />
       <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/path_provider_android-2.2.15" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/firebase_messaging_web-3.10.0" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences-2.4.0" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/patrol-3.14.0" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_linux-2.4.1" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/flutter_local_notifications-19.2.0" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/just_audio_web-0.4.13" />
       <root url="file://$USER_HOME$/Development/flutter/packages/integration_test" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/fluttertoast-8.2.11" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/flutter_webrtc-0.13.1+hotfix.1" />
-      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/flutter_callkit_incoming-2.0.4+2" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/flutter_callkit_incoming-2.5.2" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/flutter_local_notifications_windows-1.0.0" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/firebase_core_web-2.22.0" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/flutter_local_notifications_linux-6.0.0" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences-2.4.0" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/permission_handler-11.3.1" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -8,13 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		1AA255B1BB3527ABEC1572DF /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09F13E249448D724CE73394E /* Pods_Runner.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		9F1A5F6CFFEDA21A70850003 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = A4D57EC35B129AAA761B8C7A /* GoogleService-Info.plist */; };
+		C3579C5F55CA7CA463D7DC6E /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 13EB6D63B808439FE7A38FBE /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -31,17 +31,17 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		00840219CB2060E6B0B5413E /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
-		09F13E249448D724CE73394E /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		13EB6D63B808439FE7A38FBE /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		2EFC760A2451570BFB8F02E0 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		37B49B97290170A80086DB1B /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B4E36002C349A0700444B48 /* RunnerDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RunnerDebug.entitlements; sourceTree = "<group>"; };
-		44E34500112A995500ACD91A /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
-		6D2F827D7B5E13C0B70EE270 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		62881F9CD01E3B98A21A2780 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		780491CD7D0484B06ED57C0F /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -58,7 +58,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1AA255B1BB3527ABEC1572DF /* Pods_Runner.framework in Frameworks */,
+				C3579C5F55CA7CA463D7DC6E /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -68,11 +68,19 @@
 		02D7F10D7C6F93EB207FB009 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				6D2F827D7B5E13C0B70EE270 /* Pods-Runner.debug.xcconfig */,
-				44E34500112A995500ACD91A /* Pods-Runner.release.xcconfig */,
-				00840219CB2060E6B0B5413E /* Pods-Runner.profile.xcconfig */,
+				2EFC760A2451570BFB8F02E0 /* Pods-Runner.debug.xcconfig */,
+				62881F9CD01E3B98A21A2780 /* Pods-Runner.release.xcconfig */,
+				780491CD7D0484B06ED57C0F /* Pods-Runner.profile.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		224C37A5B44DA0AD38C92126 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				13EB6D63B808439FE7A38FBE /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -94,7 +102,7 @@
 				97C146EF1CF9000F007C117D /* Products */,
 				02D7F10D7C6F93EB207FB009 /* Pods */,
 				A4D57EC35B129AAA761B8C7A /* GoogleService-Info.plist */,
-				B2AD577E331C1EDE6EAE75A0 /* Frameworks */,
+				224C37A5B44DA0AD38C92126 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -123,14 +131,6 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
-		B2AD577E331C1EDE6EAE75A0 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				09F13E249448D724CE73394E /* Pods_Runner.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -138,15 +138,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				0832AB94B6DF1FB68FCD274B /* [CP] Check Pods Manifest.lock */,
+				6262F9A469F04BF6E89972A8 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				1E2B814BDE9DDBC848EAF2A3 /* [CP] Embed Pods Frameworks */,
-				AB20DBCF037BA2DCC1A7422B /* [CP] Copy Pods Resources */,
+				8F6EE7A48A59803D7196101F /* [CP] Embed Pods Frameworks */,
+				148F45294CB9D8692221B43D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -206,7 +206,40 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0832AB94B6DF1FB68FCD274B /* [CP] Check Pods Manifest.lock */ = {
+		148F45294CB9D8692221B43D /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
+			);
+			name = "Thin Binary";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		6262F9A469F04BF6E89972A8 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -228,7 +261,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1E2B814BDE9DDBC848EAF2A3 /* [CP] Embed Pods Frameworks */ = {
+		8F6EE7A48A59803D7196101F /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -245,22 +278,6 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
-			);
-			name = "Thin Binary";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
-		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -275,23 +292,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		AB20DBCF037BA2DCC1A7422B /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -397,6 +397,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.flutterWebrtc;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -533,6 +534,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.flutterWebrtc;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -563,6 +565,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.flutterWebrtc;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -66,20 +66,23 @@ class AppInitializer {
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   logger.i(
-      '[Background Notification]. Received background message: ${message.data}');
+    '[Background Notification]. Received background message: ${message.data}',
+  );
   await androidBackgroundMessageHandler(message);
 }
 
 @pragma('vm:entry-point')
 Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized();
   await runZonedGuarded(() async {
+    WidgetsFlutterBinding.ensureInitialized();
 
     // Catch Flutter framework errors
     FlutterError.onError = (FlutterErrorDetails details) {
       FlutterError.presentError(details);
-      logger.e('Caught Flutter error: ${details.exception}',
-          stackTrace: details.stack);
+      logger.e(
+        'Caught Flutter error: ${details.exception}',
+        stackTrace: details.stack,
+      );
       PlatformPushService.handler.clearPushData();
     };
 
@@ -139,7 +142,8 @@ Future<void> handlePush(Map<dynamic, dynamic> data) async {
   logger.i('[handlePush] Before txClientViewModel.getConfig()');
   final config = await txClientViewModel.getConfig();
   logger.i(
-      '[handlePush] Created PushMetaData: ${pushMetaData?.toJson()}');
+    '[handlePush] Created PushMetaData: ${pushMetaData?.toJson()}',
+  );
   txClientViewModel
     ..handlePushNotification(
       pushMetaData!,
@@ -170,8 +174,11 @@ class _MyAppState extends State<MyApp> {
       if (data != null) {
         final Map<dynamic, dynamic> mutablePayload = Map.from(data);
         final answer = mutablePayload['isAnswer'] = true;
-        PlatformPushService.handler.processIncomingCallAction(data,
-            isAnswer: answer, isDecline: !answer);
+        PlatformPushService.handler.processIncomingCallAction(
+          data,
+          isAnswer: answer,
+          isDecline: !answer,
+        );
       } else {
         logger.i('[_MyAppState] Android: No initial push data found.');
       }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -72,8 +72,8 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 
 @pragma('vm:entry-point')
 Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await runZonedGuarded(() async {
-    WidgetsFlutterBinding.ensureInitialized();
 
     // Catch Flutter framework errors
     FlutterError.onError = (FlutterErrorDetails details) {

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -1,10 +1,7 @@
 import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_callkit_incoming/entities/android_params.dart';
 import 'package:flutter_callkit_incoming/entities/call_kit_params.dart';
-import 'package:flutter_callkit_incoming/entities/ios_params.dart';
-import 'package:flutter_callkit_incoming/entities/notification_params.dart';
 import 'package:flutter_callkit_incoming/flutter_callkit_incoming.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:logger/logger.dart';
@@ -129,7 +126,8 @@ class TelnyxClientViewModel with ChangeNotifier {
   void observeCurrentCall() {
     currentCall?.callHandler.onCallStateChanged = (CallState state) {
       logger.i(
-          '[iOS_PUSH_DEBUG] TelnyxClientViewModel.observeCurrentCall: Call State changed to :: $state for callId: ${currentCall?.callId}');
+        '[iOS_PUSH_DEBUG] TelnyxClientViewModel.observeCurrentCall: Call State changed to :: $state for callId: ${currentCall?.callId}',
+      );
       switch (state) {
         case CallState.newCall:
           logger.i('New Call');
@@ -149,22 +147,25 @@ class TelnyxClientViewModel with ChangeNotifier {
           break;
         case CallState.active:
           logger.i(
-              '[iOS_PUSH_DEBUG] TelnyxClientViewModel.observeCurrentCall: Current call is Active. Call ID: ${currentCall?.callId}');
+            '[iOS_PUSH_DEBUG] TelnyxClientViewModel.observeCurrentCall: Current call is Active. Call ID: ${currentCall?.callId}',
+          );
           if (!kIsWeb && Platform.isIOS) {
             final String? callKitKnownUuid =
                 _incomingInvite?.callID ?? currentCall?.callId;
             if (callKitKnownUuid != null && callKitKnownUuid.isNotEmpty) {
               logger.i(
-                  '[iOS_PUSH_DEBUG] TelnyxClientViewModel.observeCurrentCall: Calling FlutterCallkitIncoming.setCallConnected for UUID: $callKitKnownUuid');
+                '[iOS_PUSH_DEBUG] TelnyxClientViewModel.observeCurrentCall: Calling FlutterCallkitIncoming.setCallConnected for UUID: $callKitKnownUuid',
+              );
               FlutterCallkitIncoming.setCallConnected(callKitKnownUuid);
             } else {
               logger.w(
-                  '[iOS_PUSH_DEBUG] TelnyxClientViewModel.observeCurrentCall: Could not determine CallKit UUID to setCallConnected.');
+                '[iOS_PUSH_DEBUG] TelnyxClientViewModel.observeCurrentCall: Could not determine CallKit UUID to setCallConnected.',
+              );
             }
           }
-         currentCall?.onCallQualityChange = (metrics) {
+          currentCall?.onCallQualityChange = (metrics) {
             // Access metrics.jitter, metrics.rtt, metrics.mos, metrics.quality
-           logger.i('Call quality: ${metrics}');
+            logger.i('Call quality: ${metrics}');
             _callQualityMetrics = metrics;
             notifyListeners();
           };
@@ -274,7 +275,8 @@ class TelnyxClientViewModel with ChangeNotifier {
                 await NotificationService.showIncomingCallUi(
                   callId: _incomingInvite!.callID!,
                   callerName: _incomingInvite!.callerIdName ?? 'Unknown Caller',
-                  callerNumber: _incomingInvite!.callerIdNumber ?? 'Unknown Number',
+                  callerNumber:
+                      _incomingInvite!.callerIdNumber ?? 'Unknown Number',
                 );
                 notifyListeners();
               } else {
@@ -326,7 +328,8 @@ class TelnyxClientViewModel with ChangeNotifier {
                         await FlutterCallkitIncoming.endCall(callKitId);
                       } else {
                         logger.w(
-                            'Could not find call ID in active CallKit calls map.');
+                          'Could not find call ID in active CallKit calls map.',
+                        );
                       }
                     }
                   }
@@ -424,7 +427,8 @@ class TelnyxClientViewModel with ChangeNotifier {
     TokenConfig? tokenConfig,
   ) {
     logger.i(
-        '[iOS_PUSH_DEBUG] TelnyxClientViewModel.handlePushNotification: Called with PushMetaData: ${pushMetaData.toJson()}');
+      '[iOS_PUSH_DEBUG] TelnyxClientViewModel.handlePushNotification: Called with PushMetaData: ${pushMetaData.toJson()}',
+    );
     _telnyxClient.handlePushNotification(
       pushMetaData,
       credentialConfig,
@@ -481,7 +485,7 @@ class TelnyxClientViewModel with ChangeNotifier {
       NotificationService.startOutgoingCallNotification(
         callId: _currentCall!.callId!,
         callerName: _localName, // Or however the caller should be represented
-        handle: destination, 
+        handle: destination,
         // extra: {} // Optionally pass any extra data if needed
       );
     }
@@ -507,7 +511,8 @@ class TelnyxClientViewModel with ChangeNotifier {
     );
     await FlutterCallkitIncoming.activeCalls().then((value) {
       logger.i(
-          '[iOS_PUSH_DEBUG] TelnyxClientViewModel.accept: ${value.length} Active CallKit calls before accept $value');
+        '[iOS_PUSH_DEBUG] TelnyxClientViewModel.accept: ${value.length} Active CallKit calls before accept $value',
+      );
     });
 
     // Prevent processing if already connecting or ongoing
@@ -543,7 +548,8 @@ class TelnyxClientViewModel with ChangeNotifier {
   // Private helper to contain the actual acceptance steps
   Future<void> _performAccept(IncomingInviteParams invite) async {
     logger.i(
-        '[iOS_PUSH_DEBUG] TelnyxClientViewModel._performAccept: Performing accept actions for call ${invite.callID}, caller: ${invite.callerIdName}/${invite.callerIdNumber}');
+      '[iOS_PUSH_DEBUG] TelnyxClientViewModel._performAccept: Performing accept actions for call ${invite.callID}, caller: ${invite.callerIdName}/${invite.callerIdNumber}',
+    );
     // Set state definitively before async gaps
     callState = CallStateStatus.connectingToCall;
     waitingForInvite = false; // Ensure this is reset
@@ -562,7 +568,8 @@ class TelnyxClientViewModel with ChangeNotifier {
       if (!kIsWeb) {
         if (Platform.isIOS) {
           logger.i(
-              '[iOS_PUSH_DEBUG] TelnyxClientViewModel._performAccept: Call acceptance initiated with SDK. Waiting for CallState.active to confirm connection with CallKit.');
+            '[iOS_PUSH_DEBUG] TelnyxClientViewModel._performAccept: Call acceptance initiated with SDK. Waiting for CallState.active to confirm connection with CallKit.',
+          );
         } else if (Platform.isAndroid) {
           final CallKitParams callKitParams = CallKitParams(
             id: invite.callID,

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_callkit_incoming/entities/android_params.dart';
 import 'package:flutter_callkit_incoming/entities/call_kit_params.dart';
 import 'package:flutter_callkit_incoming/entities/ios_params.dart';
 import 'package:flutter_callkit_incoming/entities/notification_params.dart';
@@ -10,7 +11,6 @@ import 'package:logger/logger.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:telnyx_flutter_webrtc/file_logger.dart';
 import 'package:telnyx_flutter_webrtc/utils/background_detector.dart';
-import 'package:telnyx_flutter_webrtc/utils/custom_sdk_logger.dart';
 import 'package:telnyx_flutter_webrtc/utils/theme.dart';
 import 'package:telnyx_webrtc/call.dart';
 import 'package:telnyx_webrtc/config/telnyx_config.dart';
@@ -21,7 +21,6 @@ import 'package:telnyx_webrtc/model/verto/receive/received_message_body.dart';
 import 'package:telnyx_webrtc/telnyx_client.dart';
 import 'package:telnyx_webrtc/model/push_notification.dart';
 import 'package:telnyx_webrtc/model/call_state.dart';
-import 'package:telnyx_webrtc/utils/logging/log_level.dart';
 import 'package:telnyx_webrtc/model/call_quality_metrics.dart';
 import 'package:telnyx_flutter_webrtc/utils/config_helper.dart';
 
@@ -164,7 +163,7 @@ class TelnyxClientViewModel with ChangeNotifier {
           }
          currentCall?.onCallQualityChange = (metrics) {
             // Access metrics.jitter, metrics.rtt, metrics.mos, metrics.quality
-            print("Call quality: ${metrics}");
+           logger.i('Call quality: ${metrics}');
             _callQualityMetrics = metrics;
             notifyListeners();
           };
@@ -467,6 +466,50 @@ class TelnyxClientViewModel with ChangeNotifier {
       'Fake State',
       customHeaders: {'X-Header-1': 'Value1', 'X-Header-2': 'Value2'},
     );
+
+    logger.i(
+      '[iOS_PUSH_DEBUG] TelnyxClientViewModel.call: Call initiated to $destination. Call ID: ${_currentCall?.callId}',
+    );
+
+    final params = CallKitParams(
+      id: _currentCall?.callId ?? '',
+      nameCaller: _localName,
+      appName: 'Telnyx Flutter Voice',
+      handle: destination,
+      type: 0, // 0 for audio call, 1 for video call
+      textAccept: 'Accept',
+      textDecline: 'Decline',
+      duration: 30000,
+      headers: <String, dynamic>{'platform': 'flutter'},
+      android: const AndroidParams(
+        isCustomNotification: true,
+        isShowLogo: false,
+        ringtonePath: 'system_ringtone_default',
+        backgroundColor: '#0955fa',
+        actionColor: '#4CAF50',
+        textColor: '#ffffff',
+        incomingCallNotificationChannelName: 'Incoming Call',
+        missedCallNotificationChannelName: 'Missed Call',
+      ),
+      ios: const IOSParams(
+        iconName: 'CallKitLogo',
+        handleType: 'generic',
+        supportsVideo: false,
+        maximumCallGroups: 2,
+        maximumCallsPerCallGroup: 1,
+        audioSessionMode: 'default',
+        audioSessionActive: true,
+        audioSessionPreferredSampleRate: 44100.0,
+        audioSessionPreferredIOBufferDuration: 0.005,
+        supportsDTMF: true,
+        supportsHolding: true,
+        supportsGrouping: false,
+        supportsUngrouping: false,
+        ringtonePath: 'system_ringtone_default',
+      ),
+    );
+
+    FlutterCallkitIncoming.startCall(params);
     observeCurrentCall();
   }
 

--- a/packages/telnyx_webrtc/lib/call.dart
+++ b/packages/telnyx_webrtc/lib/call.dart
@@ -16,7 +16,6 @@ import 'package:telnyx_webrtc/peer/peer.dart'
 import 'package:telnyx_webrtc/tx_socket.dart'
     if (dart.library.js) 'package:telnyx_webrtc/tx_socket_web.dart';
 import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
-import 'package:telnyx_webrtc/utils/stats/webrtc_stats_reporter.dart';
 import 'package:uuid/uuid.dart';
 import 'package:just_audio/just_audio.dart';
 

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -271,7 +271,7 @@ class Peer {
       session.peerConnection?.onIceCandidate = (candidate) async {
         if (session.peerConnection != null) {
           GlobalLogger().i(
-              'Peer :: onIceCandidate in _createAnswer received: ${candidate.candidate}');
+              'Peer :: onIceCandidate in _createAnswer received: ${candidate.candidate}',);
           if (candidate.candidate != null) {
             final candidateString = candidate.candidate.toString();
             final isValidCandidate =
@@ -285,7 +285,7 @@ class Peer {
               _lastCandidateTime = DateTime.now();
             } else {
               GlobalLogger().i(
-                  'Peer :: Ignoring non-STUN/TURN candidate: $candidateString');
+                  'Peer :: Ignoring non-STUN/TURN candidate: $candidateString',);
             }
           }
         } else {
@@ -415,7 +415,7 @@ class Peer {
 
     peerConnection?.onIceCandidate = (candidate) async {
       GlobalLogger().i(
-          'Peer :: onIceCandidate in _createSession received: ${candidate.candidate}');
+          'Peer :: onIceCandidate in _createSession received: ${candidate.candidate}',);
       if (candidate.candidate != null) {
         final candidateString = candidate.candidate.toString();
         final isValidCandidate = candidateString.contains('stun.telnyx.com') ||

--- a/packages/telnyx_webrtc/lib/peer/session.dart
+++ b/packages/telnyx_webrtc/lib/peer/session.dart
@@ -1,6 +1,4 @@
 import 'package:flutter_webrtc/flutter_webrtc.dart';
-import 'package:telnyx_webrtc/model/call_quality_metrics.dart';
-import 'package:telnyx_webrtc/utils/stats/webrtc_stats_reporter.dart';
 
 /// Represents a WebRTC session.
 class Session {

--- a/packages/telnyx_webrtc/lib/peer/web/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/web/peer.dart
@@ -308,7 +308,7 @@ class Peer {
       // ICE candidate callback (with optional skipping logic)
       session.peerConnection?.onIceCandidate = (candidate) async {
         GlobalLogger().i(
-            'Web Peer :: onIceCandidate in _createAnswer received: ${candidate.candidate}');
+            'Web Peer :: onIceCandidate in _createAnswer received: ${candidate.candidate}',);
         if (candidate.candidate != null) {
           final candidateString = candidate.candidate.toString();
           final isValidCandidate =
@@ -323,7 +323,7 @@ class Peer {
             _lastCandidateTime = DateTime.now();
           } else {
             GlobalLogger().i(
-                'Web Peer :: Ignoring non-STUN/TURN candidate: $candidateString');
+                'Web Peer :: Ignoring non-STUN/TURN candidate: $candidateString',);
           }
         } else {
           GlobalLogger().i('Web Peer :: onIceCandidate: complete');
@@ -465,7 +465,7 @@ class Peer {
     pc
       ..onIceCandidate = (candidate) async {
         GlobalLogger().i(
-            'Web Peer :: onIceCandidate in _createSession received: ${candidate.candidate}');
+            'Web Peer :: onIceCandidate in _createSession received: ${candidate.candidate}',);
         if (candidate.candidate != null) {
           final candidateString = candidate.candidate.toString();
           final isValidCandidate =
@@ -479,7 +479,7 @@ class Peer {
             await pc.addCandidate(candidate);
           } else {
             GlobalLogger().i(
-                'Web Peer :: Ignoring non-STUN/TURN candidate: $candidateString');
+                'Web Peer :: Ignoring non-STUN/TURN candidate: $candidateString',);
           }
         } else {
           GlobalLogger().i('Web Peer :: onIceCandidate: complete');

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -897,7 +897,7 @@ class TelnyxClient {
   }
 
   void _onMessage(dynamic data) async {
-    GlobalLogger().i('TelnyxClient._onMessage: RAW WebSocket data received: ${data?.toString()?.trim()}');
+    GlobalLogger().i('TelnyxClient._onMessage: RAW WebSocket data received: ${data?.toString().trim()}');
 
     if (data != null) {
       if (data.toString().trim().isNotEmpty) {

--- a/packages/telnyx_webrtc/lib/utils/stats/webrtc_stats_reporter.dart
+++ b/packages/telnyx_webrtc/lib/utils/stats/webrtc_stats_reporter.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:ffi';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:telnyx_webrtc/model/call_quality.dart';
 import 'package:telnyx_webrtc/model/call_quality_metrics.dart';


### PR DESCRIPTION
[WEBRTC-2695 - Fix: Outbound audio on iOS since refactor .](https://telnyx.atlassian.net/browse/WEBRTC-2695)

---
<!-- Describe your changes here -->

## :older_man: :baby: Behaviors
### Before changes
- A lot of duplication of the CallKatParams and notification showing lofic
- Outbound calls made on iOS, where the iOS device was the invitor, would cause there to be no outbound audio

### After changes
- Callkit param creation is centralized and reused and all methods used to handle call notifications occur in the notification_service
- We now call startCall() when an invite is made, with params from the above mentioned centralized notification_service.dart.

This works because in AppDelegate.swift we explicitly disable the audio session, however this gets reenabled via the call params used in flutter_callkit_incoming via these params:

`    ios: const IOSParams(
      iconName: 'CallKitLogo',
      handleType: 'generic',
      supportsVideo: false,
      maximumCallGroups: 2,
      maximumCallsPerCallGroup: 1,
      audioSessionMode: 'default',
      audioSessionActive: true,
      audioSessionPreferredSampleRate: 44100.0,
      audioSessionPreferredIOBufferDuration: 0.005,
      supportsDTMF: true,
      supportsHolding: true,
      supportsGrouping: false,
      supportsUngrouping: false,
      ringtonePath: 'system_ringtone_default',
    ),`
    
    Specifically the audio session params. This is why inbound was working, because these params are used to show the notification. 
    
    now that we do a startCall with these params, instead of just connecting, we are using these params to enable audio again. 

## ✋ Manual testing
1. Log in on iOS
2. Send invite and make sure there is 2 way audio
3. Receive invite and make sure there is 2 way audio 
