### PR TITLE
WEBRTC-3444: Fix analysis warnings blocking pub.dev publish

### DIFF
--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -491,8 +491,8 @@ class Peer {
       }
     }
     if (remoteSdpCallId != null) {
-      _txClient.latencyTracker.markCallMilestone(remoteSdpCallId!, LatencyTracker.milestoneRemoteSdpReceived);
-      _txClient.latencyTracker.markCallMilestone(remoteSdpCallId!, LatencyTracker.milestoneRemoteSdpSet);
+      _txClient.latencyTracker.markCallMilestone(remoteSdpCallId, LatencyTracker.milestoneRemoteSdpReceived);
+      _txClient.latencyTracker.markCallMilestone(remoteSdpCallId, LatencyTracker.milestoneRemoteSdpSet);
     }
 
     // Process any queued candidates after setting remote SDP

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -49,7 +49,6 @@ import 'package:telnyx_webrtc/utils/candidate_utils.dart';
 import 'package:telnyx_webrtc/model/socket_connection_metrics.dart';
 import 'package:telnyx_webrtc/model/tx_server_configuration.dart';
 import 'package:telnyx_webrtc/model/audio_constraints.dart';
-import 'package:telnyx_webrtc/model/latency_metrics.dart';
 import 'package:telnyx_webrtc/utils/latency_tracker.dart';
 
 /// Callback for when the socket receives a message


### PR DESCRIPTION
## Summary

Fixes 3 analysis warnings that block `dart pub publish` (exit code 65):

1. **`peer.dart:494`** — Removed unnecessary `!` on `remoteSdpCallId!` (already null-checked in the `if` condition)
2. **`peer.dart:495`** — Same fix
3. **`telnyx_client.dart:52`** — Removed unused import of `latency_metrics.dart`

## Testing
- `dart analyze` should now pass with 0 warnings for these files
- After merge, the `v4.2.0` tag can be recreated and publish should succeed

## Related
- Jira: WEBRTC-3444
- Tag: v4.2.0 publish failed due to these warnings