### PR TITLE
[WEBRTC-2991] - Provide example of graceful call end on crash or app close

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,8 @@ final txClientViewModel = TelnyxClientViewModel();
 void _endActiveCallOnTermination() {
   try {
     if (txClientViewModel.currentCall != null) {
-      logger.i('[_endActiveCallOnTermination] Active call detected, ending gracefully');
+      logger.i(
+          '[_endActiveCallOnTermination] Active call detected, ending gracefully');
       txClientViewModel.endCall();
     } else {
       logger.i('[_endActiveCallOnTermination] No active call to end');
@@ -98,7 +99,7 @@ Future<void> main() async {
           'Caught Flutter error: ${details.exception}',
           stackTrace: details.stack,
         );
-        
+
         // End any active call before clearing push data
         _endActiveCallOnTermination();
         PlatformPushService.handler.clearPushData();
@@ -107,7 +108,7 @@ Future<void> main() async {
       // Catch other platform errors (e.g., Dart errors outside Flutter)
       PlatformDispatcher.instance.onError = (error, stack) {
         logger.e('Caught Platform error: $error', stackTrace: stack);
-        
+
         // End any active call before clearing push data
         _endActiveCallOnTermination();
         PlatformPushService.handler.clearPushData();
@@ -158,7 +159,7 @@ Future<void> main() async {
     },
     (error, stack) {
       logger.e('Caught Zoned error: $error', stackTrace: stack);
-      
+
       // End any active call before clearing push data
       _endActiveCallOnTermination();
       PlatformPushService.handler.clearPushData();
@@ -206,9 +207,22 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
+  late final AppLifecycleListener _listener;
+
+  Future<void> _handleStateChange(AppLifecycleState state) async {
+    if (state == AppLifecycleState.detached) {
+      logger.i(
+          '[_MyAppState] AppLifecycleState.detached - ending any active calls');
+      _endActiveCallOnTermination();
+    }
+  }
+
   @override
   void initState() {
     super.initState();
+    _listener = AppLifecycleListener(
+      onStateChange: _handleStateChange,
+    );
     logger.i('[_MyAppState] initState called.');
 
     // Platform-specific logic for handling initial push data when app starts.


### PR DESCRIPTION
[WEBRTC-2991 - Provide example of graceful call end on crash or app close.](https://telnyx.atlassian.net/browse/WEBRTC-2991)

---

This PR implements graceful call ending functionality for the Flutter Voice SDK example app to handle scenarios where the app crashes or is closed while an active call is in progress.

## :older_man: :baby: Behaviors
### Before changes
- When the app crashed or was forcefully closed during an active call, the call would remain orphaned
- No cleanup mechanism existed for active calls during app termination scenarios
- Users could experience poor call quality or confusion due to calls not being properly terminated

### After changes
- Added `_endActiveCallOnTermination()` helper function that checks for active calls and ends them gracefully
- Integrated call termination into all existing error handlers:
  - FlutterError.onError (Flutter framework errors)
  - PlatformDispatcher.instance.onError (Platform/Dart errors)
  - runZonedGuarded error handler (Zoned errors)
- Added AppLifecycleState.detached handling in BackgroundDetector for app termination
- Added dispose method to MyApp widget for additional cleanup coverage
- All call termination attempts are wrapped in try-catch blocks with proper logging

## ✋ Manual testing
1. Start the example app and initiate a call
2. Force close the app (swipe away from recent apps or kill process)
3. Verify that the call is properly terminated and no orphaned call remains
4. Start the app and initiate a call, then trigger a crash scenario
5. Verify that the call is ended gracefully before the app terminates
6. Test normal app lifecycle transitions to ensure existing functionality is preserved

## Technical Implementation Details
- Uses existing `txClientViewModel.currentCall` to detect active calls
- Leverages existing `txClientViewModel.endCall()` method for consistent call termination
- Maintains compatibility with existing push notification and CallKit integration
- Follows established logging patterns for debugging and monitoring
- No changes to pubspec.yaml or external dependencies required