### PR TITLE
WEBRTC-3146: Add development TURN/STUN server configuration support

### DIFF
--- a/packages/telnyx_webrtc/lib/config.dart
+++ b/packages/telnyx_webrtc/lib/config.dart
@@ -6,6 +6,8 @@ class DefaultConfig {
       'wss://${DefaultConfig.telnyxProdHostAddress}:${DefaultConfig.telnyxPort}';
   static const String defaultTurn = 'turn:turn.telnyx.com:3478?transport=tcp';
   static const String defaultStun = 'stun:stun.telnyx.com:3478';
+  static const String devTurn = 'turn:turndev.telnyx.com:3478?transport=tcp';
+  static const String devStun = 'stun:stundev.telnyx.com:3478';
   static const username = 'testuser';
   static const password = 'testpassword';
 }

--- a/packages/telnyx_webrtc/lib/config/telnyx_config.dart
+++ b/packages/telnyx_webrtc/lib/config/telnyx_config.dart
@@ -1,6 +1,7 @@
 import 'package:telnyx_webrtc/utils/logging/log_level.dart';
 import 'package:telnyx_webrtc/utils/logging/custom_logger.dart';
 import 'package:telnyx_webrtc/model/region.dart';
+import 'package:telnyx_webrtc/model/tx_server_configuration.dart';
 
 /// Base configuration class for common parameters
 class Config {
@@ -20,7 +21,9 @@ class Config {
     this.region = Region.auto,
     this.fallbackOnRegionFailure = true,
     this.forceRelayCandidate = false,
-  });
+    TxServerConfiguration? serverConfiguration,
+  }) : serverConfiguration =
+           serverConfiguration ?? TxServerConfiguration.production();
 
   /// Name associated with the SIP account
   final String sipCallerIDName;
@@ -71,6 +74,11 @@ class Config {
   ///   as all media will be relayed through TURN servers.
   /// - Important: This setting is disabled by default to maintain optimal call quality.
   final bool forceRelayCandidate;
+
+  /// Server configuration for TURN/STUN servers and WebSocket host.
+  /// Use [TxServerConfiguration.production] for production environment (default)
+  /// or [TxServerConfiguration.development] for development environment.
+  final TxServerConfiguration serverConfiguration;
 }
 
 /// Creates an instance of CredentialConfig which can be used to log in
@@ -87,6 +95,7 @@ class Config {
 /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
 /// [pushAnswerTimeout] is the timeout in milliseconds to wait for INVITE after accepting from push notification (default: 10000ms)
 /// [forceRelayCandidate] controls whether the SDK should force TURN relay for peer connections (default: false)
+/// [serverConfiguration] is the server configuration for TURN/STUN servers (defaults to production)
 class CredentialConfig extends Config {
   /// Creates an instance of CredentialConfig which can be used to log in
   ///
@@ -101,6 +110,7 @@ class CredentialConfig extends Config {
   /// [ringbackPath] is the path to the ringback file (audio to play when calling)
   /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
   /// [pushAnswerTimeout] is the timeout in milliseconds to wait for INVITE after accepting from push notification (default: 10000ms)
+  /// [serverConfiguration] is the server configuration for TURN/STUN servers (defaults to production)
   CredentialConfig({
     required this.sipUser,
     required this.sipPassword,
@@ -118,6 +128,7 @@ class CredentialConfig extends Config {
     super.region = Region.auto,
     super.fallbackOnRegionFailure = true,
     super.forceRelayCandidate = false,
+    super.serverConfiguration,
   });
 
   /// SIP username to log in with. Either a SIP Credential from the Portal or a Generated Credential from the API
@@ -141,6 +152,7 @@ class CredentialConfig extends Config {
 /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
 /// [pushAnswerTimeout] is the timeout in milliseconds to wait for INVITE after accepting from push notification (default: 10000ms)
 /// [forceRelayCandidate] controls whether the SDK should force TURN relay for peer connections (default: false)
+/// [serverConfiguration] is the server configuration for TURN/STUN servers (defaults to production)
 class TokenConfig extends Config {
   /// Creates an instance of TokenConfig which can be used to log in
   ///
@@ -155,6 +167,7 @@ class TokenConfig extends Config {
   /// [ringbackPath] is the path to the ringback file (audio to play when calling)
   /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
   /// [pushAnswerTimeout] is the timeout in milliseconds to wait for INVITE after accepting from push notification (default: 10000ms)
+  /// [serverConfiguration] is the server configuration for TURN/STUN servers (defaults to production)
   TokenConfig({
     required this.sipToken,
     required super.sipCallerIDName,
@@ -171,6 +184,7 @@ class TokenConfig extends Config {
     super.region = Region.auto,
     super.fallbackOnRegionFailure = true,
     super.forceRelayCandidate = false,
+    super.serverConfiguration,
   });
 
   /// Token to log in with. The token would be generated from a Generated Credential via the API

--- a/packages/telnyx_webrtc/lib/model/tx_server_configuration.dart
+++ b/packages/telnyx_webrtc/lib/model/tx_server_configuration.dart
@@ -1,0 +1,85 @@
+import 'package:telnyx_webrtc/config.dart';
+
+/// Configuration class for Telnyx server settings.
+///
+/// This class holds the configuration for connecting to Telnyx servers,
+/// including the host address, port, and TURN/STUN server URLs.
+///
+/// Use the factory constructors [TxServerConfiguration.production] and
+/// [TxServerConfiguration.development] to create configurations for
+/// the respective environments.
+class TxServerConfiguration {
+  /// Creates a new [TxServerConfiguration] with the specified settings.
+  ///
+  /// [host] - The WebSocket host address (e.g., 'rtc.telnyx.com')
+  /// [port] - The WebSocket port (default: 443)
+  /// [turn] - The TURN server URL
+  /// [stun] - The STUN server URL
+  const TxServerConfiguration({
+    this.host = DefaultConfig.telnyxProdHostAddress,
+    this.port = DefaultConfig.telnyxPort,
+    this.turn = DefaultConfig.defaultTurn,
+    this.stun = DefaultConfig.defaultStun,
+  });
+
+  /// The WebSocket host address
+  final String host;
+
+  /// The WebSocket port
+  final int port;
+
+  /// The TURN server URL
+  final String turn;
+
+  /// The STUN server URL
+  final String stun;
+
+  /// Creates a production server configuration with default production values.
+  ///
+  /// Uses:
+  /// - Host: rtc.telnyx.com
+  /// - TURN: turn.telnyx.com:3478
+  /// - STUN: stun.telnyx.com:3478
+  factory TxServerConfiguration.production() => const TxServerConfiguration(
+    host: DefaultConfig.telnyxProdHostAddress,
+    port: DefaultConfig.telnyxPort,
+    turn: DefaultConfig.defaultTurn,
+    stun: DefaultConfig.defaultStun,
+  );
+
+  /// Creates a development server configuration with default development values.
+  ///
+  /// Uses:
+  /// - Host: rtcdev.telnyx.com
+  /// - TURN: turndev.telnyx.com:3478
+  /// - STUN: stundev.telnyx.com:3478
+  factory TxServerConfiguration.development() => const TxServerConfiguration(
+    host: DefaultConfig.telnyxDevHostAddress,
+    port: DefaultConfig.telnyxPort,
+    turn: DefaultConfig.devTurn,
+    stun: DefaultConfig.devStun,
+  );
+
+  /// Returns the full WebSocket URL for this configuration.
+  String get socketUrl => 'wss://$host:$port';
+
+  /// Creates a copy of this configuration with the specified fields replaced.
+  TxServerConfiguration copyWith({
+    String? host,
+    int? port,
+    String? turn,
+    String? stun,
+  }) {
+    return TxServerConfiguration(
+      host: host ?? this.host,
+      port: port ?? this.port,
+      turn: turn ?? this.turn,
+      stun: stun ?? this.stun,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'TxServerConfiguration(host: $host, port: $port, turn: $turn, stun: $stun)';
+  }
+}

--- a/packages/telnyx_webrtc/lib/telnyx_webrtc.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_webrtc.dart
@@ -12,6 +12,7 @@ export './model/socket_method.dart';
 export './model/telnyx_message.dart';
 export './model/telnyx_socket_error.dart';
 export './model/socket_connection_metrics.dart';
+export './model/tx_server_configuration.dart';
 
 export './model/verto/receive/ai_conversation_message.dart';
 export './model/verto/receive/auth_failure_message_body.dart';


### PR DESCRIPTION
## Summary

This PR adds support for configuring development TURN/STUN servers in the Flutter WebRTC SDK, allowing developers to use `turndev.telnyx.com` and `stundev.telnyx.com` instead of production servers when testing in development environments.

## Jira Ticket
[WEBRTC-3146](https://telnyx.atlassian.net/browse/WEBRTC-3146)

## Changes

### New Files
- `packages/telnyx_webrtc/lib/model/tx_server_configuration.dart`: New `TxServerConfiguration` class with `production()` and `development()` factory methods

### Modified Files
- `packages/telnyx_webrtc/lib/config.dart`: Added `devTurn` and `devStun` constants
- `packages/telnyx_webrtc/lib/config/telnyx_config.dart`: Added `serverConfiguration` parameter to `Config`, `CredentialConfig`, and `TokenConfig`
- `packages/telnyx_webrtc/lib/peer/peer.dart`: Updated constructor to accept `providedTurn` and `providedStun` parameters
- `packages/telnyx_webrtc/lib/peer/web/peer.dart`: Same changes as mobile peer
- `packages/telnyx_webrtc/lib/telnyx_client.dart`: Updated to pass server configuration to Peer instances
- `packages/telnyx_webrtc/lib/telnyx_webrtc.dart`: Exported `TxServerConfiguration`

## Usage

```dart
// For production (default)
final config = CredentialConfig(
  sipUser: 'user',
  sipPassword: 'password',
  sipCallerIDName: 'Caller',
  sipCallerIDNumber: '+1234567890',
);

// For development
final config = CredentialConfig(
  sipUser: 'user',
  sipPassword: 'password',
  sipCallerIDName: 'Caller',
  sipCallerIDNumber: '+1234567890',
  serverConfiguration: TxServerConfiguration.development(),
);
```

## Related
- Clone of [WEBRTC-3133](https://telnyx.atlassian.net/browse/WEBRTC-3133) (Android implementation)
- Original ENGDESK ticket: [ENGDESK-47474](https://telnyx.atlassian.net/browse/ENGDESK-47474)

## Testing
- [ ] Manual testing with development environment
- [ ] Verify TURN/STUN server connections

[WEBRTC-3146]: https://telnyx.atlassian.net/browse/WEBRTC-3146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBRTC-3133]: https://telnyx.atlassian.net/browse/WEBRTC-3133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ