### PR TITLE
[WEBRTC-3011] - Simplify SDK Version parsing by using const

### DIFF
--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -227,7 +227,7 @@ class Peer {
       );
 
       Timer(const Duration(milliseconds: 500), () async {
-        final userAgent = await VersionUtils.getUserAgent();
+        final userAgent = VersionUtils.getUserAgent();
         final dialogParams = DialogParams(
           attach: false,
           audio: true,
@@ -379,7 +379,7 @@ class Peer {
           (value) => sdpUsed = value?.sdp.toString(),
         );
 
-        final userAgent = await VersionUtils.getUserAgent();
+        final userAgent = VersionUtils.getUserAgent();
         final dialogParams = DialogParams(
           attach: false,
           audio: true,

--- a/packages/telnyx_webrtc/lib/peer/web/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/web/peer.dart
@@ -236,7 +236,7 @@ class Peer {
 
       // Send INVITE
       Timer(const Duration(milliseconds: 500), () async {
-        final userAgent = await VersionUtils.getUserAgent();
+        final userAgent = VersionUtils.getUserAgent();
         final dialogParams = DialogParams(
           attach: false,
           audio: true,
@@ -396,7 +396,7 @@ class Peer {
           sdpUsed = localDesc.sdp;
         }
 
-        final userAgent = await VersionUtils.getUserAgent();
+        final userAgent = VersionUtils.getUserAgent();
         final dialogParams = DialogParams(
           attach: false,
           audio: true,

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -1229,8 +1229,8 @@ class TelnyxClient {
 
     setLogLevel(logLevel);
 
-    final versionData = await VersionUtils.getSDKVersion();
-    final userAgentData = await VersionUtils.getUserAgent();
+    final versionData = VersionUtils.getSDKVersion();
+    final userAgentData = VersionUtils.getUserAgent();
 
     final userAgent = UserAgent(sdkVersion: versionData, data: userAgentData);
 

--- a/packages/telnyx_webrtc/lib/utils/version_utils.dart
+++ b/packages/telnyx_webrtc/lib/utils/version_utils.dart
@@ -1,38 +1,16 @@
-import 'package:flutter/services.dart';
-
 /// Utility class for retrieving SDK version information
 class VersionUtils {
-  static String? _sdkVersion;
+  /// SDK version constant
+  static const String _sdkVersion = '3.0.1';
 
-  /// Gets the SDK version from the telnyx_webrtc package pubspec.yaml
-  /// Returns the version string or a fallback version if unable to read
-  static Future<String> getSDKVersion() async {
-    if (_sdkVersion != null) return _sdkVersion!;
-
-    try {
-      final String pubspecContent = await rootBundle.loadString(
-        'packages/telnyx_webrtc/pubspec.yaml',
-      );
-      final lines = pubspecContent.split('\n');
-      for (final line in lines) {
-        if (line.startsWith('version:')) {
-          final version = line.split(':')[1].trim();
-          _sdkVersion = version;
-          return _sdkVersion!;
-        }
-      }
-      // If we get here, no version line was found
-      _sdkVersion = 'unknown';
-    } catch (e) {
-      // Fallback version if we can't read SDK pubspec.yaml
-      _sdkVersion = 'unknown';
-    }
-    return _sdkVersion ?? 'unknown';
+  /// Gets the SDK version
+  /// Returns the current SDK version as a constant
+  static String getSDKVersion() {
+    return _sdkVersion;
   }
 
   /// Constructs the user agent string in the format Flutter-{SDK-Version}
-  static Future<String> getUserAgent() async {
-    final sdkVersion = await getSDKVersion();
-    return 'Flutter-$sdkVersion';
+  static String getUserAgent() {
+    return 'Flutter-$_sdkVersion';
   }
 }

--- a/packages/telnyx_webrtc/test/version_utils_test.dart
+++ b/packages/telnyx_webrtc/test/version_utils_test.dart
@@ -3,27 +3,23 @@ import 'package:telnyx_webrtc/utils/version_utils.dart';
 
 void main() {
   group('VersionUtils', () {
-    test(
-      'getSDKVersion returns fallback version when pubspec.yaml cannot be read',
-      () async {
-        // Since we can't easily mock the rootBundle in a unit test,
-        // this test verifies the fallback behavior
-        final version = await VersionUtils.getSDKVersion();
-        expect(version, isNotEmpty);
-        expect(version, matches(RegExp(r'^\d+\.\d+\.\d+.*')));
-      },
-    );
-
-    test('getUserAgent returns properly formatted user agent string', () async {
-      final userAgent = await VersionUtils.getUserAgent();
-      expect(userAgent, startsWith('Flutter-'));
-      expect(userAgent, matches(RegExp(r'^Flutter-\d+\.\d+\.\d+.*')));
+    test('getSDKVersion returns constant version', () {
+      final version = VersionUtils.getSDKVersion();
+      expect(version, equals('3.0.1'));
+      expect(version, isNotEmpty);
     });
 
-    test('getSDKVersion caches result on subsequent calls', () async {
-      final version1 = await VersionUtils.getSDKVersion();
-      final version2 = await VersionUtils.getSDKVersion();
+    test('getUserAgent returns properly formatted user agent string', () {
+      final userAgent = VersionUtils.getUserAgent();
+      expect(userAgent, equals('Flutter-3.0.1'));
+      expect(userAgent, startsWith('Flutter-'));
+    });
+
+    test('getSDKVersion returns consistent result on multiple calls', () {
+      final version1 = VersionUtils.getSDKVersion();
+      final version2 = VersionUtils.getSDKVersion();
       expect(version1, equals(version2));
+      expect(version1, equals('3.0.1'));
     });
   });
 }


### PR DESCRIPTION
**[WEBRTC-3011 - Simplify SDK Version parsing by using const](https://telnyx.atlassian.net/browse/WEBRTC-3011)**

---

This PR simplifies the SDK version parsing mechanism by replacing the complex pubspec.yaml parsing logic with a simple constant value.

## :older_man: :baby: Behaviors

### Before changes
- SDK version was retrieved by parsing pubspec.yaml file using rootBundle
- Complex async logic with error handling and caching
- Methods were async and required await calls throughout the codebase
- Potential for runtime errors if pubspec.yaml couldn't be read

### After changes  
- SDK version is now a simple constant '3.0.1'
- Removed all async/await complexity
- Methods are now synchronous and more performant
- No risk of runtime errors from file parsing
- Cleaner, more maintainable code

## ✋ Manual testing
1. Verify that getSDKVersion() returns '3.0.1'
2. Verify that getUserAgent() returns 'Flutter-3.0.1'
3. Run unit tests to ensure all tests pass
4. Test call functionality to ensure user agent is properly set in WebRTC calls

## Changes Made
- Modified  to use const instead of pubspec parsing
- Updated  to use synchronous version calls
- Updated  to remove await from getUserAgent calls
- Updated  to remove await from getUserAgent calls
- Updated  to test the new constant behavior
- Removed unnecessary  import