### PR TITLE
WEBRTC-2712: Improve SDK Error Handling Documentation - Add Error Constants Table

### DIFF
--- a/docs-markdown/error-handling/ErrorHandling.md
+++ b/docs-markdown/error-handling/ErrorHandling.md
@@ -1,5 +1,18 @@
 This document describes the error handling mechanisms in the Telnyx WebRTC Flutter SDK, specifically focusing on when and why error events are triggered and how they are processed through the SDK.
 
+## Error Constants Table
+
+The following table lists all error constants used in the SDK:
+
+| Error Message | Error Code | Description |
+| ------------- | ---------- | ----------- |
+| Token registration error | -32000 | Error during token registration |
+| Credential registration error | -32001 | Error during credential registration |
+| Codec error | -32002 | Error related to codec operation |
+| Gateway registration timeout | -32003 | Gateway registration timed out |
+| Gateway registration failed | -32004 | Gateway registration failed |
+| Call not found | N/A | The specified call cannot be found |
+
 ## Error Handling Architecture
 
 The Flutter SDK implements a structured approach to error handling through several key components:


### PR DESCRIPTION
## Description

This PR adds a table of error constants to the existing error handling documentation for the Flutter WebRTC SDK.

## Changes

* Added a new 'Error Constants Table' section to the ErrorHandling.md file
* The table includes all error messages, codes, and descriptions from the TelnyxErrorConstants class
* Formatted according to the requirements in the Jira ticket

## Jira Ticket

[WEBRTC-2712](https://telnyx.atlassian.net/WEBRTC/WEBRTC-2712)

## Related

* Requested by Doximity to improve error handling documentation
* [Slack Thread](https://telnyx.slack.com/archives/CM7AYEY78/p1747244074977409)