### PR TITLE
[WEBRTC-2993] - Reduce UI Test firebase runtimes to not run on draft PRs

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   integration_test:
     runs-on: ubuntu-latest
+    # Skip UI tests for draft PRs to reduce Firebase test quota usage
+    if: github.event.pull_request.draft != true
     steps:
       # 1) Check out repo
       - uses: actions/checkout@v3

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -3,6 +3,7 @@ name: Flutter UI Tests (Firebase Test Lab)
 on:
   pull_request:
     branches: [ main ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
[WEBRTC-2993 - Reduce UI Test firebase runtimes to not run on draft PRs.](https://telnyx.atlassian.net/browse/WEBRTC-2993)

---

This PR modifies the UI Test workflow to skip Firebase Test Lab runs on draft PRs, reducing test quota usage while maintaining full testing coverage for ready-to-review PRs.

## :older_man: :baby: Behaviors
### Before changes
- UI tests ran on all PRs to main branch, including draft PRs
- This consumed Firebase Test Lab quota unnecessarily for work-in-progress PRs

### After changes
- UI tests only run on PRs that are ready for review (not draft)
- Draft PRs will show the workflow as skipped, saving Firebase quota
- Manual workflow dispatch still works for testing when needed

## ✋ Manual testing
1. Create a draft PR and verify the UI test job is skipped
2. Convert PR to ready for review and verify UI tests run
3. Confirm manual workflow dispatch still works for testing purposes