### PR TITLE
ENGDESK-45284: Release build for web causing null errors 

### DIFF
--- a/packages/telnyx_webrtc/lib/utils/version_utils.dart
+++ b/packages/telnyx_webrtc/lib/utils/version_utils.dart
@@ -21,11 +21,13 @@ class VersionUtils {
           return _sdkVersion!;
         }
       }
+      // If we get here, no version line was found
+      _sdkVersion = 'unknown';
     } catch (e) {
       // Fallback version if we can't read SDK pubspec.yaml
       _sdkVersion = 'unknown';
     }
-    return _sdkVersion!;
+    return _sdkVersion ?? 'unknown';
   }
 
   /// Constructs the user agent string in the format Flutter-{SDK-Version}


### PR DESCRIPTION
[ENGDESK-45284 - Fix null pointer exception in version_utils.dart for web release builds](https://telnyx.atlassian.net/browse/ENGDESK-45284)

---

## :older_man: :baby: Behaviors
### Before changes
- Web release builds would crash with null pointer exception when calling `newInvite` method
- The error occurred in `version_utils.dart` line 28: `return _sdkVersion!`
- `_sdkVersion` could remain null if `pubspec.yaml` file loaded successfully but contained no 'version:' line (due to minification)

### After changes
- Fixed null safety issue by ensuring `_sdkVersion` is always set to 'unknown' fallback value
- Added explicit fallback assignment when no version line is found in the file
- Web release builds now work correctly without crashes

## ✋ Manual testing
1. Build for web in release mode: `flutter build web --release`
2. Test that `newInvite` method works without null pointer exceptions
3. Verify SDK version is correctly retrieved or falls back to 'unknown'