### PR TITLE
[ENGDESK-42685] - Fix speakerphone default state to false

### DIFF
--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -42,7 +42,7 @@ class TelnyxClientViewModel with ChangeNotifier {
   bool _registered = false;
   bool _loggingIn = false;
   bool callFromPush = false;
-  bool _speakerPhone = true;
+  bool _speakerPhone = false;
   bool _mute = false;
   bool _hold = false;
 


### PR DESCRIPTION
**[ENGDESK-42685 - Audio set to LoudSpeaker by default](https://telnyx.atlassian.net/browse/ENGDESK-42685)**

---

This PR fixes an issue where the speakerphone was enabled by default for all calls on Android, causing customer complaints about unexpected loudspeaker activation.

## :older_man: :baby: Behaviors

### Before changes
- Speakerphone was initialized to `true` by default in `TelnyxClientViewModel`
- All calls would start with speakerphone enabled, especially noticeable on Android
- Users had to manually disable speakerphone for each call

### After changes  
- Speakerphone is now initialized to `false` by default
- Calls start with normal audio routing (earpiece/headphones)
- Users can manually enable speakerphone when needed using the UI toggle

## ✋ Manual testing
1. Make an outbound call and verify speakerphone is disabled by default
2. Receive an incoming call and verify speakerphone is disabled by default  
3. Toggle speakerphone on/off during a call to ensure functionality still works
4. Test on both Android and iOS to ensure consistent behavior

## 🔧 Technical Details
- **File changed**: `lib/view/telnyx_client_view_model.dart`
- **Line 45**: Changed `bool _speakerPhone = true;` to `bool _speakerPhone = false;`
- **Impact**: Minimal change with significant UX improvement
- **Backward compatibility**: Maintained - existing speakerphone toggle functionality unchanged