### PR TITLE
chore: supersede dependabot patrol bump from 4.1.0 to 4.1.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  patrol: ^4.1.0
+  patrol: ^4.1.1
   telnyx_webrtc:
     path: ./packages/telnyx_webrtc
 


### PR DESCRIPTION
Supersedes #257.

Dependabot PR #257 is stale and now conflicts with `main`, but the only conflict is a one-line version bump in `pubspec.yaml`:

- `patrol: ^4.1.0` -> `patrol: ^4.1.1`

I recreated the bump on top of current `main` instead of force-pushing the contributor branch.
