### PR TITLE
VSDK-171: CallTimings — add call report log entries

### DIFF
--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -1089,6 +1089,15 @@ class Peer {
         _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneDtlsConnected);
         _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestonePeerConnected);
         _txClient.latencyTracker.completeCallTracking(callId);
+
+        // Add CallTimings logs to the call report
+        final timingsLogs = _txClient.latencyTracker.generateCallTimingsLogs(callId);
+        for (final entry in timingsLogs) {
+          _callReportLogCollector?.addLog(
+            level: entry['level'] as String? ?? 'info',
+            message: entry['message'] as String? ?? '',
+          );
+        }
       }
     };
 

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -1088,9 +1088,9 @@ class Peer {
         // Latency milestones
         _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneDtlsConnected);
         _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestonePeerConnected);
-        _txClient.latencyTracker.completeCallTracking(callId);
 
-        // Add CallTimings logs to the call report
+        // Generate CallTimings logs BEFORE completeCallTracking, because
+        // completeCallTracking removes the tracker from _callTrackers.
         final timingsLogs = _txClient.latencyTracker.generateCallTimingsLogs(callId);
         GlobalLogger().i('Peer :: CallTimings generated ${timingsLogs.length} entries for call $callId');
         for (final entry in timingsLogs) {
@@ -1099,6 +1099,9 @@ class Peer {
             message: entry['message'] as String? ?? '',
           );
         }
+
+        // Now complete tracking (this removes the tracker from _callTrackers)
+        _txClient.latencyTracker.completeCallTracking(callId);
       }
     };
 

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -1092,6 +1092,7 @@ class Peer {
 
         // Add CallTimings logs to the call report
         final timingsLogs = _txClient.latencyTracker.generateCallTimingsLogs(callId);
+        GlobalLogger().i('Peer :: CallTimings generated ${timingsLogs.length} entries for call $callId');
         for (final entry in timingsLogs) {
           _callReportLogCollector?.addLog(
             level: entry['level'] as String? ?? 'info',

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -1086,22 +1086,22 @@ class Peer {
         CallTimingBenchmark.end();
 
         // Latency milestones
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneDtlsConnected);
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestonePeerConnected);
+        _txClient.latencyTracker
+            .markCallMilestone(callId, LatencyTracker.milestoneDtlsConnected);
+        _txClient.latencyTracker
+            .markCallMilestone(callId, LatencyTracker.milestonePeerConnected);
 
-        // Generate CallTimings logs BEFORE completeCallTracking, because
-        // completeCallTracking removes the tracker from _callTrackers.
-        final timingsLogs = _txClient.latencyTracker.generateCallTimingsLogs(callId);
-        GlobalLogger().i('Peer :: CallTimings generated ${timingsLogs.length} entries for call $callId');
+        final timingsLogs =
+            _txClient.latencyTracker.completeCallTracking(callId);
+        GlobalLogger().i(
+          'Peer :: CallTimings generated ${timingsLogs.length} entries for call $callId',
+        );
         for (final entry in timingsLogs) {
           _callReportLogCollector?.addLog(
             level: entry['level'] as String? ?? 'info',
             message: entry['message'] as String? ?? '',
           );
         }
-
-        // Now complete tracking (this removes the tracker from _callTrackers)
-        _txClient.latencyTracker.completeCallTracking(callId);
       }
     };
 

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -1591,7 +1591,11 @@ class TelnyxClient {
     updateCall(inviteCall);
 
     // Start latency tracking for outbound call
-    latencyTracker.startCallTracking(inviteCall.callId!, isOutbound: true);
+    latencyTracker.startCallTracking(
+      inviteCall.callId!,
+      isOutbound: true,
+      useTrickleIce: useTrickleIce,
+    );
 
     // Create the peer connection with debug enabled if requested
     inviteCall.peerConnection = Peer(
@@ -1684,7 +1688,11 @@ class TelnyxClient {
     final destinationNum = invite.callerIdNumber;
 
     // Start latency tracking for inbound call
-    latencyTracker.startCallTracking(answerCall.callId!, isOutbound: false);
+    latencyTracker.startCallTracking(
+      answerCall.callId!,
+      isOutbound: false,
+      useTrickleIce: useTrickleIce,
+    );
     latencyTracker.markAnswerInitiated(answerCall.callId!);
 
     // Create the peer connection
@@ -2173,7 +2181,10 @@ class TelnyxClient {
 
                   // Mark invite received for latency tracking
                   if (offerCall.callId != null) {
-                    latencyTracker.startCallTracking(offerCall.callId!, isOutbound: false);
+                    latencyTracker.startCallTracking(
+                      offerCall.callId!,
+                      isOutbound: false,
+                    );
                     latencyTracker.markInviteReceived(offerCall.callId!);
                   }
 

--- a/packages/telnyx_webrtc/lib/utils/latency_tracker.dart
+++ b/packages/telnyx_webrtc/lib/utils/latency_tracker.dart
@@ -372,7 +372,10 @@ class LatencyTracker {
   List<Map<String, dynamic>> generateCallTimingsLogs(String callId) {
     final state = _callTrackers[callId];
     final milestones = state?.milestones;
-    if (milestones == null || milestones.isEmpty) return [];
+    if (milestones == null || milestones.isEmpty) {
+      GlobalLogger().w('LatencyTracker::generateCallTimingsLogs: No milestones for call $callId (tracker exists: ${state != null}, milestones: ${milestones?.length ?? 0})');
+      return [];
+    }
 
     final direction = state!.isOutbound ? 'outbound' : 'inbound';
     final mode = 'trickle'; // Flutter SDK uses trickle ICE

--- a/packages/telnyx_webrtc/lib/utils/latency_tracker.dart
+++ b/packages/telnyx_webrtc/lib/utils/latency_tracker.dart
@@ -296,6 +296,158 @@ class LatencyTracker {
     _callTrackers.clear();
   }
 
+  // ===== CallTimings Log Generation =====
+
+  // Column widths must match the JS SDK format so the call-report-stats
+  // portal can parse data rows with its regex:
+  //   ~r/^(?<step>.+?)\s{2,}(?<delta>[\d.]+ms|-)\s+(?<from>[\d.]+)ms\s*$/
+  // The key requirement is at least 2 spaces between columns.
+  static const int _stepColumnWidth = 40;
+  static const int _deltaColumnWidth = 10;
+
+  /// Step name mapping for outbound calls.
+  static const Map<String, String> _outboundStepMapping = {
+    milestoneCallInitiated: 'Call Start',
+    milestonePeerCreated: 'Peer object created',
+    milestonePeerSetupComplete: 'Peer setup complete',
+    milestoneMediaDevicesAcquired: 'Media devices acquired',
+    milestoneSdpNegotiationStarted: 'SDP negotiation started',
+    milestoneLocalSdpCreated: 'Local SDP created',
+    milestoneLocalSdpSet: 'Local SDP set',
+    milestoneInviteSent: 'INVITE sent',
+    milestoneRemoteRinging: 'Remote ringing',
+    milestoneCallAnsweredByRemote: 'Remote answered',
+    milestoneRemoteSdpReceived: 'Remote SDP received',
+    milestoneRemoteSdpSet: 'Remote SDP set',
+    milestoneIceGatheringStarted: 'ICE gathering started',
+    milestoneFirstIceCandidate: 'First ICE candidate',
+    milestoneFirstSrflxRelayCandidate: 'First srflx/relay candidate',
+    milestoneIceGatheringComplete: 'ICE gathering complete',
+    milestoneIceChecking: 'ICE checking',
+    milestoneIceConnected: 'ICE connected',
+    milestoneDtlsConnecting: 'DTLS connecting',
+    milestoneDtlsConnected: 'DTLS connected',
+    milestonePeerConnected: 'Peer connected',
+    milestoneFirstRtpSent: 'First RTP sent',
+    milestoneFirstRtpReceived: 'First RTP received',
+    milestoneMediaActive: 'Media active',
+    milestoneCallActive: 'Call is active',
+  };
+
+  /// Step name mapping for inbound calls.
+  static const Map<String, String> _inboundStepMapping = {
+    milestoneCallInitiated: 'Call Start',
+    milestoneInviteReceived: 'Invite received',
+    milestoneAnswerInitiated: 'Answer initiated',
+    milestonePeerCreated: 'Peer object created',
+    milestonePeerSetupComplete: 'Peer setup complete',
+    milestoneMediaDevicesAcquired: 'Media devices acquired',
+    milestoneSdpNegotiationStarted: 'SDP negotiation started',
+    milestoneLocalSdpCreated: 'Local SDP created',
+    milestoneLocalSdpSet: 'Local SDP set',
+    milestoneAnswerSent: 'ANSWER sent',
+    milestoneRemoteSdpReceived: 'Remote SDP received',
+    milestoneRemoteSdpSet: 'Remote SDP set',
+    milestoneIceGatheringStarted: 'ICE gathering started',
+    milestoneFirstIceCandidate: 'First ICE candidate',
+    milestoneFirstSrflxRelayCandidate: 'First srflx/relay candidate',
+    milestoneIceGatheringComplete: 'ICE gathering complete',
+    milestoneIceChecking: 'ICE checking',
+    milestoneIceConnected: 'ICE connected',
+    milestoneDtlsConnecting: 'DTLS connecting',
+    milestoneDtlsConnected: 'DTLS connected',
+    milestonePeerConnected: 'Peer connected',
+    milestoneFirstRtpSent: 'First RTP sent',
+    milestoneFirstRtpReceived: 'First RTP received',
+    milestoneMediaActive: 'Media active',
+    milestoneCallActive: 'Call is active',
+  };
+
+  /// Generates CallTimings log entries for a call based on tracked milestones.
+  /// The output format matches the JS SDK's CallTimings log format:
+  ///   [CallTimings][direction][mode] <step> <delta_ms> <from_start_ms>
+  ///
+  /// Returns a list of maps with 'level', 'message', and 'timestamp' keys,
+  /// compatible with CallReportLogCollector.addLog().
+  List<Map<String, dynamic>> generateCallTimingsLogs(String callId) {
+    final state = _callTrackers[callId];
+    final milestones = state?.milestones;
+    if (milestones == null || milestones.isEmpty) return [];
+
+    final direction = state!.isOutbound ? 'outbound' : 'inbound';
+    final mode = 'trickle'; // Flutter SDK uses trickle ICE
+    final prefix = '[CallTimings][$direction][$mode]';
+
+    final stepMapping =
+        state.isOutbound ? _outboundStepMapping : _inboundStepMapping;
+    final entries = <Map<String, dynamic>>[];
+    final timestamp = DateTime.now().toUtc().toIso8601String();
+
+    // Header entries
+    entries.add({
+      'level': 'info',
+      'message': '$prefix Call establishment timing breakdown:',
+      'timestamp': timestamp,
+    });
+    entries.add({
+      'level': 'info',
+      'message':
+          '$prefix ${_padRight('Step', _stepColumnWidth)}${_padLeft('Delta', _deltaColumnWidth)}    From Start',
+      'timestamp': timestamp,
+    });
+    entries.add({
+      'level': 'info',
+      'message':
+          '$prefix --------------------------------------------------------------------------',
+      'timestamp': timestamp,
+    });
+
+    // Step entries — sorted by actual chronological order to avoid negative deltas.
+    final recordedSteps = <_TimedStep>[];
+    for (final entry in stepMapping.entries) {
+      final fromStartMs = milestones[entry.key];
+      if (fromStartMs != null) {
+        recordedSteps.add(_TimedStep(entry.value, fromStartMs));
+      }
+    }
+    recordedSteps.sort((a, b) => a.fromStartMs.compareTo(b.fromStartMs));
+
+    int? previousMs;
+    for (final step in recordedSteps) {
+      final deltaMs = previousMs != null ? step.fromStartMs - previousMs : null;
+      previousMs = step.fromStartMs;
+
+      final stepPadded = _padRight(step.stepName, _stepColumnWidth);
+      final message = deltaMs == null
+          ? '$prefix $stepPadded${_padLeft('-', _deltaColumnWidth)}        ${(step.fromStartMs.toDouble()).toStringAsFixed(2)}ms'
+          : '$prefix $stepPadded${_padLeft('${deltaMs.toDouble().toStringAsFixed(2)}ms', _deltaColumnWidth)}        ${(step.fromStartMs.toDouble()).toStringAsFixed(2)}ms';
+
+      entries.add({
+        'level': 'info',
+        'message': message,
+        'timestamp': timestamp,
+      });
+    }
+
+    // Footer
+    entries.add({
+      'level': 'info',
+      'message':
+          '$prefix --------------------------------------------------------------------------',
+      'timestamp': timestamp,
+    });
+
+    return entries;
+  }
+
+  /// Right-pads a string to [width] characters.
+  static String _padRight(String s, int width) =>
+      s.length >= width ? s : s + ' ' * (width - s.length);
+
+  /// Left-pads a string to [width] characters.
+  static String _padLeft(String s, int width) =>
+      s.length >= width ? s : ' ' * (width - s.length) + s;
+
   /// Disposes resources.
   void dispose() {
     _latencyMetricsController.close();
@@ -361,4 +513,12 @@ class _CallTrackingState {
     required this.startTime,
     required this.isOutbound,
   });
+}
+
+/// Internal helper for sorting steps chronologically.
+class _TimedStep {
+  final String stepName;
+  final int fromStartMs;
+
+  _TimedStep(this.stepName, this.fromStartMs);
 }

--- a/packages/telnyx_webrtc/lib/utils/latency_tracker.dart
+++ b/packages/telnyx_webrtc/lib/utils/latency_tracker.dart
@@ -131,10 +131,16 @@ class LatencyTracker {
   /// Starts tracking latency for a new call.
   /// [callId] The unique identifier for the call.
   /// [isOutbound] True for outbound calls, false for inbound.
-  void startCallTracking(String callId, {bool isOutbound = false}) {
+  /// [useTrickleIce] True when trickle ICE is enabled for this call.
+  void startCallTracking(
+    String callId, {
+    bool isOutbound = false,
+    bool useTrickleIce = true,
+  }) {
     _callTrackers[callId] = _CallTrackingState(
       startTime: DateTime.now().millisecondsSinceEpoch,
       isOutbound: isOutbound,
+      iceMode: useTrickleIce ? 'trickle' : 'standard',
     );
     markCallMilestone(callId, milestoneCallInitiated);
   }
@@ -208,11 +214,13 @@ class LatencyTracker {
 
   /// Completes call tracking and emits the final metrics.
   /// Call this when the call reaches ACTIVE state.
-  void completeCallTracking(String callId) {
+  /// Returns generated CallTimings log entries before removing tracking state.
+  List<Map<String, dynamic>> completeCallTracking(String callId) {
     final state = _callTrackers[callId];
-    if (state == null) return;
+    if (state == null) return [];
 
     markCallMilestone(callId, milestoneCallActive);
+    final timingsLogs = generateCallTimingsLogs(callId);
 
     final milestones = Map<String, int>.unmodifiable(state.milestones);
     final totalTime =
@@ -243,6 +251,7 @@ class LatencyTracker {
 
     // Clean up
     _callTrackers.remove(callId);
+    return timingsLogs;
   }
 
   /// Cancels tracking for a call (e.g., if call fails).
@@ -373,12 +382,11 @@ class LatencyTracker {
     final state = _callTrackers[callId];
     final milestones = state?.milestones;
     if (milestones == null || milestones.isEmpty) {
-      GlobalLogger().w('LatencyTracker::generateCallTimingsLogs: No milestones for call $callId (tracker exists: ${state != null}, milestones: ${milestones?.length ?? 0})');
       return [];
     }
 
     final direction = state!.isOutbound ? 'outbound' : 'inbound';
-    final mode = 'trickle'; // Flutter SDK uses trickle ICE
+    final mode = state.iceMode;
     final prefix = '[CallTimings][$direction][$mode]';
 
     final stepMapping =
@@ -510,11 +518,13 @@ class LatencyTracker {
 class _CallTrackingState {
   final int startTime;
   final bool isOutbound;
+  final String iceMode;
   final Map<String, int> milestones = {};
 
   _CallTrackingState({
     required this.startTime,
     required this.isOutbound,
+    required this.iceMode,
   });
 }
 

--- a/packages/telnyx_webrtc/lib/utils/stats/call_report_collector.dart
+++ b/packages/telnyx_webrtc/lib/utils/stats/call_report_collector.dart
@@ -674,7 +674,7 @@ class CallReportCollector {
         );
 
         if (response.statusCode >= 200 && response.statusCode < 300) {
-          GlobalLogger().i('CallReportCollector: Successfully posted report');
+          GlobalLogger().i('CallReportCollector: Successfully posted report for call: ${summary.callId}');
           return;
         } else if (response.statusCode >= 400 && response.statusCode < 500) {
           // Client error - don't retry

--- a/packages/telnyx_webrtc/lib/utils/stats/call_report_collector.dart
+++ b/packages/telnyx_webrtc/lib/utils/stats/call_report_collector.dart
@@ -674,7 +674,7 @@ class CallReportCollector {
         );
 
         if (response.statusCode >= 200 && response.statusCode < 300) {
-          GlobalLogger().i('CallReportCollector: Successfully posted report for call: ${summary.callId}');
+          GlobalLogger().i('CallReportCollector: Successfully posted report for call: ${headers['x-call-id']}');
           return;
         } else if (response.statusCode >= 400 && response.statusCode < 500) {
           // Client error - don't retry


### PR DESCRIPTION
Implements VSDK-171

Adds `generateCallTimingsLogs()` to `LatencyTracker` that produces portal-parseable CallTimings log entries matching the JS SDK format, then wires them into the call report via `CallReportLogCollector`.

Format: `[CallTimings][direction][trickle] <step> <delta_ms> <from_start_ms>`

Same approach as Android SDK PR #805:
- Period decimal separator (Dart default, no locale issue)
- Column-aligned output (40-char step, 10-char delta) for portal regex
- Chronological sort by timestamp to prevent negative deltas
- Outbound/inbound step name mappings