### PR TITLE
Add Flutter missed call notification opt-in

### DIFF
--- a/packages/telnyx_webrtc/lib/config/telnyx_config.dart
+++ b/packages/telnyx_webrtc/lib/config/telnyx_config.dart
@@ -22,6 +22,7 @@ class Config {
     this.region = Region.auto,
     this.fallbackOnRegionFailure = true,
     this.forceRelayCandidate = false,
+    this.enableMissedCallNotifications = false,
     this.iceServers,
     this.serverConfiguration,
     this.callReportInterval = 5000,
@@ -79,6 +80,12 @@ class Config {
   /// - Important: This setting is disabled by default to maintain optimal call quality.
   final bool forceRelayCandidate;
 
+  /// Controls whether iOS missed call notifications are enabled for this registration.
+  ///
+  /// When enabled, the SDK sends a missed-call notification opt-in user agent
+  /// during login. Defaults to false.
+  final bool enableMissedCallNotifications;
+
   /// Custom ICE servers for WebRTC peer connections.
   ///
   /// When provided, these ICE servers will be used instead of the default
@@ -131,6 +138,7 @@ class Config {
 /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
 /// [pushAnswerTimeout] is the timeout in milliseconds to wait for INVITE after accepting from push notification (default: 10000ms)
 /// [forceRelayCandidate] controls whether the SDK should force TURN relay for peer connections (default: false)
+/// [enableMissedCallNotifications] controls whether iOS missed call notifications are enabled (default: false)
 /// [iceServers] custom ICE servers for WebRTC peer connections
 /// [serverConfiguration] server configuration for signaling and ICE servers
 class CredentialConfig extends Config {
@@ -147,6 +155,7 @@ class CredentialConfig extends Config {
   /// [ringbackPath] is the path to the ringback file (audio to play when calling)
   /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
   /// [pushAnswerTimeout] is the timeout in milliseconds to wait for INVITE after accepting from push notification (default: 10000ms)
+  /// [enableMissedCallNotifications] controls whether iOS missed call notifications are enabled (default: false)
   /// [iceServers] custom ICE servers for WebRTC peer connections
   /// [serverConfiguration] server configuration for signaling and ICE servers
   CredentialConfig({
@@ -166,6 +175,7 @@ class CredentialConfig extends Config {
     super.region = Region.auto,
     super.fallbackOnRegionFailure = true,
     super.forceRelayCandidate = false,
+    super.enableMissedCallNotifications = false,
     super.iceServers,
     super.serverConfiguration,
     super.callReportInterval = 5000,
@@ -194,6 +204,7 @@ class CredentialConfig extends Config {
 /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
 /// [pushAnswerTimeout] is the timeout in milliseconds to wait for INVITE after accepting from push notification (default: 10000ms)
 /// [forceRelayCandidate] controls whether the SDK should force TURN relay for peer connections (default: false)
+/// [enableMissedCallNotifications] controls whether iOS missed call notifications are enabled (default: false)
 /// [iceServers] custom ICE servers for WebRTC peer connections
 /// [serverConfiguration] server configuration for signaling and ICE servers
 class TokenConfig extends Config {
@@ -210,6 +221,7 @@ class TokenConfig extends Config {
   /// [ringbackPath] is the path to the ringback file (audio to play when calling)
   /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
   /// [pushAnswerTimeout] is the timeout in milliseconds to wait for INVITE after accepting from push notification (default: 10000ms)
+  /// [enableMissedCallNotifications] controls whether iOS missed call notifications are enabled (default: false)
   /// [iceServers] custom ICE servers for WebRTC peer connections
   /// [serverConfiguration] server configuration for signaling and ICE servers
   TokenConfig({
@@ -228,6 +240,7 @@ class TokenConfig extends Config {
     super.region = Region.auto,
     super.fallbackOnRegionFailure = true,
     super.forceRelayCandidate = false,
+    super.enableMissedCallNotifications = false,
     super.iceServers,
     super.serverConfiguration,
     super.callReportInterval = 5000,

--- a/packages/telnyx_webrtc/lib/config/telnyx_config.dart
+++ b/packages/telnyx_webrtc/lib/config/telnyx_config.dart
@@ -41,6 +41,7 @@ class Config {
     this.region = Region.auto,
     this.fallbackOnRegionFailure = true,
     this.forceRelayCandidate = false,
+    this.enableMissedCallNotifications = false,
     this.iceServers,
     this.serverConfiguration,
     this.callReportInterval = 5000,
@@ -109,6 +110,12 @@ class Config {
   ///   as all media will be relayed through TURN servers.
   /// - Important: This setting is disabled by default to maintain optimal call quality.
   final bool forceRelayCandidate;
+
+  /// Controls whether iOS missed call notifications are enabled for this registration.
+  ///
+  /// When enabled, the SDK sends a missed-call notification opt-in user agent
+  /// during login. Defaults to false.
+  final bool enableMissedCallNotifications;
 
   /// Custom ICE servers for WebRTC peer connections.
   ///
@@ -222,6 +229,7 @@ class Config {
 /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
 /// [pushAnswerTimeout] is the timeout in milliseconds to wait for INVITE after accepting from push notification (default: 10000ms)
 /// [forceRelayCandidate] controls whether the SDK should force TURN relay for peer connections (default: false)
+/// [enableMissedCallNotifications] controls whether iOS missed call notifications are enabled (default: false)
 /// [iceServers] custom ICE servers for WebRTC peer connections
 /// [serverConfiguration] server configuration for signaling and ICE servers
 class CredentialConfig extends Config {
@@ -238,6 +246,7 @@ class CredentialConfig extends Config {
   /// [ringbackPath] is the path to the ringback file (audio to play when calling)
   /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
   /// [pushAnswerTimeout] is the timeout in milliseconds to wait for INVITE after accepting from push notification (default: 10000ms)
+  /// [enableMissedCallNotifications] controls whether iOS missed call notifications are enabled (default: false)
   /// [iceServers] custom ICE servers for WebRTC peer connections
   /// [serverConfiguration] server configuration for signaling and ICE servers
   CredentialConfig({
@@ -257,6 +266,7 @@ class CredentialConfig extends Config {
     super.region = Region.auto,
     super.fallbackOnRegionFailure = true,
     super.forceRelayCandidate = false,
+    super.enableMissedCallNotifications = false,
     super.iceServers,
     super.serverConfiguration,
     super.callReportInterval = 5000,
@@ -297,6 +307,7 @@ class CredentialConfig extends Config {
 /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
 /// [pushAnswerTimeout] is the timeout in milliseconds to wait for INVITE after accepting from push notification (default: 10000ms)
 /// [forceRelayCandidate] controls whether the SDK should force TURN relay for peer connections (default: false)
+/// [enableMissedCallNotifications] controls whether iOS missed call notifications are enabled (default: false)
 /// [iceServers] custom ICE servers for WebRTC peer connections
 /// [serverConfiguration] server configuration for signaling and ICE servers
 class TokenConfig extends Config {
@@ -313,6 +324,7 @@ class TokenConfig extends Config {
   /// [ringbackPath] is the path to the ringback file (audio to play when calling)
   /// [customLogger] is a custom logger to use for logging - if left null the default logger will be used which uses the Logger package
   /// [pushAnswerTimeout] is the timeout in milliseconds to wait for INVITE after accepting from push notification (default: 10000ms)
+  /// [enableMissedCallNotifications] controls whether iOS missed call notifications are enabled (default: false)
   /// [iceServers] custom ICE servers for WebRTC peer connections
   /// [serverConfiguration] server configuration for signaling and ICE servers
   TokenConfig({
@@ -331,6 +343,7 @@ class TokenConfig extends Config {
     super.region = Region.auto,
     super.fallbackOnRegionFailure = true,
     super.forceRelayCandidate = false,
+    super.enableMissedCallNotifications = false,
     super.iceServers,
     super.serverConfiguration,
     super.callReportInterval = 5000,

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -894,7 +894,9 @@ class TelnyxClient {
       loginParams: {'decline_push': 'true'},
       sessionId: sessid,
       userVariables: notificationParams,
-      userAgent: VersionUtils.getUserAgent(),
+      userAgent: VersionUtils.getUserAgent(
+        enableMissedCallNotifications: config.enableMissedCallNotifications,
+      ),
     );
     final loginMessage = LoginMessage(
       id: uuid,
@@ -936,7 +938,9 @@ class TelnyxClient {
       loginParams: {'decline_push': 'true'},
       userVariables: notificationParams,
       sessionId: sessid,
-      userAgent: VersionUtils.getUserAgent(),
+      userAgent: VersionUtils.getUserAgent(
+        enableMissedCallNotifications: config.enableMissedCallNotifications,
+      ),
     );
     final loginMessage = LoginMessage(
       id: uuid,
@@ -1360,7 +1364,9 @@ class TelnyxClient {
       loginParams: {'attach_call': 'true'},
       sessionId: sessid,
       userVariables: notificationParams,
-      userAgent: VersionUtils.getUserAgent(),
+      userAgent: VersionUtils.getUserAgent(
+        enableMissedCallNotifications: config.enableMissedCallNotifications,
+      ),
     );
     final loginMessage = LoginMessage(
       id: uuid,
@@ -1417,7 +1423,9 @@ class TelnyxClient {
       loginParams: {'attach_call': 'true'},
       userVariables: notificationParams,
       sessionId: sessid,
-      userAgent: VersionUtils.getUserAgent(),
+      userAgent: VersionUtils.getUserAgent(
+        enableMissedCallNotifications: config.enableMissedCallNotifications,
+      ),
     );
     final loginMessage = LoginMessage(
       id: uuid,
@@ -1843,6 +1851,8 @@ class TelnyxClient {
           sipCallerIDName: tokenConfig.sipCallerIDName,
           sipCallerIDNumber: tokenConfig.sipCallerIDNumber,
           notificationToken: tokenConfig.notificationToken,
+          enableMissedCallNotifications:
+              tokenConfig.enableMissedCallNotifications,
           region: Region.auto,
           // Force auto region for fallback
           fallbackOnRegionFailure: tokenConfig.fallbackOnRegionFailure,
@@ -1864,6 +1874,8 @@ class TelnyxClient {
           sipCallerIDName: credConfig.sipCallerIDName,
           sipCallerIDNumber: credConfig.sipCallerIDNumber,
           notificationToken: credConfig.notificationToken,
+          enableMissedCallNotifications:
+              credConfig.enableMissedCallNotifications,
           region: Region.auto,
           // Force auto region for fallback
           fallbackOnRegionFailure: credConfig.fallbackOnRegionFailure,

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -1660,7 +1660,9 @@ class TelnyxClient {
       loginParams: {'decline_push': 'true'},
       sessionId: sessid,
       userVariables: notificationParams,
-      userAgent: VersionUtils.getUserAgent(),
+      userAgent: VersionUtils.getUserAgent(
+        enableMissedCallNotifications: config.enableMissedCallNotifications,
+      ),
     );
     final loginMessage = LoginMessage(
       id: uuid,
@@ -1702,7 +1704,9 @@ class TelnyxClient {
       loginParams: {'decline_push': 'true'},
       userVariables: notificationParams,
       sessionId: sessid,
-      userAgent: VersionUtils.getUserAgent(),
+      userAgent: VersionUtils.getUserAgent(
+        enableMissedCallNotifications: config.enableMissedCallNotifications,
+      ),
     );
     final loginMessage = LoginMessage(
       id: uuid,
@@ -2210,7 +2214,9 @@ class TelnyxClient {
       loginParams: {'attach_call': 'true'},
       sessionId: sessid,
       userVariables: notificationParams,
-      userAgent: VersionUtils.getUserAgent(),
+      userAgent: VersionUtils.getUserAgent(
+        enableMissedCallNotifications: config.enableMissedCallNotifications,
+      ),
     );
     final loginMessage = LoginMessage(
       id: uuid,
@@ -2267,7 +2273,9 @@ class TelnyxClient {
       loginParams: {'attach_call': 'true'},
       userVariables: notificationParams,
       sessionId: sessid,
-      userAgent: VersionUtils.getUserAgent(),
+      userAgent: VersionUtils.getUserAgent(
+        enableMissedCallNotifications: config.enableMissedCallNotifications,
+      ),
     );
     final loginMessage = LoginMessage(
       id: uuid,
@@ -3069,6 +3077,7 @@ class TelnyxClient {
       enableStructuredErrors: c.enableStructuredErrors,
       enableSignalingHealthMonitor: c.enableSignalingHealthMonitor,
       mediaPermissionsRecovery: c.mediaPermissionsRecovery,
+      enableMissedCallNotifications: c.enableMissedCallNotifications,
     );
   }
 
@@ -3110,6 +3119,7 @@ class TelnyxClient {
       enableStructuredErrors: c.enableStructuredErrors,
       enableSignalingHealthMonitor: c.enableSignalingHealthMonitor,
       mediaPermissionsRecovery: c.mediaPermissionsRecovery,
+      enableMissedCallNotifications: c.enableMissedCallNotifications,
     );
   }
 

--- a/packages/telnyx_webrtc/lib/utils/version_utils.dart
+++ b/packages/telnyx_webrtc/lib/utils/version_utils.dart
@@ -10,7 +10,9 @@ class VersionUtils {
   }
 
   /// Constructs the user agent string in the format Flutter-{SDK-Version}
-  static String getUserAgent() {
-    return 'Flutter-$_sdkVersion';
+  /// or Flutter-mpn-{SDK-Version} when missed call notifications are enabled.
+  static String getUserAgent({bool enableMissedCallNotifications = false}) {
+    final prefix = enableMissedCallNotifications ? 'Flutter-mpn' : 'Flutter';
+    return '$prefix-$_sdkVersion';
   }
 }

--- a/packages/telnyx_webrtc/test/telnyx_config_test.dart
+++ b/packages/telnyx_webrtc/test/telnyx_config_test.dart
@@ -35,6 +35,7 @@ void main() {
       expect(config.region, equals(Region.auto));
       expect(config.fallbackOnRegionFailure, isTrue);
       expect(config.forceRelayCandidate, isFalse);
+      expect(config.enableMissedCallNotifications, isFalse);
       expect(config.notificationToken, isNull);
       expect(config.autoReconnect, isNull);
       expect(config.customLogger, isNull);
@@ -61,6 +62,7 @@ void main() {
         region: Region.auto,
         fallbackOnRegionFailure: false,
         forceRelayCandidate: true,
+        enableMissedCallNotifications: true,
       );
 
       expect(config.sipCallerIDName, equals('Test User'));
@@ -77,6 +79,7 @@ void main() {
       expect(config.region, equals(Region.auto));
       expect(config.fallbackOnRegionFailure, isFalse);
       expect(config.forceRelayCandidate, isTrue);
+      expect(config.enableMissedCallNotifications, isTrue);
     });
 
     test('should handle different log levels', () {
@@ -197,6 +200,7 @@ void main() {
         region: Region.eu,
         fallbackOnRegionFailure: true,
         forceRelayCandidate: false,
+        enableMissedCallNotifications: true,
       );
 
       expect(config.sipToken, equals('test_token_123'));
@@ -214,6 +218,7 @@ void main() {
       expect(config.region, equals(Region.eu));
       expect(config.fallbackOnRegionFailure, isTrue);
       expect(config.forceRelayCandidate, isFalse);
+      expect(config.enableMissedCallNotifications, isTrue);
     });
   });
 
@@ -255,6 +260,7 @@ void main() {
         region: Region.apac,
         fallbackOnRegionFailure: false,
         forceRelayCandidate: true,
+        enableMissedCallNotifications: true,
       );
 
       expect(config.sipUser, equals('test_user'));
@@ -273,6 +279,7 @@ void main() {
       expect(config.region, equals(Region.apac));
       expect(config.fallbackOnRegionFailure, isFalse);
       expect(config.forceRelayCandidate, isTrue);
+      expect(config.enableMissedCallNotifications, isTrue);
     });
   });
 }

--- a/packages/telnyx_webrtc/test/telnyx_config_test.dart
+++ b/packages/telnyx_webrtc/test/telnyx_config_test.dart
@@ -33,6 +33,7 @@ void main() {
       expect(config.region, equals(Region.auto));
       expect(config.fallbackOnRegionFailure, isTrue);
       expect(config.forceRelayCandidate, isFalse);
+      expect(config.enableMissedCallNotifications, isFalse);
       expect(config.notificationToken, isNull);
       expect(config.autoReconnect, isNull);
       expect(config.customLogger, isNull);
@@ -59,6 +60,7 @@ void main() {
         region: Region.auto,
         fallbackOnRegionFailure: false,
         forceRelayCandidate: true,
+        enableMissedCallNotifications: true,
       );
 
       expect(config.sipCallerIDName, equals('Test User'));
@@ -75,6 +77,7 @@ void main() {
       expect(config.region, equals(Region.auto));
       expect(config.fallbackOnRegionFailure, isFalse);
       expect(config.forceRelayCandidate, isTrue);
+      expect(config.enableMissedCallNotifications, isTrue);
     });
 
     test('should handle different log levels', () {
@@ -195,6 +198,7 @@ void main() {
         region: Region.eu,
         fallbackOnRegionFailure: true,
         forceRelayCandidate: false,
+        enableMissedCallNotifications: true,
       );
 
       expect(config.sipToken, equals('test_token_123'));
@@ -212,6 +216,7 @@ void main() {
       expect(config.region, equals(Region.eu));
       expect(config.fallbackOnRegionFailure, isTrue);
       expect(config.forceRelayCandidate, isFalse);
+      expect(config.enableMissedCallNotifications, isTrue);
     });
   });
 
@@ -253,6 +258,7 @@ void main() {
         region: Region.apac,
         fallbackOnRegionFailure: false,
         forceRelayCandidate: true,
+        enableMissedCallNotifications: true,
       );
 
       expect(config.sipUser, equals('test_user'));
@@ -271,6 +277,7 @@ void main() {
       expect(config.region, equals(Region.apac));
       expect(config.fallbackOnRegionFailure, isFalse);
       expect(config.forceRelayCandidate, isTrue);
+      expect(config.enableMissedCallNotifications, isTrue);
     });
   });
 

--- a/packages/telnyx_webrtc/test/version_utils_test.dart
+++ b/packages/telnyx_webrtc/test/version_utils_test.dart
@@ -25,6 +25,19 @@ void main() {
       );
     });
 
+    test('getUserAgent returns missed call opt-in user agent when enabled', () {
+      final userAgent = VersionUtils.getUserAgent(
+        enableMissedCallNotifications: true,
+      );
+      expect(userAgent, startsWith('Flutter-mpn-'));
+      expect(
+        userAgent,
+        matches(
+          RegExp(r'^Flutter-mpn-\d+\.\d+\.\d+$'),
+        ),
+      );
+    });
+
     test('getSDKVersion returns consistent result on multiple calls', () {
       final version1 = VersionUtils.getSDKVersion();
       final version2 = VersionUtils.getSDKVersion();


### PR DESCRIPTION
## Summary
- add enableMissedCallNotifications to Flutter SDK configs, defaulting to false
- send Flutter-mpn-<version> during credential/token login when the flag is enabled
- preserve the flag through decline-push login and region fallback config recreation

## Testing
- flutter test test/version_utils_test.dart test/telnyx_config_test.dart

Depends on backend support in team-telnyx/push-notification#189.