### PR TITLE
Implement missing custom logger method

### DIFF
--- a/packages/telnyx_webrtc/test/telnyx_config_test.dart
+++ b/packages/telnyx_webrtc/test/telnyx_config_test.dart
@@ -7,7 +7,12 @@ import 'package:telnyx_webrtc/utils/logging/custom_logger.dart';
 // Mock custom logger for testing
 class MockCustomLogger implements CustomLogger {
   @override
-  void log(String message, LogLevel level) {
+  void setLogLevel(LogLevel level) {
+    // Mock implementation
+  }
+
+  @override
+  void log(LogLevel level, String message) {
     // Mock implementation
   }
 }


### PR DESCRIPTION
[WEBRTC-XXX - Fix: CustomLogger mock implementation.](https://telnyx.atlassian.net/browse/WEBRTC-XXX)

---
This PR resolves a compilation error in the `MockCustomLogger` by implementing the missing `setLogLevel` method and correcting the parameter order for the `log` method to match the `CustomLogger` interface.

## :older_man: :baby: Behaviors
### Before changes
The `MockCustomLogger` class failed to compile with a "Missing concrete implementation of 'CustomLogger.setLogLevel'" error, and its `log` method signature did not match the `CustomLogger` interface.

### After changes
The `MockCustomLogger` class now correctly implements the `CustomLogger` interface, resolving the compilation error and ensuring proper mocking behavior for tests.

## ✋ Manual testing
1. Run all tests: `flutter test`
2. Verify that `packages/telnyx_webrtc/test/telnyx_config_test.dart` compiles and passes.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc6d5ab6-ff0e-4995-9c9f-ee5eaeabfffb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc6d5ab6-ff0e-4995-9c9f-ee5eaeabfffb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

