### PR TITLE
WEBRTC-3444: Remove unused fields blocking pub.dev publish

### DIFF
--- a/packages/telnyx_webrtc/lib/utils/stats/call_report_collector.dart
+++ b/packages/telnyx_webrtc/lib/utils/stats/call_report_collector.dart
@@ -359,8 +359,6 @@ class CallReportCollector {
   Map<String, dynamic>? _lastCandidatePair;
 
   // ICE candidate data
-  Map<String, dynamic>? _lastLocalCandidate;
-  Map<String, dynamic>? _lastRemoteCandidate;
   String? _selectedLocalCandidateId;
   String? _selectedRemoteCandidateId;
 


### PR DESCRIPTION
## Summary

Removes 2 unused fields that cause `unused_field` warnings blocking `dart pub publish`:

- `_lastLocalCandidate` — declared in `CallReportCollector` but never read/written
- `_lastRemoteCandidate` — same

These surfaced after the previous PR #278 fixed the first 3 warnings.

## Testing
- `dart analyze` should have 0 warnings for this file
- After merge, recreate `v4.2.0` tag and publish should succeed

## Related
- Jira: WEBRTC-3444
- Follow-up to #278