### PR TITLE
WEBRTC-3044: [Flutter] Reactive Circus UI tests fallback mechanism

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -1,4 +1,4 @@
-name: Flutter UI Tests (Firebase Test Lab)
+name: Flutter UI Tests (Firebase Test Lab with Reactive Circus Fallback)
 
 on:
   pull_request:
@@ -65,6 +65,8 @@ jobs:
 
       # 8) Run tests on Firebase Test Lab
       - name: Run Tests on Firebase Test Lab
+        id: firebase_tests
+        continue-on-error: true
         run: |
           gcloud firebase test android run \
           --type instrumentation \
@@ -75,3 +77,54 @@ jobs:
           --device model=akita,version=34,locale=en,orientation=portrait \
           --record-video \
           --environment-variables clearPackageData=true
+          echo "firebase_status=success" >> $GITHUB_OUTPUT
+
+      # Reactive Circus fallback mechanism - runs only when Firebase tests fail
+      - name: Enable KVM group perms (Reactive Circus)
+        if: always() && steps.firebase_tests.outcome == 'failure'
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run Flutter Tests with Reactive Circus (Fallback)
+        id: fallback_tests
+        if: always() && steps.firebase_tests.outcome == 'failure'
+        continue-on-error: true
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: |
+            echo "Running Flutter integration tests as fallback..."
+            flutter test integration_test/patrol_test.dart --dart-define=APP_LOGIN_USER=${{ secrets.APP_LOGIN_USER }} --dart-define=APP_LOGIN_PASSWORD=${{ secrets.APP_LOGIN_PASSWORD }} --dart-define=APP_LOGIN_NUMBER=${{ secrets.APP_LOGIN_NUMBER }}
+
+      - name: Check Test Results
+        if: always()
+        run: |
+          # Check Firebase test results first
+          if [[ "${{ steps.firebase_tests.outcome }}" == "success" ]]; then
+            echo "✅ Firebase test suite passed"
+            exit 0
+          fi
+
+          # If Firebase tests failed, check fallback results
+          echo "⚠️ Firebase test suite failed, checking fallback results..."
+          if [[ "${{ steps.fallback_tests.outcome }}" == "success" ]]; then
+            echo "✅ Reactive Circus fallback test suite passed"
+            exit 0
+          fi
+
+          # If both Firebase and fallback tests failed
+          if [[ "${{ steps.fallback_tests.outcome }}" == "failure" ]]; then
+            echo "❌ Both Firebase and Reactive Circus fallback test suites failed"
+            exit 1
+          fi
+
+          # If fallback tests were skipped (Firebase tests passed)
+          echo "❌ All test suites failed"
+          exit 1


### PR DESCRIPTION
[WEBRTC-3044 - [Flutter] Reactive Circus UI tests fallback mechanism](https://telnyx.atlassian.net/browse/WEBRTC-3044)

---

This PR implements a fallback mechanism for Flutter UI tests using Reactive Circus when Firebase Test Lab tests fail or quota is exceeded.

## :older_man: :baby: Behaviors
### Before changes
- UI tests only ran on Firebase Test Lab
- Tests would fail completely if Firebase was unavailable or quota exceeded
- No fallback mechanism for test reliability

### After changes
- Firebase Test Lab remains the primary testing method
- Reactive Circus fallback automatically triggers when Firebase tests fail
- KVM setup enables Android emulator for fallback testing
- Comprehensive result checking ensures at least one test suite passes
- Improved test reliability and reduced dependency on Firebase quota

## ✋ Manual testing
1. Create a PR to trigger the workflow
2. Verify Firebase tests run first
3. If Firebase fails, verify Reactive Circus fallback triggers
4. Confirm test results are properly evaluated
5. Check that workflow passes if either Firebase or fallback succeeds

## Implementation Details
- Added `continue-on-error: true` to Firebase Test Lab step
- Implemented KVM group permissions setup for Android emulator
- Added Reactive Circus fallback step using `reactivecircus/android-emulator-runner@v2`
- Fallback only runs when Firebase tests fail (`if: always() && steps.firebase_tests.outcome == 'failure'`)
- Added comprehensive result checking logic that passes if either test suite succeeds
- Maintains all existing environment variables and secrets for test execution