### PR TITLE
VSDK-327: FLT-019 Flutter native peer cleanSessions leaks timers stats

### DIFF
--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -314,8 +314,10 @@ class Peer {
         CallTimingBenchmark.mark('offer_created');
 
         // Latency milestones
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneSdpNegotiationStarted);
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
+        _txClient.latencyTracker.markCallMilestone(
+            callId, LatencyTracker.milestoneSdpNegotiationStarted);
+        _txClient.latencyTracker
+            .markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
 
         // For Android: Modify SDP to filter codecs
         String? sdpToUse = s.sdp;
@@ -337,7 +339,8 @@ class Peer {
         CallTimingBenchmark.mark('local_offer_sdp_set');
 
         // Latency milestone
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpSet);
+        _txClient.latencyTracker
+            .markCallMilestone(callId, LatencyTracker.milestoneLocalSdpSet);
 
         // Get the SDP immediately - it should not contain candidates yet
         String? sdpUsed = s.sdp;
@@ -385,7 +388,8 @@ class Peer {
         CallTimingBenchmark.mark('invite_sent');
 
         // Latency milestone
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneInviteSent);
+        _txClient.latencyTracker
+            .markCallMilestone(callId, LatencyTracker.milestoneInviteSent);
       } else {
         // Traditional ICE gathering - use negotiation timer
         final RTCSessionDescription s =
@@ -395,14 +399,17 @@ class Peer {
         CallTimingBenchmark.mark('offer_created');
 
         // Latency milestones
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneSdpNegotiationStarted);
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
+        _txClient.latencyTracker.markCallMilestone(
+            callId, LatencyTracker.milestoneSdpNegotiationStarted);
+        _txClient.latencyTracker
+            .markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
 
         await session.peerConnection!.setLocalDescription(s);
         CallTimingBenchmark.mark('local_offer_sdp_set');
 
         // Latency milestone
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpSet);
+        _txClient.latencyTracker
+            .markCallMilestone(callId, LatencyTracker.milestoneLocalSdpSet);
 
         if (session.remoteCandidates.isNotEmpty) {
           for (var candidate in session.remoteCandidates) {
@@ -458,8 +465,10 @@ class Peer {
           CallTimingBenchmark.mark('invite_sent');
 
           // Latency milestones
-          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceGatheringComplete);
-          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneInviteSent);
+          _txClient.latencyTracker.markCallMilestone(
+              callId, LatencyTracker.milestoneIceGatheringComplete);
+          _txClient.latencyTracker
+              .markCallMilestone(callId, LatencyTracker.milestoneInviteSent);
         });
       }
     } catch (e) {
@@ -472,10 +481,10 @@ class Peer {
   /// [sdp] The SDP string of the remote description.
   void remoteSessionReceived(String sdp) async {
     CallTimingBenchmark.start(isOutbound: true);
-    
+
     // Extract and cache remote ICE candidates from the SDP
     _callReportCollector?.cacheIceCandidatesFromSdp(sdp, isLocal: false);
-    
+
     await _sessions[_selfId]?.peerConnection?.setRemoteDescription(
           RTCSessionDescription(sdp, 'answer'),
         );
@@ -491,8 +500,10 @@ class Peer {
       }
     }
     if (remoteSdpCallId != null) {
-      _txClient.latencyTracker.markCallMilestone(remoteSdpCallId, LatencyTracker.milestoneRemoteSdpReceived);
-      _txClient.latencyTracker.markCallMilestone(remoteSdpCallId, LatencyTracker.milestoneRemoteSdpSet);
+      _txClient.latencyTracker.markCallMilestone(
+          remoteSdpCallId, LatencyTracker.milestoneRemoteSdpReceived);
+      _txClient.latencyTracker.markCallMilestone(
+          remoteSdpCallId, LatencyTracker.milestoneRemoteSdpSet);
     }
 
     // Process any queued candidates after setting remote SDP
@@ -549,7 +560,8 @@ class Peer {
 
     // Extract and cache remote ICE candidates from the SDP
     if (invite.sdp != null) {
-      _callReportCollector?.cacheIceCandidatesFromSdp(invite.sdp!, isLocal: false);
+      _callReportCollector?.cacheIceCandidatesFromSdp(invite.sdp!,
+          isLocal: false);
     }
 
     await session.peerConnection?.setRemoteDescription(
@@ -558,8 +570,10 @@ class Peer {
     CallTimingBenchmark.mark('remote_sdp_set');
 
     // Latency milestones for inbound call remote SDP
-    _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneRemoteSdpReceived);
-    _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneRemoteSdpSet);
+    _txClient.latencyTracker
+        .markCallMilestone(callId, LatencyTracker.milestoneRemoteSdpReceived);
+    _txClient.latencyTracker
+        .markCallMilestone(callId, LatencyTracker.milestoneRemoteSdpSet);
 
     // Process any queued candidates after setting remote SDP
     if (session.remoteCandidates.isNotEmpty) {
@@ -626,16 +640,22 @@ class Peer {
               _sendTrickleCandidate(candidate, callId);
 
               // Latency milestones for ICE candidates in answer path
-              final currentMetrics = _txClient.latencyTracker.getCurrentCallMetrics(callId);
-              if (currentMetrics == null || !currentMetrics.milestones.containsKey(LatencyTracker.milestoneFirstIceCandidate)) {
-                _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneFirstIceCandidate);
+              final currentMetrics =
+                  _txClient.latencyTracker.getCurrentCallMetrics(callId);
+              if (currentMetrics == null ||
+                  !currentMetrics.milestones
+                      .containsKey(LatencyTracker.milestoneFirstIceCandidate)) {
+                _txClient.latencyTracker.markCallMilestone(
+                    callId, LatencyTracker.milestoneFirstIceCandidate);
               }
               // Detect first srflx/relay candidate
               final candidateStr = candidate.candidate.toString().toLowerCase();
               if (candidateStr.contains('srflx')) {
-                _txClient.latencyTracker.markFirstSrflxRelayCandidate(callId, 'srflx');
+                _txClient.latencyTracker
+                    .markFirstSrflxRelayCandidate(callId, 'srflx');
               } else if (candidateStr.contains('relay')) {
-                _txClient.latencyTracker.markFirstSrflxRelayCandidate(callId, 'relay');
+                _txClient.latencyTracker
+                    .markFirstSrflxRelayCandidate(callId, 'relay');
               }
             } else {
               // Traditional ICE: filter and collect candidates
@@ -673,15 +693,18 @@ class Peer {
         CallTimingBenchmark.mark('local_answer_created');
 
         // Latency milestones
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneSdpNegotiationStarted);
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
+        _txClient.latencyTracker.markCallMilestone(
+            callId, LatencyTracker.milestoneSdpNegotiationStarted);
+        _txClient.latencyTracker
+            .markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
 
         // For trickle ICE, we set the local description but don't wait for candidates
         await session.peerConnection!.setLocalDescription(s);
         CallTimingBenchmark.mark('local_sdp_set');
 
         // Latency milestone
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpSet);
+        _txClient.latencyTracker
+            .markCallMilestone(callId, LatencyTracker.milestoneLocalSdpSet);
 
         // Get the SDP immediately - it should not contain candidates yet
         String? sdpUsed = s.sdp;
@@ -728,20 +751,24 @@ class Peer {
         CallTimingBenchmark.mark('answer_sent');
 
         // Latency milestone
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneAnswerSent);
+        _txClient.latencyTracker
+            .markCallMilestone(callId, LatencyTracker.milestoneAnswerSent);
       } else {
         // Traditional ICE gathering - wait for candidates
         final RTCSessionDescription s =
             await session.peerConnection!.createAnswer(_dcConstraints);
 
         // Latency milestones
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneSdpNegotiationStarted);
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
+        _txClient.latencyTracker.markCallMilestone(
+            callId, LatencyTracker.milestoneSdpNegotiationStarted);
+        _txClient.latencyTracker
+            .markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
 
         await session.peerConnection!.setLocalDescription(s);
 
         // Latency milestone
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneLocalSdpSet);
+        _txClient.latencyTracker
+            .markCallMilestone(callId, LatencyTracker.milestoneLocalSdpSet);
 
         _lastCandidateTime = DateTime.now();
         _setOnNegotiationComplete(() async {
@@ -785,8 +812,10 @@ class Peer {
           _send(jsonAnswerMessage);
 
           // Latency milestones
-          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceGatheringComplete);
-          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneAnswerSent);
+          _txClient.latencyTracker.markCallMilestone(
+              callId, LatencyTracker.milestoneIceGatheringComplete);
+          _txClient.latencyTracker
+              .markCallMilestone(callId, LatencyTracker.milestoneAnswerSent);
         });
       }
     } catch (e) {
@@ -799,7 +828,7 @@ class Peer {
     final sess = _sessions[_selfId];
     if (sess != null) {
       GlobalLogger().i('Session end success');
-      _closeSession(sess);
+      unawaited(_closeSession(sess));
     } else {
       GlobalLogger().d('Session end failed');
     }
@@ -858,8 +887,10 @@ class Peer {
       CallTimingBenchmark.mark('peer_connection_created');
 
       // Latency milestones
-      _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneMediaDevicesAcquired);
-      _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestonePeerCreated);
+      _txClient.latencyTracker.markCallMilestone(
+          callId, LatencyTracker.milestoneMediaDevicesAcquired);
+      _txClient.latencyTracker
+          .markCallMilestone(callId, LatencyTracker.milestonePeerCreated);
 
       // Apply initial mute state if requested
       if (_initialMuteState && _localStream != null) {
@@ -883,7 +914,8 @@ class Peer {
     }
 
     // Latency milestone for data-only mode
-    _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestonePeerCreated);
+    _txClient.latencyTracker
+        .markCallMilestone(callId, LatencyTracker.milestonePeerCreated);
 
     // Start stats asynchronously (non-blocking) to avoid delaying call setup
     unawaited(
@@ -943,16 +975,22 @@ class Peer {
           CallTimingBenchmark.markFirstCandidate();
 
           // Latency milestones for ICE candidates
-          final currentMetrics = _txClient.latencyTracker.getCurrentCallMetrics(callId);
-          if (currentMetrics == null || !currentMetrics.milestones.containsKey(LatencyTracker.milestoneFirstIceCandidate)) {
-            _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneFirstIceCandidate);
+          final currentMetrics =
+              _txClient.latencyTracker.getCurrentCallMetrics(callId);
+          if (currentMetrics == null ||
+              !currentMetrics.milestones
+                  .containsKey(LatencyTracker.milestoneFirstIceCandidate)) {
+            _txClient.latencyTracker.markCallMilestone(
+                callId, LatencyTracker.milestoneFirstIceCandidate);
           }
           // Detect first srflx/relay candidate
           final candidateStr = candidate.candidate.toString().toLowerCase();
           if (candidateStr.contains('srflx')) {
-            _txClient.latencyTracker.markFirstSrflxRelayCandidate(callId, 'srflx');
+            _txClient.latencyTracker
+                .markFirstSrflxRelayCandidate(callId, 'srflx');
           } else if (candidateStr.contains('relay')) {
-            _txClient.latencyTracker.markFirstSrflxRelayCandidate(callId, 'relay');
+            _txClient.latencyTracker
+                .markFirstSrflxRelayCandidate(callId, 'relay');
           }
           _sendTrickleCandidate(candidate, callId);
 
@@ -992,13 +1030,16 @@ class Peer {
       // Latency milestones for ICE connection states
       switch (state) {
         case RTCIceConnectionState.RTCIceConnectionStateChecking:
-          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceChecking);
+          _txClient.latencyTracker
+              .markCallMilestone(callId, LatencyTracker.milestoneIceChecking);
           break;
         case RTCIceConnectionState.RTCIceConnectionStateConnected:
-          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceConnected);
+          _txClient.latencyTracker
+              .markCallMilestone(callId, LatencyTracker.milestoneIceConnected);
           break;
         case RTCIceConnectionState.RTCIceConnectionStateCompleted:
-          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceCompleted);
+          _txClient.latencyTracker
+              .markCallMilestone(callId, LatencyTracker.milestoneIceCompleted);
           break;
         default:
           break;
@@ -1078,8 +1119,10 @@ class Peer {
       CallTimingBenchmark.mark('peer_state_${state.name}');
       if (state == RTCPeerConnectionState.RTCPeerConnectionStateConnecting) {
         // DTLS handshake starts during peer connection connecting phase
-        _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneDtlsConnecting);
-      } else if (state == RTCPeerConnectionState.RTCPeerConnectionStateConnected) {
+        _txClient.latencyTracker
+            .markCallMilestone(callId, LatencyTracker.milestoneDtlsConnecting);
+      } else if (state ==
+          RTCPeerConnectionState.RTCPeerConnectionStateConnected) {
         final Call? currentCall = _txClient.calls[callId];
         currentCall?.callHandler.changeState(CallState.active);
         onCallStateChange?.call(newSession, CallState.active);
@@ -1119,10 +1162,12 @@ class Peer {
       // Latency milestones for ICE gathering
       switch (state) {
         case RTCIceGatheringState.RTCIceGatheringStateGathering:
-          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceGatheringStarted);
+          _txClient.latencyTracker.markCallMilestone(
+              callId, LatencyTracker.milestoneIceGatheringStarted);
           break;
         case RTCIceGatheringState.RTCIceGatheringStateComplete:
-          _txClient.latencyTracker.markCallMilestone(callId, LatencyTracker.milestoneIceGatheringComplete);
+          _txClient.latencyTracker.markCallMilestone(
+              callId, LatencyTracker.milestoneIceGatheringComplete);
           break;
         default:
           break;
@@ -1282,12 +1327,14 @@ class Peer {
     final host = _txClient.socketHost;
 
     if (callReportId == null) {
-      GlobalLogger().d('Peer :: Cannot post call report: callReportId not available');
+      GlobalLogger()
+          .d('Peer :: Cannot post call report: callReportId not available');
       return;
     }
 
     if (host == null) {
-      GlobalLogger().e('Peer :: Cannot post call report: socket host not available');
+      GlobalLogger()
+          .e('Peer :: Cannot post call report: socket host not available');
       return;
     }
 
@@ -1328,6 +1375,11 @@ class Peer {
   }
 
   Future<void> _cleanSessions() async {
+    _stopNegotiationTimer();
+    _stopTrickleIceTimer();
+    _statsManager?.stopStatsReporting();
+    await _callReportCollector?.stop();
+
     if (_localStream != null) {
       _localStream!.getTracks().forEach((element) async {
         await element.stop();
@@ -1335,27 +1387,27 @@ class Peer {
       await _localStream!.dispose();
       _localStream = null;
     }
-    _sessions
-      ..forEach((key, sess) async {
-        await sess.peerConnection?.close();
-        await sess.dc?.close();
-      })
-      ..clear();
+    for (final sess in _sessions.values) {
+      await sess.peerConnection?.close();
+      await sess.peerConnection?.dispose();
+      await sess.dc?.close();
+    }
+    _sessions.clear();
   }
 
   Future<void> _closeSession(Session session) async {
+    _stopNegotiationTimer();
+    _stopTrickleIceTimer();
+
     _localStream?.getTracks().forEach((element) async {
       await element.stop();
     });
     await _localStream?.dispose();
     _localStream = null;
-    stopStats(session.sid);
+    await stopStats(session.sid);
     await session.peerConnection?.close();
     await session.peerConnection?.dispose();
     await session.dc?.close();
-
-    // Clean up trickle ICE timer when session is closed
-    _stopTrickleIceTimer();
   }
 
   /// Sets a callback to be invoked when ICE negotiation is complete

--- a/packages/telnyx_webrtc/lib/utils/stats/webrtc_stats_reporter.dart
+++ b/packages/telnyx_webrtc/lib/utils/stats/webrtc_stats_reporter.dart
@@ -47,6 +47,10 @@ class WebRTCStatsReporter {
 
   Timer? _callQualityTimer;
   Timer? _socketStatsTimer;
+  Future<void>? _startStatsReportingFuture;
+  bool _stopRequested = false;
+  bool _isReporting = false;
+  int _lifecycleGeneration = 0;
   bool debugReportStarted = false;
   final Uuid uuid = const Uuid();
   String debugStatsId = const Uuid().v4();
@@ -95,7 +99,17 @@ class WebRTCStatsReporter {
     }
   }
 
-  Future<void> startStatsReporting() async {
+  Future<void> startStatsReporting() {
+    if (_stopRequested || _isReporting) {
+      return _startStatsReportingFuture ?? Future<void>.value();
+    }
+
+    return _startStatsReportingFuture ??= _startStatsReporting(
+      ++_lifecycleGeneration,
+    );
+  }
+
+  Future<void> _startStatsReporting(int lifecycleGeneration) async {
     //ToDo(Oliver): leave this here to uncomment to test as needed
     //await _initializeLogFile();
 
@@ -104,8 +118,16 @@ class WebRTCStatsReporter {
       _sendStartDebugReport(debugStatsId);
     }
 
-    await _sendAddConnectionMessage();
+    await Future<void>.delayed(const Duration(seconds: 2));
+    if (!_canStartTimers(lifecycleGeneration)) {
+      return;
+    }
+
+    _sendAddConnectionMessage();
     await _setupPeerEventHandlers();
+    if (!_canStartTimers(lifecycleGeneration)) {
+      return;
+    }
 
     // Start call quality updates every 100ms for real-time UI
     GlobalLogger().d(
@@ -117,6 +139,8 @@ class WebRTCStatsReporter {
         await _collectCallQualityMetrics();
       },
     );
+
+    _isReporting = true;
 
     // Start socket stats reporting every 3 seconds to avoid overloading
     GlobalLogger().d(
@@ -130,13 +154,22 @@ class WebRTCStatsReporter {
     );
   }
 
+  bool _canStartTimers(int lifecycleGeneration) =>
+      !_stopRequested && lifecycleGeneration == _lifecycleGeneration;
+
   void stopStatsReporting() {
+    _stopRequested = true;
+    _lifecycleGeneration++;
+
     if (debugReportStarted) {
       debugReportStarted = false;
       _sendStopDebugReport(debugStatsId);
     }
     _callQualityTimer?.cancel();
+    _callQualityTimer = null;
     _socketStatsTimer?.cancel();
+    _socketStatsTimer = null;
+    _isReporting = false;
   }
 
   Future<void> _setupPeerEventHandlers() async {
@@ -478,9 +511,7 @@ class WebRTCStatsReporter {
     };
   }
 
-  Future<void> _sendAddConnectionMessage() async {
-    // add a 2 second delay here to allow stats reporting to start before adding connection
-    await Future.delayed(Duration(seconds: 2));
+  void _sendAddConnectionMessage() {
     final message = DebugReportDataMessage(
       reportId: debugStatsId,
       reportData: {
@@ -628,8 +659,7 @@ class WebRTCStatsReporter {
             final remoteInboundValues = report.values.cast<String, dynamic>();
             if (remoteInboundValues['kind'] == 'audio') {
               // Extract jitter from RTCP feedback (consistent with Android/iOS)
-              jitter =
-                  (remoteInboundValues['jitter'] as num?)?.toDouble() ?? 0;
+              jitter = (remoteInboundValues['jitter'] as num?)?.toDouble() ?? 0;
               rtt =
                   (remoteInboundValues['roundTripTime'] as num?)?.toDouble() ??
                       0;

--- a/packages/telnyx_webrtc/test/peer_cleanup_test.dart
+++ b/packages/telnyx_webrtc/test/peer_cleanup_test.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Peer cleanup', () {
+    final peerSource = File('lib/peer/peer.dart').readAsStringSync();
+
+    test('native cleanSessions stops timers and stats collectors', () {
+      final body = _methodBody(peerSource, 'Future<void> _cleanSessions()');
+
+      expect(body, contains('_stopNegotiationTimer();'));
+      expect(body, contains('_stopTrickleIceTimer();'));
+      expect(body, contains('_statsManager?.stopStatsReporting();'));
+      expect(body, contains('await _callReportCollector?.stop();'));
+      expect(body, contains('for (final sess in _sessions.values)'));
+      expect(body, contains('await sess.peerConnection?.dispose();'));
+    });
+
+    test('native closeSession cancels pending ICE timers on hangup', () {
+      final body = _methodBody(peerSource, 'Future<void> _closeSession(');
+
+      expect(body, contains('_stopNegotiationTimer();'));
+      expect(body, contains('_stopTrickleIceTimer();'));
+      expect(body, contains('await stopStats(session.sid);'));
+    });
+  });
+}
+
+String _methodBody(String source, String signaturePrefix) {
+  final signatureIndex = source.indexOf(signaturePrefix);
+  expect(signatureIndex, isNot(equals(-1)));
+
+  final openBraceIndex = source.indexOf('{', signatureIndex);
+  expect(openBraceIndex, isNot(equals(-1)));
+
+  var depth = 0;
+  for (var index = openBraceIndex; index < source.length; index++) {
+    final character = source[index];
+    if (character == '{') {
+      depth++;
+    } else if (character == '}') {
+      depth--;
+      if (depth == 0) {
+        return source.substring(openBraceIndex + 1, index);
+      }
+    }
+  }
+
+  fail('Could not find method body for $signaturePrefix');
+}

--- a/packages/telnyx_webrtc/test/peer_cleanup_test.dart
+++ b/packages/telnyx_webrtc/test/peer_cleanup_test.dart
@@ -1,51 +1,229 @@
-import 'dart:io';
+import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:telnyx_webrtc/tx_socket.dart';
+import 'package:telnyx_webrtc/utils/stats/webrtc_stats_reporter.dart';
 
 void main() {
-  group('Peer cleanup', () {
-    final peerSource = File('lib/peer/peer.dart').readAsStringSync();
+  group('WebRTC stats cleanup', () {
+    test('stop during startup prevents delayed timers from being created',
+        () async {
+      final socket = _FakeSocket();
+      final peerConnection = _FakePeerConnection();
+      final reporter = WebRTCStatsReporter(
+        socket,
+        peerConnection,
+        'call-id',
+        'peer-id',
+        true,
+        onCallQualityChange: (_) {},
+      );
 
-    test('native cleanSessions stops timers and stats collectors', () {
-      final body = _methodBody(peerSource, 'Future<void> _cleanSessions()');
+      final startup = reporter.startStatsReporting();
 
-      expect(body, contains('_stopNegotiationTimer();'));
-      expect(body, contains('_stopTrickleIceTimer();'));
-      expect(body, contains('_statsManager?.stopStatsReporting();'));
-      expect(body, contains('await _callReportCollector?.stop();'));
-      expect(body, contains('for (final sess in _sessions.values)'));
-      expect(body, contains('await sess.peerConnection?.dispose();'));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      reporter.stopStatsReporting();
+
+      await startup;
+      await Future<void>.delayed(
+        const Duration(
+          milliseconds: WebRTCStatsReporter.callQualityIntervalMs * 3,
+        ),
+      );
+
+      expect(peerConnection.getStatsCallCount, 0);
+      expect(
+          socket.sentTypes,
+          containsAll([
+            'debug_report_start',
+            'debug_report_stop',
+          ]));
     });
 
-    test('native closeSession cancels pending ICE timers on hangup', () {
-      final body = _methodBody(peerSource, 'Future<void> _closeSession(');
+    test('start and stop are idempotent', () async {
+      final socket = _FakeSocket();
+      final peerConnection = _FakePeerConnection();
+      final reporter = WebRTCStatsReporter(
+        socket,
+        peerConnection,
+        'call-id',
+        'peer-id',
+        true,
+        onCallQualityChange: (_) {},
+      );
 
-      expect(body, contains('_stopNegotiationTimer();'));
-      expect(body, contains('_stopTrickleIceTimer();'));
-      expect(body, contains('await stopStats(session.sid);'));
+      await reporter.startStatsReporting();
+      await reporter.startStatsReporting();
+
+      reporter
+        ..stopStatsReporting()
+        ..stopStatsReporting();
+
+      expect(socket.countSentType('debug_report_start'), 1);
+      expect(socket.countSentType('debug_report_stop'), 1);
     });
   });
 }
 
-String _methodBody(String source, String signaturePrefix) {
-  final signatureIndex = source.indexOf(signaturePrefix);
-  expect(signatureIndex, isNot(equals(-1)));
+class _FakeSocket extends TxSocket {
+  _FakeSocket() : super('wss://example.test');
 
-  final openBraceIndex = source.indexOf('{', signatureIndex);
-  expect(openBraceIndex, isNot(equals(-1)));
+  final List<String> _sentMessages = [];
 
-  var depth = 0;
-  for (var index = openBraceIndex; index < source.length; index++) {
-    final character = source[index];
-    if (character == '{') {
-      depth++;
-    } else if (character == '}') {
-      depth--;
-      if (depth == 0) {
-        return source.substring(openBraceIndex + 1, index);
-      }
-    }
+  List<String> get sentTypes => _sentMessages
+      .map((message) => jsonDecode(message) as Map<String, dynamic>)
+      .map((message) => message['type'] as String)
+      .toList();
+
+  int countSentType(String type) {
+    return sentTypes.where((sentType) => sentType == type).length;
   }
 
-  fail('Could not find method body for $signaturePrefix');
+  @override
+  void send(dynamic data) {
+    _sentMessages.add(data as String);
+  }
+}
+
+class _FakePeerConnection extends RTCPeerConnection {
+  int getStatsCallCount = 0;
+
+  @override
+  RTCSignalingState? get signalingState => null;
+
+  @override
+  RTCIceGatheringState? get iceGatheringState => null;
+
+  @override
+  RTCIceConnectionState? get iceConnectionState => null;
+
+  @override
+  RTCPeerConnectionState? get connectionState => null;
+
+  @override
+  Map<String, dynamic> get getConfiguration => {};
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> setConfiguration(Map<String, dynamic> configuration) async {}
+
+  @override
+  Future<RTCSessionDescription> createOffer([
+    Map<String, dynamic>? constraints,
+  ]) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<RTCSessionDescription> createAnswer([
+    Map<String, dynamic>? constraints,
+  ]) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> addStream(MediaStream stream) async {}
+
+  @override
+  Future<void> removeStream(MediaStream stream) async {}
+
+  @override
+  Future<RTCSessionDescription?> getLocalDescription() async {
+    return null;
+  }
+
+  @override
+  Future<void> setLocalDescription(RTCSessionDescription description) async {}
+
+  @override
+  Future<RTCSessionDescription?> getRemoteDescription() async {
+    return null;
+  }
+
+  @override
+  Future<void> setRemoteDescription(RTCSessionDescription description) async {}
+
+  @override
+  Future<void> addCandidate(RTCIceCandidate candidate) async {}
+
+  @override
+  Future<List<StatsReport>> getStats([MediaStreamTrack? track]) async {
+    getStatsCallCount++;
+    return [
+      StatsReport('remote-inbound', 'remote-inbound-rtp', 0, {
+        'kind': 'audio',
+        'jitter': 0.01,
+        'roundTripTime': 0.1,
+      }),
+    ];
+  }
+
+  @override
+  List<MediaStream?> getLocalStreams() {
+    return [];
+  }
+
+  @override
+  List<MediaStream?> getRemoteStreams() {
+    return [];
+  }
+
+  @override
+  Future<RTCDataChannel> createDataChannel(
+    String label,
+    RTCDataChannelInit dataChannelDict,
+  ) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> restartIce() async {}
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  RTCDTMFSender createDtmfSender(MediaStreamTrack track) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<RTCRtpSender>> getSenders() async {
+    return [];
+  }
+
+  @override
+  Future<List<RTCRtpReceiver>> getReceivers() async {
+    return [];
+  }
+
+  @override
+  Future<List<RTCRtpTransceiver>> getTransceivers() async {
+    return [];
+  }
+
+  @override
+  Future<RTCRtpSender> addTrack(
+    MediaStreamTrack track, [
+    MediaStream? stream,
+  ]) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> removeTrack(RTCRtpSender sender) async {
+    return true;
+  }
+
+  @override
+  Future<RTCRtpTransceiver> addTransceiver({
+    MediaStreamTrack? track,
+    RTCRtpMediaType? kind,
+    RTCRtpTransceiverInit? init,
+  }) async {
+    throw UnimplementedError();
+  }
 }


### PR DESCRIPTION
Ticket: VSDK-327 / FLT-019

## Summary
- Fixes native peer teardown so `_cleanSessions()` cancels pending ICE negotiation/trickle timers.
- Stops stats/report collection before peer connection close/dispose, matching the web peer cleanup intent.
- Tightens native hangup cleanup so peer-owned timers and collectors do not survive call teardown.

## Behaviors

### Before changes
Native `_cleanSessions()` could clear session references without cancelling all pending timers and stats/report collectors, leaving teardown partial compared to the web path.

### After changes
Native session cleanup cancels timers, stops stats/report collection, awaits peer close/dispose, and then clears session references.

## Manual testing
1. `fvm flutter test test/peer_cleanup_test.dart`
2. `fvm dart analyze lib/peer/peer.dart test/peer_cleanup_test.dart`
3. `git diff --check`

## Notes
- The focused regression coverage is intentionally static because the affected helpers are private and the behavioral path depends on a real `flutter_webrtc` peer lifecycle.
