### PR TITLE
WEBRTC-2937: Unit tests for widget package (for CI)

### DIFF
--- a/packages/telnyx_webrtc/test/audio_codec_test.dart
+++ b/packages/telnyx_webrtc/test/audio_codec_test.dart
@@ -18,10 +18,7 @@ void main() {
     });
 
     test('should create AudioCodec with minimal properties', () {
-      const codec = AudioCodec(
-        mimeType: 'audio/PCMU',
-        clockRate: 8000,
-      );
+      const codec = AudioCodec(mimeType: 'audio/PCMU', clockRate: 8000);
 
       expect(codec.mimeType, equals('audio/PCMU'));
       expect(codec.clockRate, equals(8000));
@@ -40,29 +37,22 @@ void main() {
       final json = codec.toJson();
 
       expect(
-          json,
-          equals({
-            'mimeType': 'audio/opus',
-            'clockRate': 48000,
-            'channels': 2,
-            'sdpFmtpLine': 'minptime=10;useinbandfec=1',
-          }));
+        json,
+        equals({
+          'mimeType': 'audio/opus',
+          'clockRate': 48000,
+          'channels': 2,
+          'sdpFmtpLine': 'minptime=10;useinbandfec=1',
+        }),
+      );
     });
 
     test('should serialize to JSON with null values omitted', () {
-      const codec = AudioCodec(
-        mimeType: 'audio/PCMU',
-        clockRate: 8000,
-      );
+      const codec = AudioCodec(mimeType: 'audio/PCMU', clockRate: 8000);
 
       final json = codec.toJson();
 
-      expect(
-          json,
-          equals({
-            'mimeType': 'audio/PCMU',
-            'clockRate': 8000,
-          }));
+      expect(json, equals({'mimeType': 'audio/PCMU', 'clockRate': 8000}));
       expect(json.containsKey('channels'), isFalse);
       expect(json.containsKey('sdpFmtpLine'), isFalse);
     });
@@ -84,10 +74,7 @@ void main() {
     });
 
     test('should deserialize from JSON with missing optional fields', () {
-      final json = {
-        'mimeType': 'audio/PCMU',
-        'clockRate': 8000,
-      };
+      final json = {'mimeType': 'audio/PCMU', 'clockRate': 8000};
 
       final codec = AudioCodec.fromJson(json);
 
@@ -110,10 +97,7 @@ void main() {
         channels: 2,
       );
 
-      const codec3 = AudioCodec(
-        mimeType: 'audio/PCMU',
-        clockRate: 8000,
-      );
+      const codec3 = AudioCodec(mimeType: 'audio/PCMU', clockRate: 8000);
 
       expect(codec1, equals(codec2));
       expect(codec1, isNot(equals(codec3)));

--- a/packages/telnyx_webrtc/test/call_state_test.dart
+++ b/packages/telnyx_webrtc/test/call_state_test.dart
@@ -1,0 +1,190 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:telnyx_webrtc/model/call_state.dart';
+import 'package:telnyx_webrtc/model/network_reason.dart';
+import 'package:telnyx_webrtc/model/call_termination_reason.dart';
+
+void main() {
+  group('CallState', () {
+    test('should have all expected enum values', () {
+      expect(CallState.values, hasLength(8));
+      expect(CallState.values, contains(CallState.newCall));
+      expect(CallState.values, contains(CallState.connecting));
+      expect(CallState.values, contains(CallState.ringing));
+      expect(CallState.values, contains(CallState.active));
+      expect(CallState.values, contains(CallState.held));
+      expect(CallState.values, contains(CallState.reconnecting));
+      expect(CallState.values, contains(CallState.dropped));
+      expect(CallState.values, contains(CallState.done));
+      expect(CallState.values, contains(CallState.error));
+    });
+
+    test('should correctly identify active state', () {
+      expect(CallState.active.isActive, isTrue);
+      expect(CallState.newCall.isActive, isFalse);
+      expect(CallState.connecting.isActive, isFalse);
+      expect(CallState.ringing.isActive, isFalse);
+      expect(CallState.held.isActive, isFalse);
+      expect(CallState.reconnecting.isActive, isFalse);
+      expect(CallState.dropped.isActive, isFalse);
+      expect(CallState.done.isActive, isFalse);
+      expect(CallState.error.isActive, isFalse);
+    });
+
+    test('should correctly identify reconnecting state', () {
+      expect(CallState.reconnecting.isReconnecting, isTrue);
+      expect(CallState.newCall.isReconnecting, isFalse);
+      expect(CallState.connecting.isReconnecting, isFalse);
+      expect(CallState.ringing.isReconnecting, isFalse);
+      expect(CallState.active.isReconnecting, isFalse);
+      expect(CallState.held.isReconnecting, isFalse);
+      expect(CallState.dropped.isReconnecting, isFalse);
+      expect(CallState.done.isReconnecting, isFalse);
+      expect(CallState.error.isReconnecting, isFalse);
+    });
+
+    test('should correctly identify dropped state', () {
+      expect(CallState.dropped.isDropped, isTrue);
+      expect(CallState.newCall.isDropped, isFalse);
+      expect(CallState.connecting.isDropped, isFalse);
+      expect(CallState.ringing.isDropped, isFalse);
+      expect(CallState.active.isDropped, isFalse);
+      expect(CallState.held.isDropped, isFalse);
+      expect(CallState.reconnecting.isDropped, isFalse);
+      expect(CallState.done.isDropped, isFalse);
+      expect(CallState.error.isDropped, isFalse);
+    });
+
+    test('should correctly identify done state', () {
+      expect(CallState.done.isDone, isTrue);
+      expect(CallState.newCall.isDone, isFalse);
+      expect(CallState.connecting.isDone, isFalse);
+      expect(CallState.ringing.isDone, isFalse);
+      expect(CallState.active.isDone, isFalse);
+      expect(CallState.held.isDone, isFalse);
+      expect(CallState.reconnecting.isDone, isFalse);
+      expect(CallState.dropped.isDone, isFalse);
+      expect(CallState.error.isDone, isFalse);
+    });
+
+    group('withNetworkReason', () {
+      test('should set network reason for reconnecting state', () {
+        final state = CallState.reconnecting.withNetworkReason(
+          NetworkReason.networkSwitch,
+        );
+        expect(state.networkReason, equals(NetworkReason.networkSwitch));
+      });
+
+      test('should set network reason for dropped state', () {
+        final state = CallState.dropped.withNetworkReason(
+          NetworkReason.networkLost,
+        );
+        expect(state.networkReason, equals(NetworkReason.networkLost));
+      });
+
+      test('should throw StateError for invalid states', () {
+        expect(
+          () =>
+              CallState.newCall.withNetworkReason(NetworkReason.networkSwitch),
+          throwsStateError,
+        );
+        expect(
+          () => CallState.connecting.withNetworkReason(
+            NetworkReason.networkSwitch,
+          ),
+          throwsStateError,
+        );
+        expect(
+          () =>
+              CallState.ringing.withNetworkReason(NetworkReason.networkSwitch),
+          throwsStateError,
+        );
+        expect(
+          () => CallState.active.withNetworkReason(NetworkReason.networkSwitch),
+          throwsStateError,
+        );
+        expect(
+          () => CallState.held.withNetworkReason(NetworkReason.networkSwitch),
+          throwsStateError,
+        );
+        expect(
+          () => CallState.done.withNetworkReason(NetworkReason.networkSwitch),
+          throwsStateError,
+        );
+        expect(
+          () => CallState.error.withNetworkReason(NetworkReason.networkSwitch),
+          throwsStateError,
+        );
+      });
+    });
+
+    group('withTerminationReason', () {
+      test('should set termination reason for done state', () {
+        const reason = CallTerminationReason(cause: 'USER_BUSY', sipCode: 486);
+        final state = CallState.done.withTerminationReason(reason);
+        expect(state.terminationReason, equals(reason));
+      });
+
+      test('should set null termination reason for done state', () {
+        final state = CallState.done.withTerminationReason(null);
+        expect(state.terminationReason, isNull);
+      });
+
+      test('should throw StateError for invalid states', () {
+        const reason = CallTerminationReason(cause: 'USER_BUSY', sipCode: 486);
+        expect(
+          () => CallState.newCall.withTerminationReason(reason),
+          throwsStateError,
+        );
+        expect(
+          () => CallState.connecting.withTerminationReason(reason),
+          throwsStateError,
+        );
+        expect(
+          () => CallState.ringing.withTerminationReason(reason),
+          throwsStateError,
+        );
+        expect(
+          () => CallState.active.withTerminationReason(reason),
+          throwsStateError,
+        );
+        expect(
+          () => CallState.held.withTerminationReason(reason),
+          throwsStateError,
+        );
+        expect(
+          () => CallState.reconnecting.withTerminationReason(reason),
+          throwsStateError,
+        );
+        expect(
+          () => CallState.dropped.withTerminationReason(reason),
+          throwsStateError,
+        );
+        expect(
+          () => CallState.error.withTerminationReason(reason),
+          throwsStateError,
+        );
+      });
+    });
+
+    test('should return null network reason for states without reason', () {
+      expect(CallState.newCall.networkReason, isNull);
+      expect(CallState.connecting.networkReason, isNull);
+      expect(CallState.ringing.networkReason, isNull);
+      expect(CallState.active.networkReason, isNull);
+      expect(CallState.held.networkReason, isNull);
+      expect(CallState.done.networkReason, isNull);
+      expect(CallState.error.networkReason, isNull);
+    });
+
+    test('should return null termination reason for states without reason', () {
+      expect(CallState.newCall.terminationReason, isNull);
+      expect(CallState.connecting.terminationReason, isNull);
+      expect(CallState.ringing.terminationReason, isNull);
+      expect(CallState.active.terminationReason, isNull);
+      expect(CallState.held.terminationReason, isNull);
+      expect(CallState.reconnecting.terminationReason, isNull);
+      expect(CallState.dropped.terminationReason, isNull);
+      expect(CallState.error.terminationReason, isNull);
+    });
+  });
+}

--- a/packages/telnyx_webrtc/test/call_termination_reason_test.dart
+++ b/packages/telnyx_webrtc/test/call_termination_reason_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:telnyx_webrtc/model/call_termination_reason.dart';
+
+void main() {
+  group('CallTerminationReason', () {
+    test('should create CallTerminationReason with all parameters', () {
+      const reason = CallTerminationReason(
+        cause: 'CALL_REJECTED',
+        causeCode: 21,
+        sipCode: 403,
+        sipReason: 'Dialed number is not included in whitelisted countries',
+      );
+
+      expect(reason.cause, equals('CALL_REJECTED'));
+      expect(reason.causeCode, equals(21));
+      expect(reason.sipCode, equals(403));
+      expect(
+        reason.sipReason,
+        equals('Dialed number is not included in whitelisted countries'),
+      );
+    });
+
+    test('should create CallTerminationReason with minimal parameters', () {
+      const reason = CallTerminationReason();
+
+      expect(reason.cause, isNull);
+      expect(reason.causeCode, isNull);
+      expect(reason.sipCode, isNull);
+      expect(reason.sipReason, isNull);
+    });
+
+    test('should create CallTerminationReason with partial parameters', () {
+      const reason = CallTerminationReason(
+        sipCode: 404,
+        sipReason: 'Not Found',
+      );
+
+      expect(reason.cause, isNull);
+      expect(reason.causeCode, isNull);
+      expect(reason.sipCode, equals(404));
+      expect(reason.sipReason, equals('Not Found'));
+    });
+
+    group('toString', () {
+      test('should format string with SIP code and reason', () {
+        const reason = CallTerminationReason(
+          sipCode: 403,
+          sipReason: 'Forbidden',
+        );
+
+        expect(reason.toString(), equals('SIP 403: Forbidden'));
+      });
+
+      test(
+        'should format string with SIP code and cause when no SIP reason',
+        () {
+          const reason = CallTerminationReason(
+            cause: 'CALL_REJECTED',
+            sipCode: 403,
+          );
+
+          expect(reason.toString(), equals('SIP 403: CALL_REJECTED'));
+        },
+      );
+
+      test(
+        'should format string with only SIP code when no reason or cause',
+        () {
+          const reason = CallTerminationReason(sipCode: 404);
+
+          expect(reason.toString(), equals('SIP 404'));
+        },
+      );
+
+      test('should format string with cause when no SIP code', () {
+        const reason = CallTerminationReason(cause: 'NETWORK_ERROR');
+
+        expect(reason.toString(), equals('NETWORK_ERROR'));
+      });
+
+      test('should return "Unknown reason" when all fields are null', () {
+        const reason = CallTerminationReason();
+
+        expect(reason.toString(), equals('Unknown reason'));
+      });
+
+      test('should return "Unknown reason" when all fields are empty', () {
+        const reason = CallTerminationReason(cause: '', sipReason: '');
+
+        expect(reason.toString(), equals('Unknown reason'));
+      });
+
+      test('should prefer SIP reason over cause when both are present', () {
+        const reason = CallTerminationReason(
+          cause: 'CALL_REJECTED',
+          sipCode: 403,
+          sipReason: 'Forbidden Access',
+        );
+
+        expect(reason.toString(), equals('SIP 403: Forbidden Access'));
+      });
+
+      test('should handle empty SIP reason and fall back to cause', () {
+        const reason = CallTerminationReason(
+          cause: 'TIMEOUT',
+          sipCode: 408,
+          sipReason: '',
+        );
+
+        expect(reason.toString(), equals('SIP 408: TIMEOUT'));
+      });
+
+      test('should handle complex real-world scenarios', () {
+        const reason1 = CallTerminationReason(
+          cause: 'CALL_REJECTED',
+          causeCode: 21,
+          sipCode: 403,
+          sipReason: 'Dialed number is not included in whitelisted countries',
+        );
+
+        expect(
+          reason1.toString(),
+          equals(
+            'SIP 403: Dialed number is not included in whitelisted countries',
+          ),
+        );
+
+        const reason2 = CallTerminationReason(
+          cause: 'USER_BUSY',
+          causeCode: 17,
+          sipCode: 486,
+          sipReason: 'Busy Here',
+        );
+
+        expect(reason2.toString(), equals('SIP 486: Busy Here'));
+      });
+    });
+  });
+}

--- a/packages/telnyx_webrtc/test/gateway_state_test.dart
+++ b/packages/telnyx_webrtc/test/gateway_state_test.dart
@@ -1,0 +1,194 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:telnyx_webrtc/model/gateway_state.dart';
+
+void main() {
+  group('GatewayState', () {
+    test('should have all expected state constants', () {
+      expect(GatewayState.unreged, equals('UNREGED'));
+      expect(GatewayState.trying, equals('TRYING'));
+      expect(GatewayState.register, equals('REGISTER'));
+      expect(GatewayState.reged, equals('REGED'));
+      expect(GatewayState.unregister, equals('UNREGISTER'));
+      expect(GatewayState.attached, equals('ATTACHED'));
+      expect(GatewayState.failed, equals('FAILED'));
+      expect(GatewayState.failWait, equals('FAIL_WAIT'));
+      expect(GatewayState.expired, equals('EXPIRED'));
+      expect(GatewayState.noreg, equals('NOREG'));
+      expect(GatewayState.idle, equals('IDLE'));
+    });
+
+    test('should be usable in switch statements', () {
+      String getStateDescription(String state) {
+        switch (state) {
+          case GatewayState.unreged:
+            return 'Gateway is unregistered';
+          case GatewayState.trying:
+            return 'Gateway is trying to register';
+          case GatewayState.register:
+            return 'Gateway is registering';
+          case GatewayState.reged:
+            return 'Gateway is registered';
+          case GatewayState.unregister:
+            return 'Gateway is unregistering';
+          case GatewayState.attached:
+            return 'Gateway is attached';
+          case GatewayState.failed:
+            return 'Gateway registration failed';
+          case GatewayState.failWait:
+            return 'Gateway is waiting after failure';
+          case GatewayState.expired:
+            return 'Gateway registration expired';
+          case GatewayState.noreg:
+            return 'Gateway has no registration';
+          case GatewayState.idle:
+            return 'Gateway is idle';
+          default:
+            return 'Unknown gateway state';
+        }
+      }
+
+      expect(
+        getStateDescription(GatewayState.unreged),
+        equals('Gateway is unregistered'),
+      );
+      expect(
+        getStateDescription(GatewayState.trying),
+        equals('Gateway is trying to register'),
+      );
+      expect(
+        getStateDescription(GatewayState.register),
+        equals('Gateway is registering'),
+      );
+      expect(
+        getStateDescription(GatewayState.reged),
+        equals('Gateway is registered'),
+      );
+      expect(
+        getStateDescription(GatewayState.unregister),
+        equals('Gateway is unregistering'),
+      );
+      expect(
+        getStateDescription(GatewayState.attached),
+        equals('Gateway is attached'),
+      );
+      expect(
+        getStateDescription(GatewayState.failed),
+        equals('Gateway registration failed'),
+      );
+      expect(
+        getStateDescription(GatewayState.failWait),
+        equals('Gateway is waiting after failure'),
+      );
+      expect(
+        getStateDescription(GatewayState.expired),
+        equals('Gateway registration expired'),
+      );
+      expect(
+        getStateDescription(GatewayState.noreg),
+        equals('Gateway has no registration'),
+      );
+      expect(getStateDescription(GatewayState.idle), equals('Gateway is idle'));
+      expect(getStateDescription('UNKNOWN'), equals('Unknown gateway state'));
+    });
+
+    test('should be usable in collections', () {
+      final allStates = [
+        GatewayState.unreged,
+        GatewayState.trying,
+        GatewayState.register,
+        GatewayState.reged,
+        GatewayState.unregister,
+        GatewayState.attached,
+        GatewayState.failed,
+        GatewayState.failWait,
+        GatewayState.expired,
+        GatewayState.noreg,
+        GatewayState.idle,
+      ];
+
+      expect(allStates, hasLength(11));
+      expect(allStates, contains(GatewayState.unreged));
+      expect(allStates, contains(GatewayState.trying));
+      expect(allStates, contains(GatewayState.register));
+      expect(allStates, contains(GatewayState.reged));
+      expect(allStates, contains(GatewayState.unregister));
+      expect(allStates, contains(GatewayState.attached));
+      expect(allStates, contains(GatewayState.failed));
+      expect(allStates, contains(GatewayState.failWait));
+      expect(allStates, contains(GatewayState.expired));
+      expect(allStates, contains(GatewayState.noreg));
+      expect(allStates, contains(GatewayState.idle));
+    });
+
+    test('should be usable as map keys', () {
+      final stateMap = <String, bool>{
+        GatewayState.unreged: false,
+        GatewayState.trying: false,
+        GatewayState.register: false,
+        GatewayState.reged: true,
+        GatewayState.unregister: false,
+        GatewayState.attached: true,
+        GatewayState.failed: false,
+        GatewayState.failWait: false,
+        GatewayState.expired: false,
+        GatewayState.noreg: false,
+        GatewayState.idle: false,
+      };
+
+      expect(stateMap[GatewayState.unreged], isFalse);
+      expect(stateMap[GatewayState.trying], isFalse);
+      expect(stateMap[GatewayState.register], isFalse);
+      expect(stateMap[GatewayState.reged], isTrue);
+      expect(stateMap[GatewayState.unregister], isFalse);
+      expect(stateMap[GatewayState.attached], isTrue);
+      expect(stateMap[GatewayState.failed], isFalse);
+      expect(stateMap[GatewayState.failWait], isFalse);
+      expect(stateMap[GatewayState.expired], isFalse);
+      expect(stateMap[GatewayState.noreg], isFalse);
+      expect(stateMap[GatewayState.idle], isFalse);
+    });
+
+    test('should identify successful states', () {
+      final successfulStates = [GatewayState.reged, GatewayState.attached];
+      final failureStates = [
+        GatewayState.unreged,
+        GatewayState.failed,
+        GatewayState.expired,
+        GatewayState.failWait,
+      ];
+
+      for (final state in successfulStates) {
+        expect(
+          state == GatewayState.reged || state == GatewayState.attached,
+          isTrue,
+        );
+      }
+
+      for (final state in failureStates) {
+        expect(
+          state == GatewayState.reged || state == GatewayState.attached,
+          isFalse,
+        );
+      }
+    });
+
+    test('should identify transitional states', () {
+      final transitionalStates = [
+        GatewayState.trying,
+        GatewayState.register,
+        GatewayState.unregister,
+      ];
+
+      for (final state in transitionalStates) {
+        expect(
+          [
+            GatewayState.trying,
+            GatewayState.register,
+            GatewayState.unregister,
+          ].contains(state),
+          isTrue,
+        );
+      }
+    });
+  });
+}

--- a/packages/telnyx_webrtc/test/network_reason_test.dart
+++ b/packages/telnyx_webrtc/test/network_reason_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:telnyx_webrtc/model/network_reason.dart';
+
+void main() {
+  group('NetworkReason', () {
+    test('should have all expected enum values', () {
+      expect(NetworkReason.values, hasLength(4));
+      expect(NetworkReason.values, contains(NetworkReason.networkSwitch));
+      expect(NetworkReason.values, contains(NetworkReason.networkLost));
+      expect(NetworkReason.values, contains(NetworkReason.airplaneMode));
+      expect(NetworkReason.values, contains(NetworkReason.serverError));
+    });
+
+    test('should have correct messages for each enum value', () {
+      expect(NetworkReason.networkSwitch.message, equals('Network switched'));
+      expect(NetworkReason.networkLost.message, equals('Network lost'));
+      expect(
+        NetworkReason.airplaneMode.message,
+        equals('Airplane mode enabled'),
+      );
+      expect(NetworkReason.serverError.message, equals('Server error'));
+    });
+
+    test('should be able to compare enum values', () {
+      expect(NetworkReason.networkSwitch, equals(NetworkReason.networkSwitch));
+      expect(NetworkReason.networkLost, equals(NetworkReason.networkLost));
+      expect(NetworkReason.airplaneMode, equals(NetworkReason.airplaneMode));
+      expect(NetworkReason.serverError, equals(NetworkReason.serverError));
+
+      expect(
+        NetworkReason.networkSwitch,
+        isNot(equals(NetworkReason.networkLost)),
+      );
+      expect(
+        NetworkReason.networkLost,
+        isNot(equals(NetworkReason.airplaneMode)),
+      );
+      expect(
+        NetworkReason.airplaneMode,
+        isNot(equals(NetworkReason.serverError)),
+      );
+    });
+
+    test('should have consistent toString behavior', () {
+      expect(NetworkReason.networkSwitch.toString(), contains('networkSwitch'));
+      expect(NetworkReason.networkLost.toString(), contains('networkLost'));
+      expect(NetworkReason.airplaneMode.toString(), contains('airplaneMode'));
+      expect(NetworkReason.serverError.toString(), contains('serverError'));
+    });
+
+    test('should be usable in switch statements', () {
+      String getDescription(NetworkReason reason) {
+        switch (reason) {
+          case NetworkReason.networkSwitch:
+            return 'The network connection has been switched';
+          case NetworkReason.networkLost:
+            return 'The network connection has been lost';
+          case NetworkReason.airplaneMode:
+            return 'Airplane mode has been enabled';
+          case NetworkReason.serverError:
+            return 'A server error has occurred';
+        }
+      }
+
+      expect(
+        getDescription(NetworkReason.networkSwitch),
+        equals('The network connection has been switched'),
+      );
+      expect(
+        getDescription(NetworkReason.networkLost),
+        equals('The network connection has been lost'),
+      );
+      expect(
+        getDescription(NetworkReason.airplaneMode),
+        equals('Airplane mode has been enabled'),
+      );
+      expect(
+        getDescription(NetworkReason.serverError),
+        equals('A server error has occurred'),
+      );
+    });
+
+    test('should be usable in collections', () {
+      final reasons = <NetworkReason>[
+        NetworkReason.networkSwitch,
+        NetworkReason.networkLost,
+        NetworkReason.airplaneMode,
+        NetworkReason.serverError,
+      ];
+
+      expect(reasons, hasLength(4));
+      expect(reasons, contains(NetworkReason.networkSwitch));
+      expect(reasons, contains(NetworkReason.networkLost));
+      expect(reasons, contains(NetworkReason.airplaneMode));
+      expect(reasons, contains(NetworkReason.serverError));
+    });
+
+    test('should be usable as map keys', () {
+      final reasonMap = <NetworkReason, String>{
+        NetworkReason.networkSwitch: 'switch',
+        NetworkReason.networkLost: 'lost',
+        NetworkReason.airplaneMode: 'airplane',
+        NetworkReason.serverError: 'error',
+      };
+
+      expect(reasonMap[NetworkReason.networkSwitch], equals('switch'));
+      expect(reasonMap[NetworkReason.networkLost], equals('lost'));
+      expect(reasonMap[NetworkReason.airplaneMode], equals('airplane'));
+      expect(reasonMap[NetworkReason.serverError], equals('error'));
+    });
+  });
+}

--- a/packages/telnyx_webrtc/test/string_utils_test.dart
+++ b/packages/telnyx_webrtc/test/string_utils_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:telnyx_webrtc/utils/string_utils.dart';
+
+void main() {
+  group('String Utils', () {
+    group('randomBetween', () {
+      test('should generate number within range', () {
+        for (int i = 0; i < 100; i++) {
+          final result = randomBetween(1, 10);
+          expect(result, greaterThanOrEqualTo(1));
+          expect(result, lessThanOrEqualTo(10));
+        }
+      });
+
+      test('should handle same from and to values', () {
+        final result = randomBetween(5, 5);
+        expect(result, equals(5));
+      });
+
+      test('should throw exception when from > to', () {
+        expect(() => randomBetween(10, 5), throwsException);
+      });
+
+      test('should handle negative ranges', () {
+        for (int i = 0; i < 50; i++) {
+          final result = randomBetween(-10, -1);
+          expect(result, greaterThanOrEqualTo(-10));
+          expect(result, lessThanOrEqualTo(-1));
+        }
+      });
+
+      test('should handle zero in range', () {
+        for (int i = 0; i < 50; i++) {
+          final result = randomBetween(-5, 5);
+          expect(result, greaterThanOrEqualTo(-5));
+          expect(result, lessThanOrEqualTo(5));
+        }
+      });
+    });
+
+    group('randomString', () {
+      test('should generate string of correct length', () {
+        expect(randomString(0), hasLength(0));
+        expect(randomString(1), hasLength(1));
+        expect(randomString(5), hasLength(5));
+        expect(randomString(10), hasLength(10));
+        expect(randomString(100), hasLength(100));
+      });
+
+      test('should generate different strings on multiple calls', () {
+        final strings = <String>{};
+        for (int i = 0; i < 50; i++) {
+          strings.add(randomString(10));
+        }
+        // With high probability, we should get many different strings
+        expect(strings.length, greaterThan(40));
+      });
+
+      test('should respect custom character range', () {
+        // Generate string with only digits (ASCII 48-57)
+        final numericString = randomString(10, from: 48, to: 57);
+        expect(numericString, hasLength(10));
+        for (int i = 0; i < numericString.length; i++) {
+          final charCode = numericString.codeUnitAt(i);
+          expect(charCode, greaterThanOrEqualTo(48));
+          expect(charCode, lessThanOrEqualTo(57));
+        }
+      });
+
+      test('should handle single character range', () {
+        final singleCharString = randomString(5, from: 65, to: 65); // Only 'A'
+        expect(singleCharString, equals('AAAAA'));
+      });
+
+      test('should use default ASCII printable range', () {
+        final defaultString = randomString(10);
+        expect(defaultString, hasLength(10));
+        for (int i = 0; i < defaultString.length; i++) {
+          final charCode = defaultString.codeUnitAt(i);
+          expect(charCode, greaterThanOrEqualTo(33));
+          expect(charCode, lessThanOrEqualTo(126));
+        }
+      });
+    });
+
+    group('randomNumeric', () {
+      test('should generate numeric string of correct length', () {
+        expect(randomNumeric(0), hasLength(0));
+        expect(randomNumeric(1), hasLength(1));
+        expect(randomNumeric(5), hasLength(5));
+        expect(randomNumeric(10), hasLength(10));
+      });
+
+      test('should generate only numeric characters', () {
+        final numericString = randomNumeric(20);
+        expect(numericString, hasLength(20));
+
+        final numericRegex = RegExp(r'^\d+$');
+        expect(numericRegex.hasMatch(numericString), isTrue);
+
+        // Check each character is a digit
+        for (int i = 0; i < numericString.length; i++) {
+          final char = numericString[i];
+          expect(int.tryParse(char), isNotNull);
+          expect(int.parse(char), greaterThanOrEqualTo(0));
+          expect(int.parse(char), lessThanOrEqualTo(9));
+        }
+      });
+
+      test('should generate different numeric strings on multiple calls', () {
+        final strings = <String>{};
+        for (int i = 0; i < 50; i++) {
+          strings.add(randomNumeric(8));
+        }
+        // With high probability, we should get many different strings
+        expect(strings.length, greaterThan(40));
+      });
+
+      test('should handle edge cases', () {
+        expect(randomNumeric(0), equals(''));
+
+        final singleDigit = randomNumeric(1);
+        expect(singleDigit, hasLength(1));
+        expect(int.tryParse(singleDigit), isNotNull);
+      });
+
+      test('should be usable for generating IDs', () {
+        final id1 = randomNumeric(10);
+        final id2 = randomNumeric(10);
+
+        expect(id1, hasLength(10));
+        expect(id2, hasLength(10));
+        expect(id1, isNot(equals(id2))); // Very unlikely to be the same
+
+        // Both should be valid numbers
+        expect(int.tryParse(id1), isNotNull);
+        expect(int.tryParse(id2), isNotNull);
+      });
+    });
+
+    group('Integration tests', () {
+      test('should work together for complex scenarios', () {
+        // Generate a mixed string with letters and numbers
+        final letters = randomString(5, from: 65, to: 90); // A-Z
+        final numbers = randomNumeric(5);
+        final combined = letters + numbers;
+
+        expect(combined, hasLength(10));
+        expect(letters, hasLength(5));
+        expect(numbers, hasLength(5));
+
+        // Verify letters part
+        for (int i = 0; i < 5; i++) {
+          final charCode = letters.codeUnitAt(i);
+          expect(charCode, greaterThanOrEqualTo(65));
+          expect(charCode, lessThanOrEqualTo(90));
+        }
+
+        // Verify numbers part
+        final numericRegex = RegExp(r'^\d+$');
+        expect(numericRegex.hasMatch(numbers), isTrue);
+      });
+    });
+  });
+}

--- a/packages/telnyx_webrtc/test/telnyx_client_test.mocks.dart
+++ b/packages/telnyx_webrtc/test/telnyx_client_test.mocks.dart
@@ -35,54 +35,57 @@ class MockTelnyxClient extends _i1.Mock implements _i4.TelnyxClient {
   @override
   _i4.OnSocketMessageReceived get onSocketMessageReceived =>
       (super.noSuchMethod(
-        Invocation.getter(#onSocketMessageReceived),
-        returnValue: (_i5.TelnyxMessage message) {},
-      ) as _i4.OnSocketMessageReceived);
+            Invocation.getter(#onSocketMessageReceived),
+            returnValue: (_i5.TelnyxMessage message) {},
+          )
+          as _i4.OnSocketMessageReceived);
   @override
   set onSocketMessageReceived(
     _i4.OnSocketMessageReceived? _onSocketMessageReceived,
-  ) =>
-      super.noSuchMethod(
-        Invocation.setter(#onSocketMessageReceived, _onSocketMessageReceived),
-        returnValueForMissingStub: null,
-      );
+  ) => super.noSuchMethod(
+    Invocation.setter(#onSocketMessageReceived, _onSocketMessageReceived),
+    returnValueForMissingStub: null,
+  );
   @override
-  _i4.OnSocketErrorReceived get onSocketErrorReceived => (super.noSuchMethod(
-        Invocation.getter(#onSocketErrorReceived),
-        returnValue: (_i6.TelnyxSocketError message) {},
-      ) as _i4.OnSocketErrorReceived);
+  _i4.OnSocketErrorReceived get onSocketErrorReceived =>
+      (super.noSuchMethod(
+            Invocation.getter(#onSocketErrorReceived),
+            returnValue: (_i6.TelnyxSocketError message) {},
+          )
+          as _i4.OnSocketErrorReceived);
   @override
   set onSocketErrorReceived(
     _i4.OnSocketErrorReceived? _onSocketErrorReceived,
-  ) =>
-      super.noSuchMethod(
-        Invocation.setter(#onSocketErrorReceived, _onSocketErrorReceived),
-        returnValueForMissingStub: null,
-      );
+  ) => super.noSuchMethod(
+    Invocation.setter(#onSocketErrorReceived, _onSocketErrorReceived),
+    returnValueForMissingStub: null,
+  );
   @override
-  _i2.TxSocket get txSocket => (super.noSuchMethod(
-        Invocation.getter(#txSocket),
-        returnValue: _FakeTxSocket_0(),
-      ) as _i2.TxSocket);
+  _i2.TxSocket get txSocket =>
+      (super.noSuchMethod(
+            Invocation.getter(#txSocket),
+            returnValue: _FakeTxSocket_0(),
+          )
+          as _i2.TxSocket);
   @override
   set txSocket(_i2.TxSocket? _txSocket) => super.noSuchMethod(
-        Invocation.setter(#txSocket, _txSocket),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#txSocket, _txSocket),
+    returnValueForMissingStub: null,
+  );
   @override
   set sessid(String? _sessionId) => super.noSuchMethod(
-        Invocation.setter(#sessionId, _sessionId),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#sessionId, _sessionId),
+    returnValueForMissingStub: null,
+  );
   @override
   _i3.Call get call =>
       (super.noSuchMethod(Invocation.getter(#call), returnValue: _FakeCall_1())
           as _i3.Call);
   @override
   set call(_i3.Call? _call) => super.noSuchMethod(
-        Invocation.setter(#call, _call),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#call, _call),
+    returnValueForMissingStub: null,
+  );
   @override
   set _storedCredentialConfig(_i7.CredentialConfig? _storedCredentialConfig) =>
       super.noSuchMethod(
@@ -96,39 +99,45 @@ class MockTelnyxClient extends _i1.Mock implements _i4.TelnyxClient {
         returnValueForMissingStub: null,
       );
   @override
-  bool isConnected() => (super.noSuchMethod(
-        Invocation.method(#isConnected, []),
-        returnValue: false,
-      ) as bool);
+  bool isConnected() =>
+      (super.noSuchMethod(
+            Invocation.method(#isConnected, []),
+            returnValue: false,
+          )
+          as bool);
   @override
-  String getGatewayStatus() => (super.noSuchMethod(
-        Invocation.method(#getGatewayStatus, []),
-        returnValue: '',
-      ) as String);
+  String getGatewayStatus() =>
+      (super.noSuchMethod(
+            Invocation.method(#getGatewayStatus, []),
+            returnValue: '',
+          )
+          as String);
   @override
   void connect() => super.noSuchMethod(
-        Invocation.method(#connect, []),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#connect, []),
+    returnValueForMissingStub: null,
+  );
 
   @override
-  _i3.Call createCall() => (super.noSuchMethod(
-        Invocation.method(#createCall, []),
-        returnValue: _FakeCall_1(),
-      ) as _i3.Call);
+  _i3.Call createCall() =>
+      (super.noSuchMethod(
+            Invocation.method(#createCall, []),
+            returnValue: _FakeCall_1(),
+          )
+          as _i3.Call);
   @override
   void credentialLogin(_i7.CredentialConfig? config) => super.noSuchMethod(
-        Invocation.method(#credentialLogin, [config]),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#credentialLogin, [config]),
+    returnValueForMissingStub: null,
+  );
   @override
   void tokenLogin(_i7.TokenConfig? config) => super.noSuchMethod(
-        Invocation.method(#tokenLogin, [config]),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#tokenLogin, [config]),
+    returnValueForMissingStub: null,
+  );
   @override
   void disconnect() => super.noSuchMethod(
-        Invocation.method(#disconnect, []),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#disconnect, []),
+    returnValueForMissingStub: null,
+  );
 }

--- a/packages/telnyx_webrtc/test/telnyx_config_test.dart
+++ b/packages/telnyx_webrtc/test/telnyx_config_test.dart
@@ -1,0 +1,260 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_webrtc/model/region.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+import 'package:telnyx_webrtc/utils/logging/custom_logger.dart';
+
+// Mock custom logger for testing
+class MockCustomLogger implements CustomLogger {
+  @override
+  void log(String message, LogLevel level) {
+    // Mock implementation
+  }
+}
+
+void main() {
+  group('Config', () {
+    test('should create Config with required parameters', () {
+      final config = Config(
+        sipCallerIDName: 'Test User',
+        sipCallerIDNumber: '+1234567890',
+        debug: true,
+      );
+
+      expect(config.sipCallerIDName, equals('Test User'));
+      expect(config.sipCallerIDNumber, equals('+1234567890'));
+      expect(config.debug, isTrue);
+      expect(config.logLevel, equals(LogLevel.all));
+      expect(config.region, equals(Region.auto));
+      expect(config.fallbackOnRegionFailure, isTrue);
+      expect(config.forceRelayCandidate, isFalse);
+      expect(config.notificationToken, isNull);
+      expect(config.autoReconnect, isNull);
+      expect(config.customLogger, isNull);
+      expect(config.ringTonePath, isNull);
+      expect(config.ringbackPath, isNull);
+      expect(config.reconnectionTimeout, isNull);
+    });
+
+    test('should create Config with all optional parameters', () {
+      final customLogger = MockCustomLogger();
+      final config = Config(
+        sipCallerIDName: 'Test User',
+        sipCallerIDNumber: '+1234567890',
+        debug: false,
+        notificationToken: 'test_token_123',
+        autoReconnect: true,
+        logLevel: LogLevel.error,
+        customLogger: customLogger,
+        ringTonePath: '/path/to/ringtone.mp3',
+        ringbackPath: '/path/to/ringback.mp3',
+        reconnectionTimeout: 30,
+        region: Region.us,
+        fallbackOnRegionFailure: false,
+        forceRelayCandidate: true,
+      );
+
+      expect(config.sipCallerIDName, equals('Test User'));
+      expect(config.sipCallerIDNumber, equals('+1234567890'));
+      expect(config.debug, isFalse);
+      expect(config.notificationToken, equals('test_token_123'));
+      expect(config.autoReconnect, isTrue);
+      expect(config.logLevel, equals(LogLevel.error));
+      expect(config.customLogger, equals(customLogger));
+      expect(config.ringTonePath, equals('/path/to/ringtone.mp3'));
+      expect(config.ringbackPath, equals('/path/to/ringback.mp3'));
+      expect(config.reconnectionTimeout, equals(30));
+      expect(config.region, equals(Region.us));
+      expect(config.fallbackOnRegionFailure, isFalse);
+      expect(config.forceRelayCandidate, isTrue);
+    });
+
+    test('should handle different log levels', () {
+      final configs = [
+        Config(
+          sipCallerIDName: 'Test',
+          sipCallerIDNumber: '+123',
+          debug: true,
+          logLevel: LogLevel.all,
+        ),
+        Config(
+          sipCallerIDName: 'Test',
+          sipCallerIDNumber: '+123',
+          debug: true,
+          logLevel: LogLevel.debug,
+        ),
+        Config(
+          sipCallerIDName: 'Test',
+          sipCallerIDNumber: '+123',
+          debug: true,
+          logLevel: LogLevel.info,
+        ),
+        Config(
+          sipCallerIDName: 'Test',
+          sipCallerIDNumber: '+123',
+          debug: true,
+          logLevel: LogLevel.warning,
+        ),
+        Config(
+          sipCallerIDName: 'Test',
+          sipCallerIDNumber: '+123',
+          debug: true,
+          logLevel: LogLevel.error,
+        ),
+        Config(
+          sipCallerIDName: 'Test',
+          sipCallerIDNumber: '+123',
+          debug: true,
+          logLevel: LogLevel.none,
+        ),
+      ];
+
+      expect(configs[0].logLevel, equals(LogLevel.all));
+      expect(configs[1].logLevel, equals(LogLevel.debug));
+      expect(configs[2].logLevel, equals(LogLevel.info));
+      expect(configs[3].logLevel, equals(LogLevel.warning));
+      expect(configs[4].logLevel, equals(LogLevel.error));
+      expect(configs[5].logLevel, equals(LogLevel.none));
+    });
+
+    test('should handle different regions', () {
+      final configs = [
+        Config(
+          sipCallerIDName: 'Test',
+          sipCallerIDNumber: '+123',
+          debug: true,
+          region: Region.auto,
+        ),
+        Config(
+          sipCallerIDName: 'Test',
+          sipCallerIDNumber: '+123',
+          debug: true,
+          region: Region.us,
+        ),
+        Config(
+          sipCallerIDName: 'Test',
+          sipCallerIDNumber: '+123',
+          debug: true,
+          region: Region.europe,
+        ),
+        Config(
+          sipCallerIDName: 'Test',
+          sipCallerIDNumber: '+123',
+          debug: true,
+          region: Region.australia,
+        ),
+      ];
+
+      expect(configs[0].region, equals(Region.auto));
+      expect(configs[1].region, equals(Region.us));
+      expect(configs[2].region, equals(Region.europe));
+      expect(configs[3].region, equals(Region.australia));
+    });
+  });
+
+  group('TokenConfig', () {
+    test('should create TokenConfig with required parameters', () {
+      final config = TokenConfig(
+        sipToken: 'test_token_123',
+        sipCallerIDName: 'Test User',
+        sipCallerIDNumber: '+1234567890',
+        debug: true,
+      );
+
+      expect(config.sipToken, equals('test_token_123'));
+      expect(config.sipCallerIDName, equals('Test User'));
+      expect(config.sipCallerIDNumber, equals('+1234567890'));
+      expect(config.debug, isTrue);
+    });
+
+    test('should create TokenConfig with all optional parameters', () {
+      final customLogger = MockCustomLogger();
+      final config = TokenConfig(
+        sipToken: 'test_token_123',
+        sipCallerIDName: 'Test User',
+        sipCallerIDNumber: '+1234567890',
+        debug: false,
+        notificationToken: 'notification_token',
+        autoReconnect: false,
+        logLevel: LogLevel.warning,
+        customLogger: customLogger,
+        ringTonePath: '/ringtone.wav',
+        ringbackPath: '/ringback.wav',
+        reconnectionTimeout: 45,
+        region: Region.europe,
+        fallbackOnRegionFailure: true,
+        forceRelayCandidate: false,
+      );
+
+      expect(config.sipToken, equals('test_token_123'));
+      expect(config.sipCallerIDName, equals('Test User'));
+      expect(config.sipCallerIDNumber, equals('+1234567890'));
+      expect(config.debug, isFalse);
+      expect(config.notificationToken, equals('notification_token'));
+      expect(config.autoReconnect, isFalse);
+      expect(config.logLevel, equals(LogLevel.warning));
+      expect(config.customLogger, equals(customLogger));
+      expect(config.ringTonePath, equals('/ringtone.wav'));
+      expect(config.ringbackPath, equals('/ringback.wav'));
+      expect(config.reconnectionTimeout, equals(45));
+      expect(config.region, equals(Region.europe));
+      expect(config.fallbackOnRegionFailure, isTrue);
+      expect(config.forceRelayCandidate, isFalse);
+    });
+  });
+
+  group('CredentialConfig', () {
+    test('should create CredentialConfig with required parameters', () {
+      final config = CredentialConfig(
+        sipUser: 'test_user',
+        sipPassword: 'test_password',
+        sipCallerIDName: 'Test User',
+        sipCallerIDNumber: '+1234567890',
+        debug: true,
+      );
+
+      expect(config.sipUser, equals('test_user'));
+      expect(config.sipPassword, equals('test_password'));
+      expect(config.sipCallerIDName, equals('Test User'));
+      expect(config.sipCallerIDNumber, equals('+1234567890'));
+      expect(config.debug, isTrue);
+    });
+
+    test('should create CredentialConfig with all optional parameters', () {
+      final customLogger = MockCustomLogger();
+      final config = CredentialConfig(
+        sipUser: 'test_user',
+        sipPassword: 'test_password',
+        sipCallerIDName: 'Test User',
+        sipCallerIDNumber: '+1234567890',
+        debug: false,
+        notificationToken: 'notification_token',
+        autoReconnect: true,
+        logLevel: LogLevel.info,
+        customLogger: customLogger,
+        ringTonePath: '/custom_ringtone.mp3',
+        ringbackPath: '/custom_ringback.mp3',
+        reconnectionTimeout: 60,
+        region: Region.australia,
+        fallbackOnRegionFailure: false,
+        forceRelayCandidate: true,
+      );
+
+      expect(config.sipUser, equals('test_user'));
+      expect(config.sipPassword, equals('test_password'));
+      expect(config.sipCallerIDName, equals('Test User'));
+      expect(config.sipCallerIDNumber, equals('+1234567890'));
+      expect(config.debug, isFalse);
+      expect(config.notificationToken, equals('notification_token'));
+      expect(config.autoReconnect, isTrue);
+      expect(config.logLevel, equals(LogLevel.info));
+      expect(config.customLogger, equals(customLogger));
+      expect(config.ringTonePath, equals('/custom_ringtone.mp3'));
+      expect(config.ringbackPath, equals('/custom_ringback.mp3'));
+      expect(config.reconnectionTimeout, equals(60));
+      expect(config.region, equals(Region.australia));
+      expect(config.fallbackOnRegionFailure, isFalse);
+      expect(config.forceRelayCandidate, isTrue);
+    });
+  });
+}

--- a/packages/telnyx_webrtc/test/tx_socket_test.mocks.dart
+++ b/packages/telnyx_webrtc/test/tx_socket_test.mocks.dart
@@ -33,42 +33,46 @@ class MockTxSocket extends _i1.Mock implements _i2.TxSocket {
           as _i2.OnOpenCallback);
   @override
   set onOpen(_i2.OnOpenCallback? _onOpen) => super.noSuchMethod(
-        Invocation.setter(#onOpen, _onOpen),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#onOpen, _onOpen),
+    returnValueForMissingStub: null,
+  );
   @override
-  _i2.OnMessageCallback get onMessage => (super.noSuchMethod(
-        Invocation.getter(#onMessage),
-        returnValue: (dynamic msg) {},
-      ) as _i2.OnMessageCallback);
+  _i2.OnMessageCallback get onMessage =>
+      (super.noSuchMethod(
+            Invocation.getter(#onMessage),
+            returnValue: (dynamic msg) {},
+          )
+          as _i2.OnMessageCallback);
   @override
   set onMessage(_i2.OnMessageCallback? _onMessage) => super.noSuchMethod(
-        Invocation.setter(#onMessage, _onMessage),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#onMessage, _onMessage),
+    returnValueForMissingStub: null,
+  );
   @override
-  _i2.OnCloseCallback get onClose => (super.noSuchMethod(
-        Invocation.getter(#onClose),
-        returnValue: (int code, String reason) {},
-      ) as _i2.OnCloseCallback);
+  _i2.OnCloseCallback get onClose =>
+      (super.noSuchMethod(
+            Invocation.getter(#onClose),
+            returnValue: (int code, String reason) {},
+          )
+          as _i2.OnCloseCallback);
   @override
   set onClose(_i2.OnCloseCallback? _onClose) => super.noSuchMethod(
-        Invocation.setter(#onClose, _onClose),
-        returnValueForMissingStub: null,
-      );
+    Invocation.setter(#onClose, _onClose),
+    returnValueForMissingStub: null,
+  );
   @override
   void connect() => super.noSuchMethod(
-        Invocation.method(#connect, []),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#connect, []),
+    returnValueForMissingStub: null,
+  );
   @override
   void send(dynamic data) => super.noSuchMethod(
-        Invocation.method(#send, [data]),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#send, [data]),
+    returnValueForMissingStub: null,
+  );
   @override
   void close() => super.noSuchMethod(
-        Invocation.method(#close, []),
-        returnValueForMissingStub: null,
-      );
+    Invocation.method(#close, []),
+    returnValueForMissingStub: null,
+  );
 }


### PR DESCRIPTION
## Summary

This PR adds comprehensive unit tests for the Flutter widget package to support CI workflows as requested in WEBRTC-2937.

## Changes Made

### New Unit Test Files:
- **call_state_test.dart** - Tests CallState enum with network/termination reasons
- **telnyx_config_test.dart** - Tests Config, TokenConfig, CredentialConfig classes  
- **call_termination_reason_test.dart** - Tests CallTerminationReason with toString formatting
- **network_reason_test.dart** - Tests NetworkReason enum with messages
- **gateway_state_test.dart** - Tests GatewayState constants
- **string_utils_test.dart** - Tests utility functions (randomBetween, randomString, randomNumeric)

### Improvements:
- Formatted existing test files for consistency
- Added comprehensive test coverage for core models and utilities
- Tests are designed to work with existing CI workflows

## Test Coverage

The new tests cover:
- ✅ CallState enum values and state transitions
- ✅ Network reason handling for call states
- ✅ Call termination reason handling
- ✅ Configuration classes (Token, Credential, Config)
- ✅ NetworkReason enum with proper messages
- ✅ GatewayState constants
- ✅ String utility functions with edge cases

## CI Integration

These tests integrate with the existing unit test workflow in `.github/workflows/unit_tests.yml` and will run automatically on CI.

## Related

- Jira: [WEBRTC-2937](https://telnyx.atlassian.net/browse/WEBRTC-2937)
- Addresses requirement for unit tests to support CI workflows

[WEBRTC-2937]: https://telnyx.atlassian.net/browse/WEBRTC-2937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ