### PR TITLE
WEBRTC-3438: Add SDK latency tracking system

### DIFF
--- a/packages/telnyx_webrtc/lib/call.dart
+++ b/packages/telnyx_webrtc/lib/call.dart
@@ -383,6 +383,11 @@ class Call {
     _txClient.onCallStateChangedToActive(callId);
 
     _txClient.calls.remove(callId);
+
+    // Cancel latency tracking for this call
+    if (callId != null) {
+      _txClient.latencyTracker.cancelCallTracking(callId!);
+    }
     final message = TelnyxMessage(
       socketMethod: SocketMethod.bye,
       message: ReceivedMessage(method: 'telnyx_rtc.bye'),

--- a/packages/telnyx_webrtc/lib/model/latency_metrics.dart
+++ b/packages/telnyx_webrtc/lib/model/latency_metrics.dart
@@ -1,0 +1,100 @@
+/// Data class representing latency measurements for WebRTC call establishment.
+/// These metrics help developers understand the time taken for each step in the call flow.
+///
+/// All time values are in milliseconds.
+class LatencyMetrics {
+  /// The unique identifier for the call these metrics belong to (null for registration metrics)
+  final String? callId;
+
+  /// True if this is an outbound call, false for inbound
+  final bool isOutbound;
+
+  /// Time from login initiation to successful registration (CLIENT_READY)
+  final int? registrationLatencyMs;
+
+  /// Time from call initiation (newInvite/acceptCall) to ACTIVE state
+  final int? callSetupLatencyMs;
+
+  /// Time from call initiation to first RTP packet sent/received
+  final int? timeToFirstRtpMs;
+
+  /// Time spent gathering ICE candidates
+  final int? iceGatheringLatencyMs;
+
+  /// Time spent in SIP signaling (INVITE to answer)
+  final int? signalingLatencyMs;
+
+  /// Time from signaling complete to media flowing
+  final int? mediaEstablishmentLatencyMs;
+
+  /// Detailed breakdown of individual milestones with timestamps
+  final Map<String, int> milestones;
+
+  /// Timestamp when these metrics were collected
+  final int timestamp;
+
+  const LatencyMetrics({
+    this.callId,
+    this.isOutbound = false,
+    this.registrationLatencyMs,
+    this.callSetupLatencyMs,
+    this.timeToFirstRtpMs,
+    this.iceGatheringLatencyMs,
+    this.signalingLatencyMs,
+    this.mediaEstablishmentLatencyMs,
+    this.milestones = const {},
+    int? timestamp,
+  }) : timestamp = timestamp ?? _nowMs();
+
+  static int _nowMs() => DateTime.now().millisecondsSinceEpoch;
+
+  /// Returns a formatted string representation of the latency metrics.
+  @override
+  String toString() {
+    final isRegistration = callId == null && registrationLatencyMs != null;
+    final header = isRegistration
+        ? 'REGISTRATION LATENCY METRICS'
+        : '${isOutbound ? "OUTBOUND" : "INBOUND"} CALL LATENCY METRICS';
+
+    final sb = StringBuffer()
+      ..writeln('═══════════════════════════════════════════════════')
+      ..writeln('       $header')
+      ..writeln('═══════════════════════════════════════════════════');
+
+    if (callId != null) sb.writeln('Call ID: $callId');
+    if (registrationLatencyMs != null) {
+      sb.writeln('Registration Latency:      ${registrationLatencyMs}ms');
+    }
+    if (callSetupLatencyMs != null) {
+      sb.writeln('Call Setup Latency:        ${callSetupLatencyMs}ms');
+    }
+    if (timeToFirstRtpMs != null) {
+      sb.writeln('Time to First RTP:         ${timeToFirstRtpMs}ms');
+    }
+    if (iceGatheringLatencyMs != null) {
+      sb.writeln('ICE Gathering Latency:     ${iceGatheringLatencyMs}ms');
+    }
+    if (signalingLatencyMs != null) {
+      sb.writeln('Signaling Latency:         ${signalingLatencyMs}ms');
+    }
+    if (mediaEstablishmentLatencyMs != null) {
+      sb.writeln('Media Establishment:       ${mediaEstablishmentLatencyMs}ms');
+    }
+
+    if (milestones.isNotEmpty) {
+      sb.writeln('───────────────────────────────────────────────────');
+      sb.writeln('Detailed Milestones:');
+      final sorted = milestones.entries.toList()
+        ..sort((a, b) => a.value.compareTo(b.value));
+      for (final entry in sorted) {
+        sb.writeln('  ${entry.key.padRight(35)} ${entry.value}ms');
+      }
+    }
+    sb.writeln('═══════════════════════════════════════════════════');
+
+    return sb.toString();
+  }
+}
+
+/// Callback for receiving latency metrics updates.
+typedef LatencyMetricsCallback = void Function(LatencyMetrics metrics);

--- a/packages/telnyx_webrtc/lib/model/latency_metrics.dart
+++ b/packages/telnyx_webrtc/lib/model/latency_metrics.dart
@@ -33,7 +33,7 @@ class LatencyMetrics {
   /// Timestamp when these metrics were collected
   final int timestamp;
 
-  const LatencyMetrics({
+  LatencyMetrics({
     this.callId,
     this.isOutbound = false,
     this.registrationLatencyMs,

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -31,6 +31,7 @@ import 'package:telnyx_webrtc/model/jsonrpc.dart';
 import 'package:telnyx_webrtc/model/audio_codec.dart';
 import 'package:telnyx_webrtc/model/audio_constraints.dart';
 import 'package:telnyx_webrtc/utils/call_timing_benchmark.dart';
+import 'package:telnyx_webrtc/utils/latency_tracker.dart';
 
 /// Represents a peer in the WebRTC communication.
 class Peer {
@@ -312,6 +313,10 @@ class Peer {
         );
         CallTimingBenchmark.mark('offer_created');
 
+        // Latency milestones
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneSdpNegotiationStarted);
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
+
         // For Android: Modify SDP to filter codecs
         String? sdpToUse = s.sdp;
         if (preferredCodecs != null &&
@@ -330,6 +335,9 @@ class Peer {
           RTCSessionDescription(sdpToUse, s.type),
         );
         CallTimingBenchmark.mark('local_offer_sdp_set');
+
+        // Latency milestone
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpSet);
 
         // Get the SDP immediately - it should not contain candidates yet
         String? sdpUsed = s.sdp;
@@ -375,6 +383,9 @@ class Peer {
         );
         _send(jsonInviteMessage);
         CallTimingBenchmark.mark('invite_sent');
+
+        // Latency milestone
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneInviteSent);
       } else {
         // Traditional ICE gathering - use negotiation timer
         final RTCSessionDescription s =
@@ -382,8 +393,16 @@ class Peer {
           _dcConstraints,
         );
         CallTimingBenchmark.mark('offer_created');
+
+        // Latency milestones
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneSdpNegotiationStarted);
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
+
         await session.peerConnection!.setLocalDescription(s);
         CallTimingBenchmark.mark('local_offer_sdp_set');
+
+        // Latency milestone
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpSet);
 
         if (session.remoteCandidates.isNotEmpty) {
           for (var candidate in session.remoteCandidates) {
@@ -437,6 +456,10 @@ class Peer {
           CallTimingBenchmark.mark('ice_gathering_complete');
           _send(jsonInviteMessage);
           CallTimingBenchmark.mark('invite_sent');
+
+          // Latency milestones
+          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceGatheringComplete);
+          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneInviteSent);
         });
       }
     } catch (e) {
@@ -457,6 +480,20 @@ class Peer {
           RTCSessionDescription(sdp, 'answer'),
         );
     CallTimingBenchmark.mark('remote_answer_sdp_set');
+
+    // Latency milestones for outbound call remote SDP
+    // Find the call ID for the current session
+    String? remoteSdpCallId;
+    for (final call in _txClient.calls.values) {
+      if (call.peerConnection == this) {
+        remoteSdpCallId = call.callId;
+        break;
+      }
+    }
+    if (remoteSdpCallId != null) {
+      _txClient.latencyTracker.markCallMilestone(remoteSdpCallId!, LatencyTracker.milestoneRemoteSdpReceived);
+      _txClient.latencyTracker.markCallMilestone(remoteSdpCallId!, LatencyTracker.milestoneRemoteSdpSet);
+    }
 
     // Process any queued candidates after setting remote SDP
     final session = _sessions[_selfId];
@@ -519,6 +556,10 @@ class Peer {
       RTCSessionDescription(invite.sdp, 'offer'),
     );
     CallTimingBenchmark.mark('remote_sdp_set');
+
+    // Latency milestones for inbound call remote SDP
+    _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneRemoteSdpReceived);
+    _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneRemoteSdpSet);
 
     // Process any queued candidates after setting remote SDP
     if (session.remoteCandidates.isNotEmpty) {
@@ -583,6 +624,19 @@ class Peer {
             if (_useTrickleIce) {
               // With trickle ICE, send all candidates immediately
               _sendTrickleCandidate(candidate, callId);
+
+              // Latency milestones for ICE candidates in answer path
+              final currentMetrics = _txClient.latencyTracker.getCurrentCallMetrics(callId);
+              if (currentMetrics == null || !currentMetrics.milestones.containsKey(LatencyTracker.milestoneFirstIceCandidate)) {
+                _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneFirstIceCandidate);
+              }
+              // Detect first srflx/relay candidate
+              final candidateStr = candidate.candidate.toString().toLowerCase();
+              if (candidateStr.contains('srflx')) {
+                _txClient.latencyTracker.markFirstSrflxRelayCandidate(callId, 'srflx');
+              } else if (candidateStr.contains('relay')) {
+                _txClient.latencyTracker.markFirstSrflxRelayCandidate(callId, 'relay');
+              }
             } else {
               // Traditional ICE: filter and collect candidates
               final candidateString = candidate.candidate.toString();
@@ -618,9 +672,16 @@ class Peer {
             await session.peerConnection!.createAnswer(_dcConstraints);
         CallTimingBenchmark.mark('local_answer_created');
 
+        // Latency milestones
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneSdpNegotiationStarted);
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
+
         // For trickle ICE, we set the local description but don't wait for candidates
         await session.peerConnection!.setLocalDescription(s);
         CallTimingBenchmark.mark('local_sdp_set');
+
+        // Latency milestone
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpSet);
 
         // Get the SDP immediately - it should not contain candidates yet
         String? sdpUsed = s.sdp;
@@ -665,11 +726,22 @@ class Peer {
             .i('Peer :: Sending ANSWER with trickle ICE enabled (immediate)');
         _send(jsonAnswerMessage);
         CallTimingBenchmark.mark('answer_sent');
+
+        // Latency milestone
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneAnswerSent);
       } else {
         // Traditional ICE gathering - wait for candidates
         final RTCSessionDescription s =
             await session.peerConnection!.createAnswer(_dcConstraints);
+
+        // Latency milestones
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneSdpNegotiationStarted);
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
+
         await session.peerConnection!.setLocalDescription(s);
+
+        // Latency milestone
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpSet);
 
         _lastCandidateTime = DateTime.now();
         _setOnNegotiationComplete(() async {
@@ -711,6 +783,10 @@ class Peer {
 
           final String jsonAnswerMessage = jsonEncode(answerMessage);
           _send(jsonAnswerMessage);
+
+          // Latency milestones
+          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceGatheringComplete);
+          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneAnswerSent);
         });
       }
     } catch (e) {
@@ -781,6 +857,10 @@ class Peer {
       peerConnection = results[1] as RTCPeerConnection;
       CallTimingBenchmark.mark('peer_connection_created');
 
+      // Latency milestones
+      _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneMediaDevicesAcquired);
+      _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestonePeerCreated);
+
       // Apply initial mute state if requested
       if (_initialMuteState && _localStream != null) {
         final audioTracks = _localStream!.getAudioTracks();
@@ -801,6 +881,9 @@ class Peer {
       );
       CallTimingBenchmark.mark('peer_connection_created');
     }
+
+    // Latency milestone for data-only mode
+    _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestonePeerCreated);
 
     // Start stats asynchronously (non-blocking) to avoid delaying call setup
     unawaited(
@@ -858,6 +941,19 @@ class Peer {
             'Peer :: Sending trickle ICE candidate: ${candidate.candidate}',
           );
           CallTimingBenchmark.markFirstCandidate();
+
+          // Latency milestones for ICE candidates
+          final currentMetrics = _txClient.latencyTracker.getCurrentCallMetrics(callId);
+          if (currentMetrics == null || !currentMetrics.milestones.containsKey(LatencyTracker.milestoneFirstIceCandidate)) {
+            _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneFirstIceCandidate);
+          }
+          // Detect first srflx/relay candidate
+          final candidateStr = candidate.candidate.toString().toLowerCase();
+          if (candidateStr.contains('srflx')) {
+            _txClient.latencyTracker.markFirstSrflxRelayCandidate(callId, 'srflx');
+          } else if (candidateStr.contains('relay')) {
+            _txClient.latencyTracker.markFirstSrflxRelayCandidate(callId, 'relay');
+          }
           _sendTrickleCandidate(candidate, callId);
 
           // Reset the trickle ICE timer when a candidate is generated
@@ -892,6 +988,22 @@ class Peer {
       GlobalLogger().i('Peer :: ICE Connection State change :: $state');
       // Benchmark all ICE connection state transitions
       CallTimingBenchmark.mark('ice_state_${state.name}');
+
+      // Latency milestones for ICE connection states
+      switch (state) {
+        case RTCIceConnectionState.RTCIceConnectionStateChecking:
+          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceChecking);
+          break;
+        case RTCIceConnectionState.RTCIceConnectionStateConnected:
+          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceConnected);
+          break;
+        case RTCIceConnectionState.RTCIceConnectionStateCompleted:
+          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceCompleted);
+          break;
+        default:
+          break;
+      }
+
       // Log to call report
       _callReportLogCollector?.logIceConnectionStateChanged(
         callId: callId,
@@ -964,11 +1076,19 @@ class Peer {
     peerConnection?.onConnectionState = (state) {
       GlobalLogger().i('Peer :: Peer Connection State change :: $state');
       CallTimingBenchmark.mark('peer_state_${state.name}');
-      if (state == RTCPeerConnectionState.RTCPeerConnectionStateConnected) {
+      if (state == RTCPeerConnectionState.RTCPeerConnectionStateConnecting) {
+        // DTLS handshake starts during peer connection connecting phase
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneDtlsConnecting);
+      } else if (state == RTCPeerConnectionState.RTCPeerConnectionStateConnected) {
         final Call? currentCall = _txClient.calls[callId];
         currentCall?.callHandler.changeState(CallState.active);
         onCallStateChange?.call(newSession, CallState.active);
         CallTimingBenchmark.end();
+
+        // Latency milestones
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneDtlsConnected);
+        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestonePeerConnected);
+        _txClient.latencyTracker.completeCallTracking(callId);
       }
     };
 
@@ -983,6 +1103,17 @@ class Peer {
 
     peerConnection?.onIceGatheringState = (state) {
       GlobalLogger().i('Peer :: ICE Gathering State change :: $state');
+      // Latency milestones for ICE gathering
+      switch (state) {
+        case RTCIceGatheringState.RTCIceGatheringStateGathering:
+          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceGatheringStarted);
+          break;
+        case RTCIceGatheringState.RTCIceGatheringStateComplete:
+          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceGatheringComplete);
+          break;
+        default:
+          break;
+      }
       // Log to call report
       _callReportLogCollector?.logIceGatheringStateChanged(
         callId: callId,
@@ -1002,6 +1133,10 @@ class Peer {
     };
 
     newSession.peerConnection = peerConnection;
+
+    // Mark peer setup complete for latency tracking
+    _txClient.latencyTracker.markPeerSetupComplete(callId);
+
     return newSession;
   }
 

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -49,6 +49,8 @@ import 'package:telnyx_webrtc/utils/candidate_utils.dart';
 import 'package:telnyx_webrtc/model/socket_connection_metrics.dart';
 import 'package:telnyx_webrtc/model/tx_server_configuration.dart';
 import 'package:telnyx_webrtc/model/audio_constraints.dart';
+import 'package:telnyx_webrtc/model/latency_metrics.dart';
+import 'package:telnyx_webrtc/utils/latency_tracker.dart';
 
 /// Callback for when the socket receives a message
 typedef OnSocketMessageReceived = void Function(TelnyxMessage message);
@@ -148,6 +150,10 @@ class TelnyxClient {
 
     _checkReconnection();
   }
+
+  /// The latency tracker instance for this client.
+  /// Access via `telnyxClient.latencyTracker` to read metrics or set a listener.
+  final LatencyTracker latencyTracker = LatencyTracker();
 
   /// The current instance of [TxSocket] associated with this client
   TxSocket txSocket = TxSocket(DefaultConfig.socketHostAddress);
@@ -1036,6 +1042,9 @@ class TelnyxClient {
     // Store current config for potential fallback
     _currentConfig = tokenConfig;
 
+    // Start registration latency tracking
+    latencyTracker.startRegistrationTracking();
+
     // First check if there is a custom logger set within the config - if so, we set it here
     _logger = tokenConfig.customLogger ?? DefaultLogger();
     GlobalLogger.logger = _logger;
@@ -1068,6 +1077,7 @@ class TelnyxClient {
           GlobalLogger().i(
             'TelnyxClient.connectWithToken (via _onOpen): Web Socket is now connected',
           );
+          latencyTracker.markRegistrationMilestone(LatencyTracker.milestoneSocketConnected);
           _onOpen();
           tokenLogin(tokenConfig);
         }
@@ -1095,6 +1105,9 @@ class TelnyxClient {
   void connectWithCredential(CredentialConfig credentialConfig) {
     // Store current config for potential fallback
     _currentConfig = credentialConfig;
+
+    // Start registration latency tracking
+    latencyTracker.startRegistrationTracking();
 
     // First check if there is a custom logger set within the config - if so, we set it here
     // Use custom logger if provided or fallback to default.
@@ -1127,6 +1140,7 @@ class TelnyxClient {
           GlobalLogger().i(
             'TelnyxClient.connectWithCredential (via _onOpen): Web Socket is now connected',
           );
+          latencyTracker.markRegistrationMilestone(LatencyTracker.milestoneSocketConnected);
           _onOpen();
           credentialLogin(credentialConfig);
         }
@@ -1314,6 +1328,11 @@ class TelnyxClient {
   @Deprecated('Use connectWithCredential(..) instead')
   void credentialLogin(CredentialConfig config) {
     _storedCredentialConfig = config;
+    // Only start registration tracking if not already started by connectWithCredential
+    if (!latencyTracker.isTrackingRegistration) {
+      latencyTracker.startRegistrationTracking();
+    }
+    latencyTracker.markRegistrationMilestone(LatencyTracker.milestoneLoginSent);
     final uuid = const Uuid().v4();
     final user = config.sipUser;
     final password = config.sipPassword;
@@ -1368,6 +1387,11 @@ class TelnyxClient {
   @Deprecated('Use connectWithToken(..) instead')
   void tokenLogin(TokenConfig config) {
     _storedTokenConfig = config;
+    // Only start registration tracking if not already started by connectWithToken
+    if (!latencyTracker.isTrackingRegistration) {
+      latencyTracker.startRegistrationTracking();
+    }
+    latencyTracker.markRegistrationMilestone(LatencyTracker.milestoneLoginSent);
     final uuid = const Uuid().v4();
     final token = config.sipToken;
     final fcmToken = config.notificationToken;
@@ -1567,6 +1591,9 @@ class TelnyxClient {
     final base64State = base64.encode(utf8.encode(clientState));
     updateCall(inviteCall);
 
+    // Start latency tracking for outbound call
+    latencyTracker.startCallTracking(inviteCall.callId!, isOutbound: true);
+
     // Create the peer connection with debug enabled if requested
     inviteCall.peerConnection = Peer(
       inviteCall.txSocket,
@@ -1656,6 +1683,10 @@ class TelnyxClient {
       ..sessionClientState = clientState;
 
     final destinationNum = invite.callerIdNumber;
+
+    // Start latency tracking for inbound call
+    latencyTracker.startCallTracking(answerCall.callId!, isOutbound: false);
+    latencyTracker.markAnswerInitiated(answerCall.callId!);
 
     // Create the peer connection
     answerCall.peerConnection = Peer(
@@ -1895,6 +1926,9 @@ class TelnyxClient {
                       _invalidateGatewayResponseTimer();
                       _resetGatewayCounters();
                       gatewayState = GatewayState.reged;
+                      
+                      // Complete registration latency tracking
+                      latencyTracker.completeRegistrationTracking();
                       
                       // Store call_report_id for call report authentication
                       callReportId = stateMessage.resultParams?.stateParams?.callReportId;
@@ -2138,6 +2172,12 @@ class TelnyxClient {
                     ..callId = invite.inviteParams?.callID;
                   updateCall(offerCall);
 
+                  // Mark invite received for latency tracking
+                  if (offerCall.callId != null) {
+                    latencyTracker.startCallTracking(offerCall.callId!, isOutbound: false);
+                    latencyTracker.markInviteReceived(offerCall.callId!);
+                  }
+
                   onSocketMessageReceived.call(message);
 
                   offerCall.callHandler.changeState(CallState.ringing);
@@ -2252,6 +2292,12 @@ class TelnyxClient {
                     );
                   }
 
+                  // Mark latency milestones for answer received
+                  if (answerCall.callId != null) {
+                    latencyTracker.markCallMilestone(answerCall.callId!, LatencyTracker.milestoneRemoteSdpReceived);
+                    latencyTracker.markCallAnsweredByRemote(answerCall.callId!);
+                  }
+
                   final message = TelnyxMessage(
                     socketMethod: SocketMethod.answer,
                     message: inviteAnswer,
@@ -2334,6 +2380,11 @@ class TelnyxClient {
                   );
 
                   calls.remove(byeCall.callId);
+
+                  // Cancel latency tracking for this call
+                  if (byeCall.callId != null) {
+                    latencyTracker.cancelCallTracking(byeCall.callId!);
+                  }
                   break;
                 }
               case SocketMethod.ringing:
@@ -2348,6 +2399,11 @@ class TelnyxClient {
                     );
                     _sendNoCallError();
                     return;
+                  }
+
+                  // Mark remote ringing for latency tracking (outbound calls)
+                  if (ringingCall.callId != null) {
+                    latencyTracker.markRemoteRinging(ringingCall.callId!);
                   }
 
                   // Send ringing acknowledgement

--- a/packages/telnyx_webrtc/lib/telnyx_webrtc.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_webrtc.dart
@@ -34,3 +34,6 @@ export './peer/peer.dart';
 
 export './utils/stats/call_report_collector.dart';
 export './utils/stats/call_report_log_collector.dart';
+
+export './model/latency_metrics.dart';
+export './utils/latency_tracker.dart';

--- a/packages/telnyx_webrtc/lib/utils/latency_tracker.dart
+++ b/packages/telnyx_webrtc/lib/utils/latency_tracker.dart
@@ -1,0 +1,364 @@
+import 'dart:async';
+
+import 'package:telnyx_webrtc/model/latency_metrics.dart';
+import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
+
+/// Tracks and calculates latency metrics for WebRTC call establishment.
+///
+/// This class provides detailed timing information for:
+/// - Registration latency: Time from login to CLIENT_READY
+/// - Inbound call latency: Time from acceptCall() to first RTP packet
+/// - Outbound call latency: Time from newInvite() to first RTP packet
+class LatencyTracker {
+  // Milestone names for registration
+  static const String milestoneLoginInitiated = 'login_initiated';
+  static const String milestoneSocketConnected = 'socket_connected';
+  static const String milestoneLoginSent = 'login_sent';
+  static const String milestoneClientReady = 'client_ready';
+
+  // Milestone names for calls
+  static const String milestoneCallInitiated = 'call_initiated';
+  static const String milestonePeerCreated = 'peer_connection_created';
+  static const String milestonePeerSetupComplete = 'peer_setup_complete';
+  static const String milestoneMediaDevicesAcquired = 'media_devices_acquired';
+  static const String milestoneSdpNegotiationStarted = 'sdp_negotiation_started';
+  static const String milestoneLocalSdpCreated = 'local_sdp_created';
+  static const String milestoneLocalSdpSet = 'local_sdp_set';
+  static const String milestoneInviteSent = 'invite_sent';
+  static const String milestoneAnswerSent = 'answer_sent';
+  static const String milestoneRemoteSdpReceived = 'remote_sdp_received';
+  static const String milestoneRemoteSdpSet = 'remote_sdp_set';
+
+  // Inbound call specific milestones
+  static const String milestoneInviteReceived = 'invite_received';
+  static const String milestoneAnswerInitiated = 'answer_initiated';
+
+  // Outbound call specific milestones
+  static const String milestoneRemoteRinging = 'remote_side_ringing';
+  static const String milestoneCallAnsweredByRemote = 'call_answered_by_remote';
+
+  // ICE gathering milestones
+  static const String milestoneIceGatheringStarted = 'ice_gathering_started';
+  static const String milestoneFirstIceCandidate = 'first_ice_candidate';
+  static const String milestoneFirstSrflxRelayCandidate =
+      'first_srflx_relay_candidate';
+  static const String milestoneIceGatheringComplete = 'ice_gathering_complete';
+
+  // ICE connection milestones
+  static const String milestoneIceChecking = 'ice_checking';
+  static const String milestoneIceConnected = 'ice_connected';
+  static const String milestoneIceCompleted = 'ice_completed';
+
+  // DTLS milestones
+  static const String milestoneDtlsConnecting = 'dtls_connecting';
+  static const String milestoneDtlsConnected = 'dtls_connected';
+
+  // Peer connection milestones
+  static const String milestonePeerConnected = 'peer_connected';
+  static const String milestoneFirstRtpSent = 'first_rtp_sent';
+  static const String milestoneFirstRtpReceived = 'first_rtp_received';
+  static const String milestoneMediaActive = 'media_active';
+  static const String milestoneCallActive = 'call_active';
+
+  // ===== Registration Tracking =====
+  int _registrationStartTime = 0;
+  final Map<String, int> _registrationMilestones = {};
+  bool _isTrackingRegistration = false;
+
+  /// Whether registration tracking is currently in progress.
+  bool get isTrackingRegistration => _isTrackingRegistration;
+
+  // ===== Per-Call Tracking =====
+  final Map<String, _CallTrackingState> _callTrackers = {};
+
+  // ===== Listeners =====
+  LatencyMetricsCallback? _latencyMetricsListener;
+
+  final StreamController<LatencyMetrics> _latencyMetricsController =
+      StreamController<LatencyMetrics>.broadcast();
+
+  /// Stream of latency metrics updates.
+  Stream<LatencyMetrics> get latencyMetricsStream =>
+      _latencyMetricsController.stream;
+
+  /// Sets the callback for latency metrics updates.
+  void setLatencyMetricsListener(LatencyMetricsCallback? listener) {
+    _latencyMetricsListener = listener;
+  }
+
+  // ===== Registration Tracking =====
+
+  /// Starts tracking registration latency.
+  /// Call this when login/connect is initiated.
+  void startRegistrationTracking() {
+    _registrationStartTime = DateTime.now().millisecondsSinceEpoch;
+    _registrationMilestones.clear();
+    _isTrackingRegistration = true;
+    markRegistrationMilestone(milestoneLoginInitiated);
+  }
+
+  /// Records a milestone during registration.
+  void markRegistrationMilestone(String milestone) {
+    if (!_isTrackingRegistration) return;
+    final elapsed =
+        DateTime.now().millisecondsSinceEpoch - _registrationStartTime;
+    _registrationMilestones[milestone] = elapsed;
+  }
+
+  /// Completes registration tracking and emits metrics.
+  /// Call this when CLIENT_READY is received.
+  void completeRegistrationTracking() {
+    if (!_isTrackingRegistration) return;
+
+    markRegistrationMilestone(milestoneClientReady);
+    _isTrackingRegistration = false;
+
+    final registrationLatency =
+        DateTime.now().millisecondsSinceEpoch - _registrationStartTime;
+
+    final metrics = LatencyMetrics(
+      registrationLatencyMs: registrationLatency,
+      milestones: Map.unmodifiable(_registrationMilestones),
+    );
+
+    _emitMetrics(metrics);
+    GlobalLogger().i('Registration completed in ${registrationLatency}ms');
+    GlobalLogger().d(metrics.toString());
+  }
+
+  // ===== Call Tracking =====
+
+  /// Starts tracking latency for a new call.
+  /// [callId] The unique identifier for the call.
+  /// [isOutbound] True for outbound calls, false for inbound.
+  void startCallTracking(String callId, {bool isOutbound = false}) {
+    _callTrackers[callId] = _CallTrackingState(
+      startTime: DateTime.now().millisecondsSinceEpoch,
+      isOutbound: isOutbound,
+    );
+    markCallMilestone(callId, milestoneCallInitiated);
+  }
+
+  /// Records a milestone for a specific call.
+  void markCallMilestone(String callId, String milestone) {
+    final state = _callTrackers[callId];
+    if (state == null) return;
+    final elapsed =
+        DateTime.now().millisecondsSinceEpoch - state.startTime;
+    state.milestones[milestone] = elapsed;
+  }
+
+  /// Marks when the first RTP packet is sent or received.
+  void markFirstRtp(String callId, {bool isSent = false}) {
+    final milestone =
+        isSent ? milestoneFirstRtpSent : milestoneFirstRtpReceived;
+    markCallMilestone(callId, milestone);
+  }
+
+  /// Marks when an inbound call invite is received.
+  /// Call this when the invite arrives, before user answers.
+  void markInviteReceived(String callId) {
+    markCallMilestone(callId, milestoneInviteReceived);
+  }
+
+  /// Marks when the user initiates answering an inbound call.
+  /// Call this at the start of acceptCall().
+  void markAnswerInitiated(String callId) {
+    markCallMilestone(callId, milestoneAnswerInitiated);
+  }
+
+  /// Marks when the remote side starts ringing (outbound calls).
+  /// Call this when SIP 180 Ringing or equivalent is received.
+  void markRemoteRinging(String callId) {
+    markCallMilestone(callId, milestoneRemoteRinging);
+  }
+
+  /// Marks when the remote side answers the call (outbound calls).
+  /// Call this when SIP 200 OK or equivalent is received.
+  void markCallAnsweredByRemote(String callId) {
+    markCallMilestone(callId, milestoneCallAnsweredByRemote);
+  }
+
+  /// Marks when the first server-reflexive or relay ICE candidate is found.
+  void markFirstSrflxRelayCandidate(String callId, String candidateType) {
+    final state = _callTrackers[callId];
+    if (state == null) return;
+    // Only mark if not already marked
+    if (!state.milestones.containsKey(milestoneFirstSrflxRelayCandidate)) {
+      if (candidateType == 'srflx' || candidateType == 'relay') {
+        markCallMilestone(callId, milestoneFirstSrflxRelayCandidate);
+      }
+    }
+  }
+
+  /// Marks when media devices (microphone/camera) are acquired.
+  void markMediaDevicesAcquired(String callId) {
+    markCallMilestone(callId, milestoneMediaDevicesAcquired);
+  }
+
+  /// Marks when SDP negotiation starts (createOffer/createAnswer).
+  void markSdpNegotiationStarted(String callId) {
+    markCallMilestone(callId, milestoneSdpNegotiationStarted);
+  }
+
+  /// Marks when peer setup is complete.
+  void markPeerSetupComplete(String callId) {
+    markCallMilestone(callId, milestonePeerSetupComplete);
+  }
+
+  /// Completes call tracking and emits the final metrics.
+  /// Call this when the call reaches ACTIVE state.
+  void completeCallTracking(String callId) {
+    final state = _callTrackers[callId];
+    if (state == null) return;
+
+    markCallMilestone(callId, milestoneCallActive);
+
+    final milestones = Map<String, int>.unmodifiable(state.milestones);
+    final totalTime =
+        DateTime.now().millisecondsSinceEpoch - state.startTime;
+
+    // Calculate derived metrics
+    final iceGatheringLatency = _calculateIceGatheringLatency(milestones);
+    final signalingLatency =
+        _calculateSignalingLatency(milestones, state.isOutbound);
+    final mediaEstablishmentLatency =
+        _calculateMediaEstablishmentLatency(milestones);
+    final timeToFirstRtp = _calculateTimeToFirstRtp(milestones);
+
+    final metrics = LatencyMetrics(
+      callId: callId,
+      isOutbound: state.isOutbound,
+      callSetupLatencyMs: totalTime,
+      timeToFirstRtpMs: timeToFirstRtp,
+      iceGatheringLatencyMs: iceGatheringLatency,
+      signalingLatencyMs: signalingLatency,
+      mediaEstablishmentLatencyMs: mediaEstablishmentLatency,
+      milestones: milestones,
+    );
+
+    _emitMetrics(metrics);
+    GlobalLogger().i('Call $callId completed in ${totalTime}ms');
+    GlobalLogger().d(metrics.toString());
+
+    // Clean up
+    _callTrackers.remove(callId);
+  }
+
+  /// Cancels tracking for a call (e.g., if call fails).
+  void cancelCallTracking(String callId) {
+    _callTrackers.remove(callId);
+  }
+
+  /// Gets current metrics snapshot for a call in progress.
+  LatencyMetrics? getCurrentCallMetrics(String callId) {
+    final state = _callTrackers[callId];
+    if (state == null) return null;
+    final milestones = Map<String, int>.unmodifiable(state.milestones);
+    final currentTime =
+        DateTime.now().millisecondsSinceEpoch - state.startTime;
+
+    return LatencyMetrics(
+      callId: callId,
+      isOutbound: state.isOutbound,
+      callSetupLatencyMs: currentTime,
+      milestones: milestones,
+    );
+  }
+
+  /// Calculates the answer delay for inbound calls.
+  /// This is the time from invite received to user answering.
+  int? calculateAnswerDelay(String callId) {
+    final state = _callTrackers[callId];
+    if (state == null) return null;
+    final inviteReceived = state.milestones[milestoneInviteReceived];
+    final answerInitiated = state.milestones[milestoneAnswerInitiated];
+    if (inviteReceived == null || answerInitiated == null) return null;
+    return answerInitiated - inviteReceived;
+  }
+
+  /// Calculates the time for remote side to answer (outbound calls).
+  /// This is from invite sent to call answered.
+  int? calculateRemoteAnswerTime(String callId) {
+    final state = _callTrackers[callId];
+    if (state == null) return null;
+    final inviteSent = state.milestones[milestoneInviteSent];
+    final callAnswered = state.milestones[milestoneCallAnsweredByRemote];
+    if (inviteSent == null || callAnswered == null) return null;
+    return callAnswered - inviteSent;
+  }
+
+  /// Clears all tracking state.
+  void reset() {
+    _registrationStartTime = 0;
+    _registrationMilestones.clear();
+    _isTrackingRegistration = false;
+    _callTrackers.clear();
+  }
+
+  /// Disposes resources.
+  void dispose() {
+    _latencyMetricsController.close();
+  }
+
+  // ===== Private Helpers =====
+
+  void _emitMetrics(LatencyMetrics metrics) {
+    _latencyMetricsListener?.call(metrics);
+    if (!_latencyMetricsController.isClosed) {
+      _latencyMetricsController.add(metrics);
+    }
+  }
+
+  int? _calculateIceGatheringLatency(Map<String, int> milestones) {
+    final start = milestones[milestoneFirstIceCandidate];
+    if (start == null) return null;
+    final end = milestones[milestoneIceGatheringComplete] ??
+        milestones[milestoneIceConnected];
+    if (end == null) return null;
+    return end - start;
+  }
+
+  int? _calculateSignalingLatency(
+      Map<String, int> milestones, bool isOutbound) {
+    if (isOutbound) {
+      final start = milestones[milestoneInviteSent];
+      final end = milestones[milestoneRemoteSdpReceived];
+      if (start == null || end == null) return null;
+      return end - start;
+    } else {
+      final start = milestones[milestoneCallInitiated];
+      final end = milestones[milestoneAnswerSent];
+      if (start == null || end == null) return null;
+      return end - start;
+    }
+  }
+
+  int? _calculateMediaEstablishmentLatency(Map<String, int> milestones) {
+    final start = milestones[milestoneIceConnected] ??
+        milestones[milestonePeerConnected];
+    if (start == null) return null;
+    final end = milestones[milestoneFirstRtpReceived] ??
+        milestones[milestoneFirstRtpSent] ??
+        milestones[milestoneMediaActive];
+    if (end == null) return null;
+    return end > start ? end - start : null;
+  }
+
+  int? _calculateTimeToFirstRtp(Map<String, int> milestones) {
+    return milestones[milestoneFirstRtpReceived] ??
+        milestones[milestoneFirstRtpSent];
+  }
+}
+
+/// Internal state for per-call tracking.
+class _CallTrackingState {
+  final int startTime;
+  final bool isOutbound;
+  final Map<String, int> milestones = {};
+
+  _CallTrackingState({
+    required this.startTime,
+    required this.isOutbound,
+  });
+}

--- a/packages/telnyx_webrtc/test/utils/latency_tracker_test.dart
+++ b/packages/telnyx_webrtc/test/utils/latency_tracker_test.dart
@@ -1,0 +1,309 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:telnyx_webrtc/model/latency_metrics.dart';
+import 'package:telnyx_webrtc/utils/latency_tracker.dart';
+
+void main() {
+  group('LatencyTracker', () {
+    late LatencyTracker tracker;
+
+    setUp(() {
+      tracker = LatencyTracker();
+    });
+
+    tearDown(() {
+      tracker.dispose();
+    });
+
+    group('Registration Tracking', () {
+      test('startRegistrationTracking marks login_initiated milestone', () {
+        tracker.startRegistrationTracking();
+        expect(tracker.isTrackingRegistration, isTrue);
+
+        final metrics = tracker.getCurrentCallMetrics('__registration__');
+        // Registration tracking is separate from call tracking
+        // Verify we can mark milestones
+        tracker.markRegistrationMilestone(LatencyTracker.milestoneSocketConnected);
+        tracker.markRegistrationMilestone(LatencyTracker.milestoneLoginSent);
+        // No crash = success
+      });
+
+      test('completeRegistrationTracking emits metrics', () {
+        LatencyMetrics? receivedMetrics;
+        tracker.setLatencyMetricsListener((metrics) {
+          receivedMetrics = metrics;
+        });
+
+        tracker.startRegistrationTracking();
+        tracker.markRegistrationMilestone(LatencyTracker.milestoneSocketConnected);
+        tracker.markRegistrationMilestone(LatencyTracker.milestoneLoginSent);
+        tracker.completeRegistrationTracking();
+
+        expect(receivedMetrics, isNotNull);
+        expect(receivedMetrics!.registrationLatencyMs, isNotNull);
+        expect(receivedMetrics!.registrationLatencyMs, greaterThanOrEqualTo(0));
+        expect(
+          receivedMetrics!.milestones,
+          contains(LatencyTracker.milestoneClientReady),
+        );
+        expect(tracker.isTrackingRegistration, isFalse);
+      });
+
+      test('completeRegistrationTracking emits via stream', () async {
+        tracker.startRegistrationTracking();
+        tracker.markRegistrationMilestone(LatencyTracker.milestoneSocketConnected);
+        tracker.markRegistrationMilestone(LatencyTracker.milestoneLoginSent);
+
+        final metricsFuture = tracker.latencyMetricsStream.first;
+        tracker.completeRegistrationTracking();
+
+        final metrics = await metricsFuture;
+        expect(metrics.registrationLatencyMs, isNotNull);
+      });
+
+      test('markRegistrationMilestone does nothing when not tracking', () {
+        // Should not throw
+        tracker.markRegistrationMilestone(LatencyTracker.milestoneSocketConnected);
+      });
+    });
+
+    group('Call Tracking', () {
+      test('startCallTracking marks call_initiated milestone', () {
+        tracker.startCallTracking('call1', isOutbound: true);
+
+        final metrics = tracker.getCurrentCallMetrics('call1');
+        expect(metrics, isNotNull);
+        expect(metrics!.isOutbound, isTrue);
+        expect(metrics.milestones, contains(LatencyTracker.milestoneCallInitiated));
+      });
+
+      test('markCallMilestone records elapsed time', () async {
+        tracker.startCallTracking('call1', isOutbound: false);
+        await Future.delayed(const Duration(milliseconds: 10));
+        tracker.markCallMilestone('call1', LatencyTracker.milestonePeerCreated);
+
+        final metrics = tracker.getCurrentCallMetrics('call1');
+        expect(metrics!.milestones[LatencyTracker.milestonePeerCreated],
+            greaterThanOrEqualTo(10));
+      });
+
+      test('markCallMilestone ignores unknown call IDs', () {
+        // Should not throw
+        tracker.markCallMilestone('unknown', LatencyTracker.milestonePeerCreated);
+      });
+
+      test('completeCallTracking emits metrics and cleans up', () {
+        LatencyMetrics? receivedMetrics;
+        tracker.setLatencyMetricsListener((metrics) {
+          receivedMetrics = metrics;
+        });
+
+        tracker.startCallTracking('call1', isOutbound: true);
+        tracker.markCallMilestone('call1', LatencyTracker.milestonePeerCreated);
+        tracker.markCallMilestone('call1', LatencyTracker.milestoneInviteSent);
+        tracker.markCallMilestone('call1', LatencyTracker.milestoneIceConnected);
+        tracker.markCallMilestone('call1', LatencyTracker.milestonePeerConnected);
+        tracker.completeCallTracking('call1');
+
+        expect(receivedMetrics, isNotNull);
+        expect(receivedMetrics!.callId, 'call1');
+        expect(receivedMetrics!.isOutbound, isTrue);
+        expect(receivedMetrics!.callSetupLatencyMs, greaterThanOrEqualTo(0));
+        expect(receivedMetrics!.milestones,
+            contains(LatencyTracker.milestoneCallActive));
+
+        // Should be cleaned up
+        expect(tracker.getCurrentCallMetrics('call1'), isNull);
+      });
+
+      test('cancelCallTracking removes call without emitting', () {
+        LatencyMetrics? receivedMetrics;
+        tracker.setLatencyMetricsListener((metrics) {
+          receivedMetrics = metrics;
+        });
+
+        tracker.startCallTracking('call1', isOutbound: false);
+        tracker.cancelCallTracking('call1');
+
+        expect(receivedMetrics, isNull);
+        expect(tracker.getCurrentCallMetrics('call1'), isNull);
+      });
+    });
+
+    group('Inbound Call Milestones', () {
+      test('markInviteReceived records milestone', () {
+        tracker.startCallTracking('call1', isOutbound: false);
+        tracker.markInviteReceived('call1');
+
+        final metrics = tracker.getCurrentCallMetrics('call1');
+        expect(metrics!.milestones,
+            contains(LatencyTracker.milestoneInviteReceived));
+      });
+
+      test('markAnswerInitiated records milestone', () {
+        tracker.startCallTracking('call1', isOutbound: false);
+        tracker.markAnswerInitiated('call1');
+
+        final metrics = tracker.getCurrentCallMetrics('call1');
+        expect(metrics!.milestones,
+            contains(LatencyTracker.milestoneAnswerInitiated));
+      });
+    });
+
+    group('Outbound Call Milestones', () {
+      test('markRemoteRinging records milestone', () {
+        tracker.startCallTracking('call1', isOutbound: true);
+        tracker.markRemoteRinging('call1');
+
+        final metrics = tracker.getCurrentCallMetrics('call1');
+        expect(metrics!.milestones,
+            contains(LatencyTracker.milestoneRemoteRinging));
+      });
+
+      test('markCallAnsweredByRemote records milestone', () {
+        tracker.startCallTracking('call1', isOutbound: true);
+        tracker.markCallAnsweredByRemote('call1');
+
+        final metrics = tracker.getCurrentCallMetrics('call1');
+        expect(metrics!.milestones,
+            contains(LatencyTracker.milestoneCallAnsweredByRemote));
+      });
+    });
+
+    group('ICE Milestones', () {
+      test('markFirstSrflxRelayCandidate only marks once', () {
+        tracker.startCallTracking('call1', isOutbound: true);
+
+        tracker.markFirstSrflxRelayCandidate('call1', 'srflx');
+        tracker.markFirstSrflxRelayCandidate('call1', 'relay');
+
+        final metrics = tracker.getCurrentCallMetrics('call1');
+        final timestamp =
+            metrics!.milestones[LatencyTracker.milestoneFirstSrflxRelayCandidate];
+        expect(timestamp, isNotNull);
+        // Should only be recorded once
+      });
+
+      test('markFirstSrflxRelayCandidate ignores invalid types', () {
+        tracker.startCallTracking('call1', isOutbound: true);
+
+        tracker.markFirstSrflxRelayCandidate('call1', 'host');
+
+        final metrics = tracker.getCurrentCallMetrics('call1');
+        expect(metrics!.milestones,
+            isNot(contains(LatencyTracker.milestoneFirstSrflxRelayCandidate)));
+      });
+    });
+
+    group('Derived Metrics', () {
+      test('calculateAnswerDelay returns correct value', () {
+        tracker.startCallTracking('call1', isOutbound: false);
+        tracker.markInviteReceived('call1');
+        tracker.markAnswerInitiated('call1');
+
+        final delay = tracker.calculateAnswerDelay('call1');
+        expect(delay, isNotNull);
+        expect(delay, greaterThanOrEqualTo(0));
+      });
+
+      test('calculateAnswerDelay returns null without required milestones', () {
+        tracker.startCallTracking('call1', isOutbound: false);
+        // No invite_received or answer_initiated
+        expect(tracker.calculateAnswerDelay('call1'), isNull);
+      });
+
+      test('calculateRemoteAnswerTime returns correct value', () {
+        tracker.startCallTracking('call1', isOutbound: true);
+        tracker.markCallMilestone('call1', LatencyTracker.milestoneInviteSent);
+        tracker.markCallAnsweredByRemote('call1');
+
+        final time = tracker.calculateRemoteAnswerTime('call1');
+        expect(time, isNotNull);
+        expect(time, greaterThanOrEqualTo(0));
+      });
+
+      test('calculateRemoteAnswerTime returns null without required milestones', () {
+        tracker.startCallTracking('call1', isOutbound: true);
+        // No invite_sent or call_answered_by_remote
+        expect(tracker.calculateRemoteAnswerTime('call1'), isNull);
+      });
+    });
+
+    group('Reset and Cleanup', () {
+      test('reset clears all state', () {
+        tracker.startRegistrationTracking();
+        tracker.startCallTracking('call1', isOutbound: true);
+        tracker.reset();
+
+        expect(tracker.isTrackingRegistration, isFalse);
+        expect(tracker.getCurrentCallMetrics('call1'), isNull);
+      });
+
+      test('multiple calls tracked independently', () {
+        tracker.startCallTracking('call1', isOutbound: true);
+        tracker.startCallTracking('call2', isOutbound: false);
+
+        tracker.markCallMilestone('call1', LatencyTracker.milestoneInviteSent);
+        tracker.markInviteReceived('call2');
+
+        final metrics1 = tracker.getCurrentCallMetrics('call1');
+        final metrics2 = tracker.getCurrentCallMetrics('call2');
+
+        expect(metrics1!.milestones, contains(LatencyTracker.milestoneInviteSent));
+        expect(metrics1.milestones,
+            isNot(contains(LatencyTracker.milestoneInviteReceived)));
+        expect(metrics2!.milestones,
+            contains(LatencyTracker.milestoneInviteReceived));
+        expect(metrics2.milestones,
+            isNot(contains(LatencyTracker.milestoneInviteSent)));
+      });
+    });
+  });
+
+  group('LatencyMetrics', () {
+    test('toString produces formatted output', () {
+      final metrics = LatencyMetrics(
+        callId: 'test-call',
+        isOutbound: true,
+        callSetupLatencyMs: 500,
+        iceGatheringLatencyMs: 100,
+        signalingLatencyMs: 200,
+        mediaEstablishmentLatencyMs: 50,
+        milestones: {
+          'call_initiated': 0,
+          'peer_connection_created': 50,
+          'invite_sent': 100,
+        },
+      );
+
+      final output = metrics.toString();
+      expect(output, contains('OUTBOUND'));
+      expect(output, contains('test-call'));
+      expect(output, contains('500ms'));
+      expect(output, contains('call_initiated'));
+    });
+
+    test('registration metrics toString', () {
+      final metrics = LatencyMetrics(
+        registrationLatencyMs: 300,
+        milestones: {
+          'login_initiated': 0,
+          'socket_connected': 100,
+          'login_sent': 110,
+          'client_ready': 300,
+        },
+      );
+
+      final output = metrics.toString();
+      expect(output, contains('REGISTRATION'));
+      expect(output, contains('300ms'));
+    });
+
+    test('default timestamp is set', () {
+      final before = DateTime.now().millisecondsSinceEpoch;
+      final metrics = LatencyMetrics();
+      final after = DateTime.now().millisecondsSinceEpoch;
+      expect(metrics.timestamp, greaterThanOrEqualTo(before));
+      expect(metrics.timestamp, lessThanOrEqualTo(after));
+    });
+  });
+}


### PR DESCRIPTION
Port Android SDK latency tracking (commits 4472a8a, 08c62fd) to Flutter Voice SDK with Dart-idiomatic patterns.

New files:
- lib/model/latency_metrics.dart: Data class for latency measurements
- lib/utils/latency_tracker.dart: Tracks registration & call milestones
- test/utils/latency_tracker_test.dart: Unit tests

Integration points:
- telnyx_client.dart: Registration tracking (connect/login/CLIENT_READY), invite/answer/ringing/bye handlers, latencyTracker instance on TelnyxClient
- peer/peer.dart: ICE gathering/connection milestones, DTLS, peer state, SDP negotiation, first ICE candidate, peer setup complete
- call.dart: Cancel tracking on endCall
- telnyx_webrtc.dart: Export new public API

Milestones tracked:
- Registration: login_initiated, socket_connected, login_sent, client_ready
- Call setup: call_initiated, peer_connection_created, media_devices_acquired, peer_setup_complete, sdp_negotiation_started, local_sdp_created/set, invite_sent, answer_sent, remote_sdp_received/set, call_active
- ICE: gathering_started, first_candidate, first_srflx_relay_candidate, gathering_complete, checking, connected, completed
- DTLS: connecting, connected
- Inbound: invite_received, answer_initiated
- Outbound: remote_side_ringing, call_answered_by_remote

Access via telnyxClient.latencyTracker.latencyMetricsStream or setLatencyMetricsListener() callback.


