### PR TITLE
[WEBRTC-2908] - Fix flutter_callkit_incoming crash on ongoing service creation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,14 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        
+        <!-- OngoingNotificationService for flutter_callkit_incoming -->
+        <service
+            android:name="com.hiennv.flutter_callkit_incoming.OngoingNotificationService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="phoneCall|microphone" />
+        
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/lib/service/android_push_notification_handler.dart
+++ b/lib/service/android_push_notification_handler.dart
@@ -333,6 +333,14 @@ class AndroidPushNotificationHandler implements PushNotificationHandler {
           txClientViewModel.endCall();
           break;
 
+        case Event.actionCallStart:
+          _logger.i(
+            '[PushNotificationHandler-Android] actionCallStart: Outgoing call started event from CallKit.',
+          );
+          // This event is triggered when an outgoing call is initiated
+          // No specific action needed here as the call is already being handled by the view model
+          break;
+
         default:
           _logger.i(
             '[PushNotificationHandler-Android] Unhandled CallKit event in foreground: ${event.event}',


### PR DESCRIPTION
[WEBRTC-2908 - Fix flutter_callkit_incoming crash on ongoing service creation](https://telnyx.atlassian.net/browse/WEBRTC-2908)

---

This PR fixes a crash that occurs when making outbound calls with the new version of flutter_callkit_incoming (2.5.2). The crash was caused by missing foreground service declarations and unhandled CallKit events.

## :older_man: :baby: Behaviors
### Before changes
- App crashes when making outbound calls with error: `foregroundServiceType 0x00000084 is not a subset of foregroundServiceType attribute 0x00000004`
- Unhandled CallKit event logs for `Event.actionCallStart`
- OngoingNotificationService not declared in AndroidManifest.xml

### After changes
- OngoingNotificationService properly declared with `phoneCall|microphone` foreground service types
- Event.actionCallStart is handled gracefully in the Android push notification handler
- No more crashes when initiating outbound calls
- Clean logging without unhandled event warnings

## ✋ Manual testing
1. Build and run the Flutter sample app on an Android device
2. Make an outbound call
3. Verify no crash occurs during call initiation
4. Check logs to ensure Event.actionCallStart is handled properly
5. Verify ongoing call notification service works correctly

## Technical Details
- Added OngoingNotificationService declaration to AndroidManifest.xml with proper foreground service types
- Added Event.actionCallStart case handler in android_push_notification_handler.dart
- Follows existing code patterns and logging conventions