### PR TITLE
VSDK-328: FLT-020 Flutter TelnyxClient connectivity sub leak no dispose

### DIFF
--- a/lib/service/android_push_notification_handler.dart
+++ b/lib/service/android_push_notification_handler.dart
@@ -7,6 +7,7 @@ import 'package:telnyx_flutter_webrtc/main.dart'; // For logger, txClientViewMod
 import 'package:telnyx_flutter_webrtc/service/notification_service.dart';
 import 'package:telnyx_flutter_webrtc/service/push_notification_handler.dart';
 import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/model/connection_status.dart';
 import 'package:telnyx_webrtc/model/push_notification.dart';
 import 'package:telnyx_webrtc/config/telnyx_config.dart';
 import 'package:flutter_callkit_incoming/flutter_callkit_incoming.dart';
@@ -17,6 +18,33 @@ import 'package:telnyx_flutter_webrtc/utils/config_helper.dart';
 
 // Define logger at the top level for access by the background handler function
 final _backgroundLogger = Logger();
+
+void _disposeTemporaryDeclineClientAfterDisconnect(TelnyxClient client) {
+  var sawOpenConnection = false;
+  var disposed = false;
+  late final Timer fallbackTimer;
+
+  void disposeOnce() {
+    if (disposed) return;
+
+    disposed = true;
+    fallbackTimer.cancel();
+    client.dispose();
+  }
+
+  fallbackTimer = Timer(const Duration(seconds: 10), disposeOnce);
+  client.onConnectionStateChanged = (ConnectionStatus status) {
+    if (status == ConnectionStatus.connected ||
+        status == ConnectionStatus.clientReady) {
+      sawOpenConnection = true;
+      return;
+    }
+
+    if (sawOpenConnection && status == ConnectionStatus.disconnected) {
+      disposeOnce();
+    }
+  };
+}
 
 // This function MUST be annotated with @pragma('vm:entry-point') and be a top level function
 @pragma('vm:entry-point')
@@ -66,22 +94,32 @@ Future<void> androidBackgroundMessageHandler(RemoteMessage message) async {
             final PushMetaData pushMetaData = PushMetaData.fromJson(metadataMap)
               ..isDecline = true;
 
-            // Use simplified decline logic with decline_push parameter
             final tempDeclineClient = TelnyxClient();
-            final config = await ConfigHelper.getTelnyxConfigFromPrefs();
-            if (config != null) {
-              _backgroundLogger.i(
-                '[AndroidBackgroundHandler] Using simplified decline logic with decline_push parameter.',
-              );
-              tempDeclineClient.handlePushNotification(
-                pushMetaData,
-                config is CredentialConfig ? config : null,
-                config is TokenConfig ? config : null,
-              );
-            } else {
-              _backgroundLogger.e(
-                '[AndroidBackgroundHandler] Could not retrieve config from SharedPreferences. Cannot decline call.',
-              );
+            var cleanupArmed = false;
+            try {
+              final config = await ConfigHelper.getTelnyxConfigFromPrefs();
+              if (config != null) {
+                _backgroundLogger.i(
+                  '[AndroidBackgroundHandler] Using simplified decline logic with decline_push parameter.',
+                );
+                _disposeTemporaryDeclineClientAfterDisconnect(
+                  tempDeclineClient,
+                );
+                cleanupArmed = true;
+                tempDeclineClient.handlePushNotification(
+                  pushMetaData,
+                  config is CredentialConfig ? config : null,
+                  config is TokenConfig ? config : null,
+                );
+              } else {
+                _backgroundLogger.e(
+                  '[AndroidBackgroundHandler] Could not retrieve config from SharedPreferences. Cannot decline call.',
+                );
+              }
+            } finally {
+              if (!cleanupArmed) {
+                tempDeclineClient.dispose();
+              }
             }
           } catch (e) {
             _backgroundLogger.e(
@@ -144,7 +182,8 @@ class AndroidPushNotificationHandler implements PushNotificationHandler {
     try {
       await flutterLocalNotificationsPlugin
           .resolvePlatformSpecificImplementation<
-              AndroidFlutterLocalNotificationsPlugin>()
+            AndroidFlutterLocalNotificationsPlugin
+          >()
           ?.createNotificationChannel(channel);
       _logger.i(
         '[PushNotificationHandler-Android] High importance notification channel created/updated.',
@@ -396,8 +435,8 @@ class AndroidPushNotificationHandler implements PushNotificationHandler {
   @override
   Future<Map<String, dynamic>?> getInitialPushData() async {
     _logger.i('[PushNotificationHandler-Android] getInitialPushData');
-    final RemoteMessage? initialMessage =
-        await FirebaseMessaging.instance.getInitialMessage();
+    final RemoteMessage? initialMessage = await FirebaseMessaging.instance
+        .getInitialMessage();
     if (initialMessage != null) {
       _logger.i(
         '[PushNotificationHandler-Android] getInitialPushData: Found initial message: ${initialMessage.data}',

--- a/lib/service/ios_push_notification_handler.dart
+++ b/lib/service/ios_push_notification_handler.dart
@@ -8,10 +8,38 @@ import 'package:logger/logger.dart';
 import 'package:telnyx_flutter_webrtc/main.dart'; // For logger, txClientViewModel, handlePush
 import 'package:telnyx_flutter_webrtc/service/push_notification_handler.dart';
 import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/model/connection_status.dart';
 import 'package:telnyx_webrtc/model/push_notification.dart';
 import 'package:telnyx_webrtc/config/telnyx_config.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:telnyx_flutter_webrtc/utils/config_helper.dart';
+
+void _disposeTemporaryDeclineClientAfterDisconnect(TelnyxClient client) {
+  var sawOpenConnection = false;
+  var disposed = false;
+  late final Timer fallbackTimer;
+
+  void disposeOnce() {
+    if (disposed) return;
+
+    disposed = true;
+    fallbackTimer.cancel();
+    client.dispose();
+  }
+
+  fallbackTimer = Timer(const Duration(seconds: 10), disposeOnce);
+  client.onConnectionStateChanged = (ConnectionStatus status) {
+    if (status == ConnectionStatus.connected ||
+        status == ConnectionStatus.clientReady) {
+      sawOpenConnection = true;
+      return;
+    }
+
+    if (sawOpenConnection && status == ConnectionStatus.disconnected) {
+      disposeOnce();
+    }
+  };
+}
 
 /// iOS specific implementation of [PushNotificationHandler].
 class IOSPushNotificationHandler implements PushNotificationHandler {
@@ -133,20 +161,31 @@ class IOSPushNotificationHandler implements PushNotificationHandler {
             final PushMetaData pushMetaData = PushMetaData.fromJson(eventData)
               ..isDecline = true;
             final tempDeclineClient = TelnyxClient();
-            final config = await ConfigHelper.getTelnyxConfigFromPrefs();
-            _logger.i(
-              '[PushNotificationHandler-iOS] actionCallDecline: Temp client attempting to handlePushNotification. Config :: $config',
-            );
-            if (config != null) {
-              tempDeclineClient.handlePushNotification(
-                pushMetaData,
-                config is CredentialConfig ? config : null,
-                config is TokenConfig ? config : null,
+            var cleanupArmed = false;
+            try {
+              final config = await ConfigHelper.getTelnyxConfigFromPrefs();
+              _logger.i(
+                '[PushNotificationHandler-iOS] actionCallDecline: Temp client attempting to handlePushNotification. Config :: $config',
               );
-            } else {
-              _logger.e(
-                '[PushNotificationHandler-iOS] actionCallDecline: Could not get config for temp client.',
-              );
+              if (config != null) {
+                _disposeTemporaryDeclineClientAfterDisconnect(
+                  tempDeclineClient,
+                );
+                cleanupArmed = true;
+                tempDeclineClient.handlePushNotification(
+                  pushMetaData,
+                  config is CredentialConfig ? config : null,
+                  config is TokenConfig ? config : null,
+                );
+              } else {
+                _logger.e(
+                  '[PushNotificationHandler-iOS] actionCallDecline: Could not get config for temp client.',
+                );
+              }
+            } finally {
+              if (!cleanupArmed) {
+                tempDeclineClient.dispose();
+              }
             }
           }
           break;

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -74,7 +74,6 @@ class TelnyxClientViewModel with ChangeNotifier {
   // Call history tracking
   String? _currentCallDestination;
   CallDirection? _currentCallDirection;
-  DateTime? _currentCallStartTime;
 
   // Call termination reason tracking
   CallTerminationReason? _lastTerminationReason;
@@ -223,7 +222,6 @@ class TelnyxClientViewModel with ChangeNotifier {
     // Reset call history tracking
     _currentCallDestination = null;
     _currentCallDirection = null;
-    _currentCallStartTime = null;
 
     // Reset termination reason after a delay to allow UI to show it
     Timer(const Duration(seconds: 5), () {
@@ -423,13 +421,12 @@ class TelnyxClientViewModel with ChangeNotifier {
     // Observe Socket Messages Received
     _telnyxClient
       ..onConnectionStateChanged = (ConnectionStatus status) {
-        logger.i(
-          'TxClientViewModel :: Connection state changed: $status',
-        );
+        logger.i('TxClientViewModel :: Connection state changed: $status');
         if (_connectionStatus != status) {
           _connectionStatus = status;
           // Update the legacy _connected field for backward compatibility
-          _connected = status == ConnectionStatus.connected ||
+          _connected =
+              status == ConnectionStatus.connected ||
               status == ConnectionStatus.clientReady;
           notifyListeners();
         }
@@ -479,7 +476,6 @@ class TelnyxClientViewModel with ChangeNotifier {
                 _currentCallDestination =
                     _incomingInvite!.callerIdNumber ?? 'Unknown';
                 _currentCallDirection = CallDirection.incoming;
-                _currentCallStartTime = DateTime.now();
               }
 
               if (waitingForInvite) {
@@ -847,7 +843,6 @@ class TelnyxClientViewModel with ChangeNotifier {
     // Track outgoing call for history
     _currentCallDestination = destination;
     _currentCallDirection = CallDirection.outgoing;
-    _currentCallStartTime = DateTime.now();
 
     // Call NotificationService to handle the CallKit UI for outgoing call
     if (_currentCall?.callId != null) {
@@ -877,11 +872,12 @@ class TelnyxClientViewModel with ChangeNotifier {
     String? base64Image,
   }) {
     try {
-      currentCall?.sendConversationMessage(
-        message,
-        base64Images: base64Images,
-        base64Image: base64Image,
-      );
+      final images =
+          base64Images ??
+          (base64Image != null && base64Image.isNotEmpty
+              ? <String>[base64Image]
+              : null);
+      currentCall?.sendConversationMessage(message, base64Images: images);
     } catch (e) {
       logger.e('Error sending conversation message: $e');
     }
@@ -1207,5 +1203,11 @@ class TelnyxClientViewModel with ChangeNotifier {
         'TelnyxClientViewModel.forceIceRenegotiation: Error during renegotiation: $e',
       );
     }
+  }
+
+  @override
+  void dispose() {
+    _telnyxClient.dispose();
+    super.dispose();
   }
 }

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -68,6 +68,10 @@ typedef OnConnectionMetricsUpdate = void Function(
   SocketConnectionMetrics metrics,
 );
 
+/// Provides connectivity change events for [TelnyxClient].
+typedef ConnectivityChangesProvider = Stream<List<ConnectivityResult>>
+    Function();
+
 /// Represents the main entry point for interacting with the Telnyx RTC SDK.
 ///
 /// This class manages the WebSocket connection to the Telnyx backend, handles
@@ -108,6 +112,10 @@ class TelnyxClient {
 
   // Stores the last known connectivity result to detect actual changes.
   List<ConnectivityResult>? _previousConnectivityResult;
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
+  final ConnectivityChangesProvider _connectivityChanges;
+  final Set<Timer> _delayedConnectionTimers = <Timer>{};
+  int _connectionGeneration = 0;
 
   // Map to track reconnection timers for each call
   final Map<String?, Timer> _reconnectionTimers = {};
@@ -120,7 +128,9 @@ class TelnyxClient {
   final Map<String, StringBuffer> _assistantResponseBuffers = {};
 
   /// Default constructor for the TelnyxClient
-  TelnyxClient() {
+  TelnyxClient({ConnectivityChangesProvider? connectivityChanges})
+      : _connectivityChanges = connectivityChanges ??
+            (() => Connectivity().onConnectivityChanged) {
     onSocketMessageReceived = (TelnyxMessage message) {
       switch (message.socketMethod) {
         case SocketMethod.invite:
@@ -157,7 +167,9 @@ class TelnyxClient {
   /// The current instance of [TxSocket] associated with this client
   TxSocket txSocket = TxSocket(DefaultConfig.socketHostAddress);
 
-  bool _closed = false;
+  bool _closed = true;
+  bool _disposed = false;
+  bool _latencyTrackerDisposed = false;
   bool _connected = false;
   ConnectionStatus _connectionStatus = ConnectionStatus.disconnected;
 
@@ -170,7 +182,7 @@ class TelnyxClient {
 
   /// The WebSocket host URL for deriving the call report endpoint.
   String? _socketHost;
-  
+
   /// Gets the WebSocket host URL (used for call report endpoint derivation).
   String? get socketHost => _socketHost;
 
@@ -397,10 +409,63 @@ class TelnyxClient {
     return gatewayState;
   }
 
+  bool get _isTornDown => _closed || _disposed;
+
+  bool _isActiveConnectionGeneration(int generation) {
+    return !_isTornDown && generation == _connectionGeneration;
+  }
+
+  void _invalidateConnectionGeneration() {
+    _connectionGeneration++;
+    _cancelDelayedConnectionTimers();
+  }
+
+  Timer _scheduleConnectionTimer(
+    Duration duration,
+    void Function() callback, {
+    int? generation,
+  }) {
+    final timerGeneration = generation ?? _connectionGeneration;
+    late final Timer timer;
+    timer = Timer(duration, () {
+      _delayedConnectionTimers.remove(timer);
+      if (!_isActiveConnectionGeneration(timerGeneration)) {
+        return;
+      }
+
+      callback();
+    });
+    _delayedConnectionTimers.add(timer);
+    return timer;
+  }
+
+  void _cancelDelayedConnectionTimers() {
+    for (final timer in _delayedConnectionTimers) {
+      timer.cancel();
+    }
+    _delayedConnectionTimers.clear();
+  }
+
+  bool _prepareForConnection() {
+    if (_disposed) {
+      GlobalLogger().w('TelnyxClient is disposed and cannot reconnect');
+      return false;
+    }
+    _invalidateConnectionGeneration();
+    _invalidateGatewayResponseTimer();
+    _closed = false;
+    _checkReconnection();
+    return true;
+  }
+
   void _checkReconnection() {
-    Connectivity().onConnectivityChanged.listen((
+    if (_disposed || _connectivitySubscription != null) return;
+
+    _connectivitySubscription = _connectivityChanges().listen((
       List<ConnectivityResult> connectivityResult,
     ) {
+      if (_isTornDown) return;
+
       GlobalLogger().i(
         'Connectivity changed: ${connectivityResult.join(", ")}',
       );
@@ -441,6 +506,23 @@ class TelnyxClient {
         }
       }
     });
+  }
+
+  void _cancelConnectivitySubscription() {
+    final subscription = _connectivitySubscription;
+    if (subscription == null) return;
+
+    unawaited(subscription.cancel());
+    _connectivitySubscription = null;
+    _previousConnectivityResult = null;
+  }
+
+  void _closeSocketSafely() {
+    try {
+      txSocket.close();
+    } catch (error) {
+      GlobalLogger().e('close() | error closing the WebSocket: $error');
+    }
   }
 
   /// Set the custom logger for the SDK
@@ -561,8 +643,9 @@ class TelnyxClient {
   void _handleNetworkReconnection(NetworkReason reason) {
     // Check if autoReconnect is enabled before attempting network reconnection
     if (!_autoReconnectLogin) {
-      GlobalLogger()
-          .i('AutoReconnect is disabled, not attempting network reconnection');
+      GlobalLogger().i(
+        'AutoReconnect is disabled, not attempting network reconnection',
+      );
       for (var call in activeCalls().values) {
         call.callHandler.onCallStateChanged.call(
           CallState.dropped.withNetworkReason(NetworkReason.networkLost),
@@ -597,6 +680,7 @@ class TelnyxClient {
     _cancelReconnectionTimer(call.callId);
 
     GlobalLogger().i('Starting reconnection timer for call ${call.callId}');
+    final connectionGeneration = _connectionGeneration;
 
     // Create a new timer
     _reconnectionTimers[call.callId] = Timer(
@@ -606,6 +690,8 @@ class TelnyxClient {
             Constants.reconnectionTimeout,
       ),
       () {
+        if (!_isActiveConnectionGeneration(connectionGeneration)) return;
+
         // Check if the call is still in the reconnecting state
         if (calls.containsKey(call.callId)) {
           GlobalLogger().i('Reconnection timeout for call ${call.callId}');
@@ -633,6 +719,13 @@ class TelnyxClient {
     }
   }
 
+  void _cancelReconnectionTimers() {
+    for (final timer in _reconnectionTimers.values) {
+      timer.cancel();
+    }
+    _reconnectionTimers.clear();
+  }
+
   /// Starts the timeout timer for pending answer from push notification
   void _startPendingAnswerTimeout() {
     // Cancel any existing timeout
@@ -643,6 +736,8 @@ class TelnyxClient {
     );
 
     _pendingAnswerTimeout = Timer(_pushAnswerTimeoutDuration, () {
+      if (_isTornDown) return;
+
       _handlePendingAnswerTimeout();
     });
   }
@@ -654,6 +749,13 @@ class TelnyxClient {
       _pendingAnswerTimeout = null;
       GlobalLogger().i('Cancelled pending answer timeout');
     }
+  }
+
+  void _disposeLatencyTracker() {
+    if (_latencyTrackerDisposed) return;
+
+    latencyTracker.dispose();
+    _latencyTrackerDisposed = true;
   }
 
   /// Processes and queues the ICE candidate for the specified call.
@@ -699,8 +801,9 @@ class TelnyxClient {
   void _processQueuedIceCandidates(String callId) {
     final call = calls[callId];
     if (call == null) {
-      GlobalLogger()
-          .w('No call found for ID: $callId when processing queued candidates');
+      GlobalLogger().w(
+        'No call found for ID: $callId when processing queued candidates',
+      );
       return;
     }
 
@@ -724,8 +827,9 @@ class TelnyxClient {
             candidate.sdpMid,
             candidate.sdpMLineIndex,
           );
-          GlobalLogger()
-              .i('Successfully processed queued candidate for call $callId');
+          GlobalLogger().i(
+            'Successfully processed queued candidate for call $callId',
+          );
         } else {
           GlobalLogger().w(
             'Peer connection is null for call $callId, cannot process candidate',
@@ -745,6 +849,8 @@ class TelnyxClient {
 
   /// Handles the timeout when no INVITE is received after accepting from push
   void _handlePendingAnswerTimeout() {
+    if (_isTornDown) return;
+
     GlobalLogger().i(
       'Pending answer timeout expired - no INVITE received within ${_pushAnswerTimeoutDuration.inSeconds} seconds',
     );
@@ -907,7 +1013,7 @@ class TelnyxClient {
     txSocket.send(jsonLoginMessage);
 
     // Disconnect after sending the decline login message
-    Timer(const Duration(milliseconds: 1000), () {
+    _scheduleConnectionTimer(const Duration(milliseconds: 1000), () {
       GlobalLogger().i(
         'TelnyxClient._credentialLoginWithDecline: Disconnecting after decline login',
       );
@@ -949,7 +1055,7 @@ class TelnyxClient {
     txSocket.send(jsonLoginMessage);
 
     // Disconnect after sending the decline login message
-    Timer(const Duration(milliseconds: 1000), () {
+    _scheduleConnectionTimer(const Duration(milliseconds: 1000), () {
       GlobalLogger().i(
         'TelnyxClient._tokenLoginWithDecline: Disconnecting after decline login',
       );
@@ -987,6 +1093,9 @@ class TelnyxClient {
     PushMetaData? pushMetaData,
     OnOpenCallback openCallback,
   ) {
+    if (!_prepareForConnection()) return;
+    final connectionGeneration = _connectionGeneration;
+
     GlobalLogger().i(
       'TelnyxClient._connectWithCallBack: Called. PushMetaData: ${pushMetaData?.toJson()}',
     );
@@ -1007,8 +1116,10 @@ class TelnyxClient {
         );
       }
       txSocket
-        ..connect()
         ..onOpen = () {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) {
+            return;
+          }
           _closed = false;
           _updateConnectionState(true);
           GlobalLogger().i(
@@ -1018,17 +1129,21 @@ class TelnyxClient {
           openCallback.call();
         }
         ..onMessage = (dynamic data) {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
           _onMessage(data);
         }
         ..onClose = (int closeCode, String closeReason) {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
           GlobalLogger().i('Closed [$closeCode, $closeReason]!');
           _updateConnectionState(false);
           final wasClean = WebSocketUtils.isCleanClose(closeCode, closeReason);
           _onClose(wasClean, closeCode, closeReason);
         }
         ..onPing = (SocketConnectionMetrics metrics) {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
           onConnectionMetricsUpdate?.call(metrics);
-        };
+        }
+        ..connect();
     } catch (e, string) {
       GlobalLogger().e('${e.toString()} :: $string');
       _updateConnectionState(false);
@@ -1038,6 +1153,9 @@ class TelnyxClient {
 
   /// Connects to the WebSocket using the provided [tokenConfig]
   void connectWithToken(TokenConfig tokenConfig) {
+    if (!_prepareForConnection()) return;
+    final connectionGeneration = _connectionGeneration;
+
     // Store current config for potential fallback
     _currentConfig = tokenConfig;
 
@@ -1069,6 +1187,9 @@ class TelnyxClient {
       GlobalLogger().i('connecting to WebSocket $hostAddress');
       txSocket
         ..onOpen = () {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) {
+            return;
+          }
           _closed = false;
           _updateConnectionState(true);
           _isRegionFallbackAttempt =
@@ -1076,20 +1197,25 @@ class TelnyxClient {
           GlobalLogger().i(
             'TelnyxClient.connectWithToken (via _onOpen): Web Socket is now connected',
           );
-          latencyTracker.markRegistrationMilestone(LatencyTracker.milestoneSocketConnected);
+          latencyTracker.markRegistrationMilestone(
+            LatencyTracker.milestoneSocketConnected,
+          );
           _onOpen();
           tokenLogin(tokenConfig);
         }
         ..onMessage = (dynamic data) {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
           _onMessage(data);
         }
         ..onClose = (int closeCode, String closeReason) {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
           GlobalLogger().i('Closed [$closeCode, $closeReason]!');
           _updateConnectionState(false);
           final wasClean = WebSocketUtils.isCleanClose(closeCode, closeReason);
           _onClose(wasClean, closeCode, closeReason);
         }
         ..onPing = (SocketConnectionMetrics metrics) {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
           onConnectionMetricsUpdate?.call(metrics);
         }
         ..connect();
@@ -1102,6 +1228,9 @@ class TelnyxClient {
 
   /// Connects to the WebSocket using the provided [CredentialConfig]
   void connectWithCredential(CredentialConfig credentialConfig) {
+    if (!_prepareForConnection()) return;
+    final connectionGeneration = _connectionGeneration;
+
     // Store current config for potential fallback
     _currentConfig = credentialConfig;
 
@@ -1132,6 +1261,9 @@ class TelnyxClient {
       GlobalLogger().i('connecting to WebSocket $hostAddress');
       txSocket
         ..onOpen = () {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) {
+            return;
+          }
           _closed = false;
           _updateConnectionState(true);
           _isRegionFallbackAttempt =
@@ -1139,20 +1271,27 @@ class TelnyxClient {
           GlobalLogger().i(
             'TelnyxClient.connectWithCredential (via _onOpen): Web Socket is now connected',
           );
-          latencyTracker.markRegistrationMilestone(LatencyTracker.milestoneSocketConnected);
+          latencyTracker.markRegistrationMilestone(
+            LatencyTracker.milestoneSocketConnected,
+          );
           _onOpen();
           credentialLogin(credentialConfig);
         }
         ..onMessage = (dynamic data) {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
           _onMessage(data);
         }
         ..onClose = (int closeCode, String closeReason) {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
           GlobalLogger().i('Closed [$closeCode, $closeReason]!');
-          final bool wasClean =
-              WebSocketUtils.isCleanClose(closeCode, closeReason);
+          final bool wasClean = WebSocketUtils.isCleanClose(
+            closeCode,
+            closeReason,
+          );
           _onClose(wasClean, closeCode, closeReason);
         }
         ..onPing = (SocketConnectionMetrics metrics) {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
           onConnectionMetricsUpdate?.call(metrics);
         }
         ..connect();
@@ -1171,10 +1310,14 @@ class TelnyxClient {
   void connect() {
     GlobalLogger().i('connect()');
     if (isConnected()) {
-      GlobalLogger()
-          .i('WebSocket $_serverConfiguration.socketUrl is already connected');
+      GlobalLogger().i(
+        'WebSocket $_serverConfiguration.socketUrl is already connected',
+      );
       return;
     }
+    if (!_prepareForConnection()) return;
+    final connectionGeneration = _connectionGeneration;
+
     GlobalLogger().i('connecting to WebSocket $_serverConfiguration.socketUrl');
     try {
       if (_pushMetaData != null) {
@@ -1185,27 +1328,36 @@ class TelnyxClient {
         );
       } else {
         txSocket.hostAddress = _serverConfiguration.socketUrl;
-        GlobalLogger()
-            .i('connecting to WebSocket $_serverConfiguration.socketUrl');
+        GlobalLogger().i(
+          'connecting to WebSocket $_serverConfiguration.socketUrl',
+        );
       }
       txSocket
         ..onOpen = () {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) {
+            return;
+          }
           _closed = false;
           _updateConnectionState(true);
           GlobalLogger().i('Web Socket is now connected');
           _onOpen();
         }
         ..onMessage = (dynamic data) {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
           _onMessage(data);
         }
         ..onClose = (int closeCode, String closeReason) {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
           GlobalLogger().i('Closed [$closeCode, $closeReason]!');
           _updateConnectionState(false);
-          final bool wasClean =
-              WebSocketUtils.isCleanClose(closeCode, closeReason);
+          final bool wasClean = WebSocketUtils.isCleanClose(
+            closeCode,
+            closeReason,
+          );
           _onClose(wasClean, closeCode, closeReason);
         }
         ..onPing = (SocketConnectionMetrics metrics) {
+          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
           onConnectionMetricsUpdate?.call(metrics);
         }
         ..connect();
@@ -1220,6 +1372,9 @@ class TelnyxClient {
   /// This method is used for both network-based reconnections and gateway failures
   /// It respects the autoReconnect settings and provides better logging
   void _reconnectToSocket() {
+    if (_isTornDown) return;
+    final connectionGeneration = _connectionGeneration;
+
     // Set reconnecting status
     if (_connectionStatus != ConnectionStatus.reconnecting) {
       _connectionStatus = ConnectionStatus.reconnecting;
@@ -1231,35 +1386,44 @@ class TelnyxClient {
     );
 
     _isAttaching = true;
-    Timer(Duration(milliseconds: Constants.gatewayResponseDelay), () {
-      _isAttaching = false;
-    });
+    _scheduleConnectionTimer(
+      Duration(milliseconds: Constants.gatewayResponseDelay),
+      () {
+        _isAttaching = false;
+      },
+      generation: connectionGeneration,
+    );
 
-    txSocket.close();
+    _closeSocketSafely();
 
     // Delay to allow connection with exponential backoff for retries
     final delayMs = _connectRetryCounter > 0
         ? Constants.reconnectTimer * (1 << (_connectRetryCounter - 1))
         : 1000;
 
-    Timer(Duration(milliseconds: delayMs), () {
-      if (_storedCredentialConfig != null) {
-        GlobalLogger().i('Reconnecting with credential config');
-        connectWithCredential(_storedCredentialConfig!);
-      } else if (_storedTokenConfig != null) {
-        GlobalLogger().i('Reconnecting with token config');
-        connectWithToken(_storedTokenConfig!);
-      } else {
-        GlobalLogger()
-            .e('No stored configuration available for socket reconnection');
-        final error = TelnyxSocketError(
-          errorCode: TelnyxErrorConstants.gatewayFailedErrorCode,
-          errorMessage:
-              'No stored configuration available for socket reconnection',
-        );
-        onSocketErrorReceived(error);
-      }
-    });
+    _scheduleConnectionTimer(
+      Duration(milliseconds: delayMs),
+      () {
+        if (_storedCredentialConfig != null) {
+          GlobalLogger().i('Reconnecting with credential config');
+          connectWithCredential(_storedCredentialConfig!);
+        } else if (_storedTokenConfig != null) {
+          GlobalLogger().i('Reconnecting with token config');
+          connectWithToken(_storedTokenConfig!);
+        } else {
+          GlobalLogger().e(
+            'No stored configuration available for socket reconnection',
+          );
+          final error = TelnyxSocketError(
+            errorCode: TelnyxErrorConstants.gatewayFailedErrorCode,
+            errorMessage:
+                'No stored configuration available for socket reconnection',
+          );
+          onSocketErrorReceived(error);
+        }
+      },
+      generation: connectionGeneration,
+    );
   }
 
   /// The current instance of [Call] associated with this client. Can be used
@@ -1613,7 +1777,8 @@ class TelnyxClient {
     inviteCall.peerConnection?.setCallReportConfig(
       callReportInterval: callReportConfig?.callReportInterval ?? 5000,
       callReportLogLevel: callReportConfig?.callReportLogLevel ?? 'debug',
-      callReportMaxLogEntries: callReportConfig?.callReportMaxLogEntries ?? 1000,
+      callReportMaxLogEntries:
+          callReportConfig?.callReportMaxLogEntries ?? 1000,
     );
     // Convert AudioCodec objects to Map format for the peer connection
     List<Map<String, dynamic>>? codecMaps;
@@ -1707,11 +1872,13 @@ class TelnyxClient {
       _getEffectiveIceServers(),
     );
     // Apply call report config from stored config
-    final answerCallReportConfig = _storedCredentialConfig ?? _storedTokenConfig;
+    final answerCallReportConfig =
+        _storedCredentialConfig ?? _storedTokenConfig;
     answerCall.peerConnection?.setCallReportConfig(
       callReportInterval: answerCallReportConfig?.callReportInterval ?? 5000,
       callReportLogLevel: answerCallReportConfig?.callReportLogLevel ?? 'debug',
-      callReportMaxLogEntries: answerCallReportConfig?.callReportMaxLogEntries ?? 1000,
+      callReportMaxLogEntries:
+          answerCallReportConfig?.callReportMaxLogEntries ?? 1000,
     );
 
     // Set up the session with the callback if debug is enabled
@@ -1762,10 +1929,12 @@ class TelnyxClient {
   /// This method logs the user out and terminates the WebSocket connection.
   /// The [closeCallback] is invoked when the disconnection is complete.
   void disconnectWithCallBack(OnCloseCallback? closeCallback) {
+    _invalidateConnectionGeneration();
     _invalidateGatewayResponseTimer();
     _resetGatewayCounters();
-    // Cancel any pending answer timeout
     _cancelPendingAnswerTimeout();
+    _cancelReconnectionTimers();
+    _cancelConnectivitySubscription();
     clearPushMetaData();
     GlobalLogger().i('disconnect()');
     if (_closed) {
@@ -1778,22 +1947,22 @@ class TelnyxClient {
     _updateConnectionState(false);
     _registered = false;
     _updateConnectionStatus();
-    try {
-      txSocket.close();
-      Future.delayed(const Duration(milliseconds: 100), () {
+    _closeSocketSafely();
+    Future.delayed(const Duration(milliseconds: 100), () {
+      if (!_disposed) {
         closeCallback?.call(0, 'Client send disconnect');
-      });
-    } catch (error) {
-      GlobalLogger().e('close() | error closing the WebSocket: $error');
-    }
+      }
+    });
   }
 
   /// Closes the socket connection, effectively logging the user out.
   void disconnect() {
+    _invalidateConnectionGeneration();
     _invalidateGatewayResponseTimer();
     _resetGatewayCounters();
-    // Cancel any pending answer timeout
     _cancelPendingAnswerTimeout();
+    _cancelReconnectionTimers();
+    _cancelConnectivitySubscription();
     clearPushMetaData();
     GlobalLogger().i('disconnect()');
     if (_closed) return;
@@ -1803,11 +1972,30 @@ class TelnyxClient {
     _registered = false;
     _updateConnectionStatus();
     _onClose(true, 0, 'Client send disconnect');
-    try {
-      txSocket.close();
-    } catch (error) {
-      GlobalLogger().e('close() | error closing the WebSocket: $error');
+    _closeSocketSafely();
+  }
+
+  /// Releases resources owned by this client.
+  void dispose() {
+    if (_disposed) return;
+
+    final shouldCloseSocket = !_closed;
+    _disposed = true;
+    _closed = true;
+    _invalidateConnectionGeneration();
+    _invalidateGatewayResponseTimer();
+    _resetGatewayCounters();
+    _cancelPendingAnswerTimeout();
+    _cancelReconnectionTimers();
+    _cancelConnectivitySubscription();
+    clearPushMetaData();
+    _registered = false;
+    _connected = false;
+    _connectionStatus = ConnectionStatus.disconnected;
+    if (shouldCloseSocket) {
+      _closeSocketSafely();
     }
+    _disposeLatencyTracker();
   }
 
   /// WebSocket Event Handlers
@@ -1818,6 +2006,9 @@ class TelnyxClient {
   }
 
   void _onClose(bool wasClean, int code, String reason) {
+    if (_disposed) return;
+    final connectionGeneration = _connectionGeneration;
+
     GlobalLogger().i('WebSocket closed');
     if (wasClean == false) {
       GlobalLogger().i('WebSocket abrupt disconnection');
@@ -1853,9 +2044,13 @@ class TelnyxClient {
         );
 
         // Retry connection with auto region
-        Timer(const Duration(milliseconds: 1000), () {
-          connectWithToken(fallbackConfig as TokenConfig);
-        });
+        _scheduleConnectionTimer(
+          const Duration(milliseconds: 1000),
+          () {
+            connectWithToken(fallbackConfig as TokenConfig);
+          },
+          generation: connectionGeneration,
+        );
       } else if (_currentConfig is CredentialConfig) {
         final credConfig = _currentConfig as CredentialConfig;
         fallbackConfig = CredentialConfig(
@@ -1874,14 +2069,20 @@ class TelnyxClient {
         );
 
         // Retry connection with auto region
-        Timer(const Duration(milliseconds: 1000), () {
-          connectWithCredential(fallbackConfig as CredentialConfig);
-        });
+        _scheduleConnectionTimer(
+          const Duration(milliseconds: 1000),
+          () {
+            connectWithCredential(fallbackConfig as CredentialConfig);
+          },
+          generation: connectionGeneration,
+        );
       }
     }
   }
 
   void _onMessage(dynamic data) async {
+    if (_isTornDown) return;
+
     GlobalLogger().i(
       'TelnyxClient._onMessage: RAW WebSocket data received: ${data?.toString().trim()}',
     );
@@ -1900,8 +2101,9 @@ class TelnyxClient {
               LogLevel.info,
               'Received WebSocket message - Contains Error :: $errorJson',
             );
-            final ReceivedResult errorResult =
-                ReceivedResult.fromJson(messageJson);
+            final ReceivedResult errorResult = ReceivedResult.fromJson(
+              messageJson,
+            );
             final TelnyxSocketError error = TelnyxSocketError(
               errorCode: errorResult.error?.errorCode ?? 0,
               errorMessage: errorResult.error?.errorMessage ?? 'Unknown error',
@@ -1914,8 +2116,9 @@ class TelnyxClient {
               'Received WebSocket message - Contains Result :: $paramJson',
             );
 
-            final ReceivedResult stateMessage =
-                ReceivedResult.fromJson(messageJson);
+            final ReceivedResult stateMessage = ReceivedResult.fromJson(
+              messageJson,
+            );
             final mainMessage = ReceivedMessage(
               jsonrpc: stateMessage.jsonrpc,
               method: SocketMethod.gatewayState,
@@ -1933,14 +2136,17 @@ class TelnyxClient {
                       _invalidateGatewayResponseTimer();
                       _resetGatewayCounters();
                       gatewayState = GatewayState.reged;
-                      
+
                       // Complete registration latency tracking
                       latencyTracker.completeRegistrationTracking();
-                      
+
                       // Store call_report_id for call report authentication
-                      callReportId = stateMessage.resultParams?.stateParams?.callReportId;
+                      callReportId =
+                          stateMessage.resultParams?.stateParams?.callReportId;
                       if (callReportId != null) {
-                        GlobalLogger().d('CallReportId received: $callReportId');
+                        GlobalLogger().d(
+                          'CallReportId received: $callReportId',
+                        );
                       }
                       _waitingForReg = false;
                       final message = TelnyxMessage(
@@ -2072,22 +2278,25 @@ class TelnyxClient {
 
               // Handle updateMedia response - check the raw JSON data directly
               try {
-                final Map<String, dynamic> rawData =
-                    jsonDecode(data.toString());
+                final Map<String, dynamic> rawData = jsonDecode(
+                  data.toString(),
+                );
                 if (rawData.containsKey('result') && rawData['result'] is Map) {
                   final resultMap = rawData['result'] as Map<String, dynamic>;
                   if (resultMap['action'] == 'updateMedia') {
                     GlobalLogger().i('Received updateMedia response');
 
-                    final updateMediaResponse =
-                        UpdateMediaResponse.fromJson(resultMap);
+                    final updateMediaResponse = UpdateMediaResponse.fromJson(
+                      resultMap,
+                    );
 
                     // Find the call and handle the response
                     final callId = updateMediaResponse.callID;
                     final call = calls[callId];
                     if (call?.peerConnection != null) {
-                      await call!.peerConnection!
-                          .handleUpdateMediaResponse(updateMediaResponse);
+                      await call!.peerConnection!.handleUpdateMediaResponse(
+                        updateMediaResponse,
+                      );
                     }
                   } else {
                     GlobalLogger().i('Not an updateMedia response');
@@ -2099,11 +2308,13 @@ class TelnyxClient {
             }
           } else if (messageJson.containsKey('method')) {
             //Received Telnyx Method Message
-            final ReceivedMessage clientReadyMessage =
-                ReceivedMessage.fromJson(messageJson);
+            final ReceivedMessage clientReadyMessage = ReceivedMessage.fromJson(
+              messageJson,
+            );
             if (clientReadyMessage.voiceSdkId != null) {
-              GlobalLogger()
-                  .i('VoiceSdkID :: ${clientReadyMessage.voiceSdkId}');
+              GlobalLogger().i(
+                'VoiceSdkID :: ${clientReadyMessage.voiceSdkId}',
+              );
               _pushMetaData = PushMetaData(
                 callerNumber: null,
                 callerName: null,
@@ -2137,6 +2348,8 @@ class TelnyxClient {
                       _gatewayResponseTimer = Timer(
                         Duration(milliseconds: Constants.gatewayResponseDelay),
                         () {
+                          if (_isTornDown) return;
+
                           if (_registrationRetryCounter <
                               Constants.retryRegisterTime) {
                             if (_waitingForReg) {
@@ -2168,8 +2381,9 @@ class TelnyxClient {
               case SocketMethod.invite:
                 {
                   GlobalLogger().i('INCOMING INVITATION :: $messageJson');
-                  final ReceivedMessage invite =
-                      ReceivedMessage.fromJson(messageJson);
+                  final ReceivedMessage invite = ReceivedMessage.fromJson(
+                    messageJson,
+                  );
                   final message = TelnyxMessage(
                     socketMethod: SocketMethod.invite,
                     message: invite,
@@ -2219,8 +2433,9 @@ class TelnyxClient {
               case SocketMethod.attach:
                 {
                   GlobalLogger().i('ATTACH RECEIVED :: $messageJson');
-                  final ReceivedMessage invite =
-                      ReceivedMessage.fromJson(messageJson);
+                  final ReceivedMessage invite = ReceivedMessage.fromJson(
+                    messageJson,
+                  );
                   final message = TelnyxMessage(
                     socketMethod: SocketMethod.attach,
                     message: invite,
@@ -2282,13 +2497,15 @@ class TelnyxClient {
               case SocketMethod.answer:
                 {
                   GlobalLogger().i('INVITATION ANSWERED :: $messageJson');
-                  final ReceivedMessage inviteAnswer =
-                      ReceivedMessage.fromJson(messageJson);
+                  final ReceivedMessage inviteAnswer = ReceivedMessage.fromJson(
+                    messageJson,
+                  );
                   final Call? answerCall =
                       calls[inviteAnswer.inviteParams?.callID];
                   if (answerCall == null) {
-                    GlobalLogger()
-                        .d('Error : Call  is null from Answer Message');
+                    GlobalLogger().d(
+                      'Error : Call  is null from Answer Message',
+                    );
                     _sendNoCallError();
                     return;
                   }
@@ -2304,7 +2521,10 @@ class TelnyxClient {
 
                   // Mark latency milestones for answer received
                   if (answerCall.callId != null) {
-                    latencyTracker.markCallMilestone(answerCall.callId!, LatencyTracker.milestoneRemoteSdpReceived);
+                    latencyTracker.markCallMilestone(
+                      answerCall.callId!,
+                      LatencyTracker.milestoneRemoteSdpReceived,
+                    );
                     latencyTracker.markCallAnsweredByRemote(answerCall.callId!);
                   }
 
@@ -2363,8 +2583,9 @@ class TelnyxClient {
                   }
 
                   // Fall back to ReceivedMessage if ReceiveByeMessage parsing failed
-                  final ReceivedMessage bye =
-                      ReceivedMessage.fromJson(messageJson);
+                  final ReceivedMessage bye = ReceivedMessage.fromJson(
+                    messageJson,
+                  );
                   final String? callId =
                       byeMessage?.params?.callID ?? bye.inviteParams?.callID;
 
@@ -2400,8 +2621,9 @@ class TelnyxClient {
               case SocketMethod.ringing:
                 {
                   GlobalLogger().i('RINGING RECEIVED :: $messageJson');
-                  final ReceivedMessage ringing =
-                      ReceivedMessage.fromJson(messageJson);
+                  final ReceivedMessage ringing = ReceivedMessage.fromJson(
+                    messageJson,
+                  );
                   final Call? ringingCall = calls[ringing.inviteParams?.callID];
                   if (ringingCall == null) {
                     GlobalLogger().d(
@@ -2475,10 +2697,12 @@ class TelnyxClient {
                 }
               case SocketMethod.candidate:
                 {
-                  GlobalLogger()
-                      .i('TRICKLE ICE CANDIDATE RECEIVED :: $messageJson');
-                  final Map<String, dynamic> candidateData =
-                      jsonDecode(data.toString());
+                  GlobalLogger().i(
+                    'TRICKLE ICE CANDIDATE RECEIVED :: $messageJson',
+                  );
+                  final Map<String, dynamic> candidateData = jsonDecode(
+                    data.toString(),
+                  );
 
                   // Extract params from the candidate data
                   final Map<String, dynamic>? params = candidateData['params'];
@@ -2499,8 +2723,9 @@ class TelnyxClient {
                   final String? callId =
                       CandidateUtils.extractCallIdFromCandidate(params);
                   if (callId == null) {
-                    GlobalLogger()
-                        .w('Could not extract call ID from candidate message');
+                    GlobalLogger().w(
+                      'Could not extract call ID from candidate message',
+                    );
                     break;
                   }
 
@@ -2524,10 +2749,12 @@ class TelnyxClient {
                 }
               case SocketMethod.endOfCandidates:
                 {
-                  GlobalLogger()
-                      .i('END OF CANDIDATES RECEIVED :: $messageJson');
-                  final Map<String, dynamic> endData =
-                      jsonDecode(data.toString());
+                  GlobalLogger().i(
+                    'END OF CANDIDATES RECEIVED :: $messageJson',
+                  );
+                  final Map<String, dynamic> endData = jsonDecode(
+                    data.toString(),
+                  );
 
                   // Extract call ID
                   final String? callId =
@@ -2537,8 +2764,9 @@ class TelnyxClient {
                     // Find the call and signal end of candidates
                     final Call? call = calls[callId];
                     if (call != null) {
-                      GlobalLogger()
-                          .i('End of candidates signaled for call: $callId');
+                      GlobalLogger().i(
+                        'End of candidates signaled for call: $callId',
+                      );
                     } else {
                       GlobalLogger().w(
                         'Received endOfCandidates for unknown call: $callId',
@@ -2684,6 +2912,7 @@ class TelnyxClient {
 
   void _invalidateGatewayResponseTimer() {
     _gatewayResponseTimer?.cancel();
+    _gatewayResponseTimer = null;
   }
 
   void _resetGatewayCounters() {
@@ -2697,6 +2926,9 @@ class TelnyxClient {
   /// This method is called when gateway registration fails and autoReconnect is enabled
   /// It respects the _autoReconnectLogin setting and _connectRetryCounter limits
   void _attemptReconnection() {
+    if (_isTornDown) return;
+    final connectionGeneration = _connectionGeneration;
+
     // Set reconnecting status
     if (_connectionStatus != ConnectionStatus.reconnecting) {
       _connectionStatus = ConnectionStatus.reconnecting;
@@ -2705,8 +2937,9 @@ class TelnyxClient {
 
     // Check if autoReconnect is enabled
     if (!_autoReconnectLogin) {
-      GlobalLogger()
-          .i('AutoReconnect is disabled, not attempting reconnection');
+      GlobalLogger().i(
+        'AutoReconnect is disabled, not attempting reconnection',
+      );
       final error = TelnyxSocketError(
         errorCode: TelnyxErrorConstants.gatewayFailedErrorCode,
         errorMessage: 'AutoReconnect is disabled',
@@ -2736,28 +2969,33 @@ class TelnyxClient {
     // Use exponential backoff: base delay * (2 ^ retry_count)
     final delayMs =
         Constants.reconnectTimer * (1 << (_connectRetryCounter - 1));
-    Timer(Duration(milliseconds: delayMs), () {
-      if (_storedCredentialConfig != null) {
-        GlobalLogger().i(
-          'Attempting reconnection with credential config (attempt $_connectRetryCounter)',
-        );
-        // Use the existing _reconnectToSocket method for consistency
-        _reconnectToSocket();
-      } else if (_storedTokenConfig != null) {
-        GlobalLogger().i(
-          'Attempting reconnection with token config (attempt $_connectRetryCounter)',
-        );
-        // Use the existing _reconnectToSocket method for consistency
-        _reconnectToSocket();
-      } else {
-        GlobalLogger().e('No stored configuration available for reconnection');
-        final error = TelnyxSocketError(
-          errorCode: TelnyxErrorConstants.gatewayFailedErrorCode,
-          errorMessage: 'No stored configuration available for reconnection',
-        );
-        onSocketErrorReceived(error);
-      }
-    });
+    _scheduleConnectionTimer(
+      Duration(milliseconds: delayMs),
+      () {
+        if (_storedCredentialConfig != null) {
+          GlobalLogger().i(
+            'Attempting reconnection with credential config (attempt $_connectRetryCounter)',
+          );
+          // Use the existing _reconnectToSocket method for consistency
+          _reconnectToSocket();
+        } else if (_storedTokenConfig != null) {
+          GlobalLogger().i(
+            'Attempting reconnection with token config (attempt $_connectRetryCounter)',
+          );
+          // Use the existing _reconnectToSocket method for consistency
+          _reconnectToSocket();
+        } else {
+          GlobalLogger()
+              .e('No stored configuration available for reconnection');
+          final error = TelnyxSocketError(
+            errorCode: TelnyxErrorConstants.gatewayFailedErrorCode,
+            errorMessage: 'No stored configuration available for reconnection',
+          );
+          onSocketErrorReceived(error);
+        }
+      },
+      generation: connectionGeneration,
+    );
   }
 
   /// Gets the current socket connection metrics

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -418,6 +418,7 @@ class TelnyxClient {
   void _invalidateConnectionGeneration() {
     _connectionGeneration++;
     _cancelDelayedConnectionTimers();
+    _isAttaching = false;
   }
 
   Timer _scheduleConnectionTimer(

--- a/packages/telnyx_webrtc/lib/tx_socket.dart
+++ b/packages/telnyx_webrtc/lib/tx_socket.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:telnyx_webrtc/tx_socket_ping_metrics.dart';
@@ -19,55 +20,81 @@ class TxSocket with TxSocketPingMetricsMixin {
 
   String hostAddress;
 
-  late WebSocket _socket;
+  WebSocket? _socket;
   late OnOpenCallback onOpen;
   late OnMessageCallback onMessage;
   late OnCloseCallback onClose;
+  int _connectGeneration = 0;
 
   /// Connect to the WebSocket server
   void connect() async {
+    final generation = ++_connectGeneration;
+    final openCallback = onOpen;
+    final messageCallback = onMessage;
+    final closeCallback = onClose;
+
     try {
       GlobalLogger().i('TxSocket :: connect : $hostAddress');
 
-      _socket = await WebSocket.connect(hostAddress);
-      _socket
+      final socket = await WebSocket.connect(hostAddress);
+      if (!_isCurrentAttempt(generation)) {
+        unawaited(socket.close());
+        return;
+      }
+
+      _socket = socket;
+      socket
         ..pingInterval = const Duration(seconds: 10)
         ..timeout(const Duration(seconds: 30));
 
       // Initialize connection tracking
       initializePingTracking();
 
-      onOpen.call();
-
-      // Emit initial calculating state
-      emitInitialMetrics();
-
-      _socket.listen(
+      socket.listen(
         (dynamic data) {
+          if (!_isActiveSocket(generation, socket)) return;
+
           // Check if this is a ping/pong message
           if (isPingMessage(data)) {
             handlePingReceived();
           }
-          onMessage.call(data);
+          messageCallback.call(data);
         },
         onDone: () {
+          if (!_isActiveSocket(generation, socket)) return;
+
           cleanPingIntervals();
-          onClose.call(
-            _socket.closeCode ?? 0,
-            _socket.closeReason ?? 'Closed for unknown reason',
+          closeCallback.call(
+            socket.closeCode ?? 0,
+            socket.closeReason ?? 'Closed for unknown reason',
           );
+          if (identical(_socket, socket)) {
+            _socket = null;
+          }
         },
       );
+
+      openCallback.call();
+      if (!_isActiveSocket(generation, socket)) {
+        unawaited(socket.close());
+        return;
+      }
+
+      // Emit initial calculating state
+      emitInitialMetrics();
     } catch (e) {
+      if (!_isCurrentAttempt(generation)) return;
+
       cleanPingIntervals();
-      onClose.call(500, e.toString());
+      closeCallback.call(500, e.toString());
     }
   }
 
   /// Send data to the WebSocket server
   void send(dynamic data) {
-    if (_socket.readyState == WebSocket.open) {
-      _socket.add(data);
+    final socket = _socket;
+    if (socket != null && socket.readyState == WebSocket.open) {
+      socket.add(data);
       GlobalLogger().i('TxSocket :: Send : ${data?.toString().trim()}');
     } else {
       GlobalLogger().d('WebSocket not connected, message $data not sent');
@@ -76,7 +103,20 @@ class TxSocket with TxSocketPingMetricsMixin {
 
   /// Close the WebSocket connection
   void close() {
+    _connectGeneration++;
     cleanPingIntervals();
-    _socket.close();
+    final socket = _socket;
+    _socket = null;
+    if (socket != null) {
+      unawaited(socket.close());
+    }
+  }
+
+  bool _isCurrentAttempt(int generation) {
+    return generation == _connectGeneration;
+  }
+
+  bool _isActiveSocket(int generation, WebSocket socket) {
+    return _isCurrentAttempt(generation) && identical(_socket, socket);
   }
 }

--- a/packages/telnyx_webrtc/lib/tx_socket_web.dart
+++ b/packages/telnyx_webrtc/lib/tx_socket_web.dart
@@ -22,47 +22,77 @@ class TxSocket with TxSocketPingMetricsMixin {
 
   String hostAddress;
 
-  late WebSocket _socket;
+  WebSocket? _socket;
   late OnOpenCallback onOpen;
   late OnMessageCallback onMessage;
   late OnCloseCallback onClose;
+  int _connectGeneration = 0;
 
   /// Connect to the WebSocket server
-  void connect() async {
-    try {
-      _socket = WebSocket(hostAddress);
+  void connect() {
+    final generation = ++_connectGeneration;
+    final openCallback = onOpen;
+    final messageCallback = onMessage;
+    final closeCallback = onClose;
 
-      _socket.onOpen.listen((e) {
+    try {
+      final socket = WebSocket(hostAddress);
+
+      socket.onOpen.listen((e) {
+        if (!_isCurrentAttempt(generation)) {
+          socket.close();
+          return;
+        }
+
+        _socket = socket;
+
         // Initialize connection tracking
         initializePingTracking();
-        onOpen.call();
 
-        // Emit initial calculating state
-        emitInitialMetrics();
+        openCallback.call();
+        if (_isActiveSocket(generation, socket)) {
+          // Emit initial calculating state
+          emitInitialMetrics();
+        } else {
+          socket.close();
+        }
       });
 
-      _socket.onMessage.listen((e) {
+      socket.onMessage.listen((e) {
+        if (!_isActiveSocket(generation, socket)) return;
+
         // Check if this is a ping/pong message
         if (isPingMessage(e.data)) {
           handlePingReceived();
         }
-        onMessage.call(e.data);
+        messageCallback.call(e.data);
       });
 
-      _socket.onClose.listen((e) {
+      socket.onClose.listen((e) {
+        if (!_isActiveSocket(generation, socket)) return;
+
         cleanPingIntervals();
-        onClose.call(e.code ?? 0, e.reason ?? 'Closed for unknown reason');
+        closeCallback.call(
+          e.code ?? 0,
+          e.reason ?? 'Closed for unknown reason',
+        );
+        if (identical(_socket, socket)) {
+          _socket = null;
+        }
       });
     } catch (e) {
+      if (!_isCurrentAttempt(generation)) return;
+
       cleanPingIntervals();
-      onClose.call(500, e.toString());
+      closeCallback.call(500, e.toString());
     }
   }
 
   /// Send data to the WebSocket server
   void send(data) {
-    if (_socket.readyState == WebSocket.OPEN) {
-      _socket.send(data);
+    final socket = _socket;
+    if (socket != null && socket.readyState == WebSocket.OPEN) {
+      socket.send(data);
       GlobalLogger().i('TxSocket :: Send : ${data?.toString().trim()}');
     } else {
       GlobalLogger().d('WebSocket not connected, message $data not sent');
@@ -71,7 +101,18 @@ class TxSocket with TxSocketPingMetricsMixin {
 
   /// Close the WebSocket connection
   void close() {
+    _connectGeneration++;
     cleanPingIntervals();
-    _socket.close();
+    final socket = _socket;
+    _socket = null;
+    socket?.close();
+  }
+
+  bool _isCurrentAttempt(int generation) {
+    return generation == _connectGeneration;
+  }
+
+  bool _isActiveSocket(int generation, WebSocket socket) {
+    return _isCurrentAttempt(generation) && identical(_socket, socket);
   }
 }

--- a/packages/telnyx_webrtc/lib/utils/latency_tracker.dart
+++ b/packages/telnyx_webrtc/lib/utils/latency_tracker.dart
@@ -21,7 +21,8 @@ class LatencyTracker {
   static const String milestonePeerCreated = 'peer_connection_created';
   static const String milestonePeerSetupComplete = 'peer_setup_complete';
   static const String milestoneMediaDevicesAcquired = 'media_devices_acquired';
-  static const String milestoneSdpNegotiationStarted = 'sdp_negotiation_started';
+  static const String milestoneSdpNegotiationStarted =
+      'sdp_negotiation_started';
   static const String milestoneLocalSdpCreated = 'local_sdp_created';
   static const String milestoneLocalSdpSet = 'local_sdp_set';
   static const String milestoneInviteSent = 'invite_sent';
@@ -73,6 +74,7 @@ class LatencyTracker {
 
   // ===== Listeners =====
   LatencyMetricsCallback? _latencyMetricsListener;
+  bool _disposed = false;
 
   final StreamController<LatencyMetrics> _latencyMetricsController =
       StreamController<LatencyMetrics>.broadcast();
@@ -83,6 +85,8 @@ class LatencyTracker {
 
   /// Sets the callback for latency metrics updates.
   void setLatencyMetricsListener(LatencyMetricsCallback? listener) {
+    if (_disposed) return;
+
     _latencyMetricsListener = listener;
   }
 
@@ -149,8 +153,7 @@ class LatencyTracker {
   void markCallMilestone(String callId, String milestone) {
     final state = _callTrackers[callId];
     if (state == null) return;
-    final elapsed =
-        DateTime.now().millisecondsSinceEpoch - state.startTime;
+    final elapsed = DateTime.now().millisecondsSinceEpoch - state.startTime;
     state.milestones[milestone] = elapsed;
   }
 
@@ -223,15 +226,17 @@ class LatencyTracker {
     final timingsLogs = generateCallTimingsLogs(callId);
 
     final milestones = Map<String, int>.unmodifiable(state.milestones);
-    final totalTime =
-        DateTime.now().millisecondsSinceEpoch - state.startTime;
+    final totalTime = DateTime.now().millisecondsSinceEpoch - state.startTime;
 
     // Calculate derived metrics
     final iceGatheringLatency = _calculateIceGatheringLatency(milestones);
-    final signalingLatency =
-        _calculateSignalingLatency(milestones, state.isOutbound);
-    final mediaEstablishmentLatency =
-        _calculateMediaEstablishmentLatency(milestones);
+    final signalingLatency = _calculateSignalingLatency(
+      milestones,
+      state.isOutbound,
+    );
+    final mediaEstablishmentLatency = _calculateMediaEstablishmentLatency(
+      milestones,
+    );
     final timeToFirstRtp = _calculateTimeToFirstRtp(milestones);
 
     final metrics = LatencyMetrics(
@@ -264,8 +269,7 @@ class LatencyTracker {
     final state = _callTrackers[callId];
     if (state == null) return null;
     final milestones = Map<String, int>.unmodifiable(state.milestones);
-    final currentTime =
-        DateTime.now().millisecondsSinceEpoch - state.startTime;
+    final currentTime = DateTime.now().millisecondsSinceEpoch - state.startTime;
 
     return LatencyMetrics(
       callId: callId,
@@ -461,12 +465,19 @@ class LatencyTracker {
 
   /// Disposes resources.
   void dispose() {
+    if (_disposed) return;
+
+    _disposed = true;
+    _latencyMetricsListener = null;
+    reset();
     _latencyMetricsController.close();
   }
 
   // ===== Private Helpers =====
 
   void _emitMetrics(LatencyMetrics metrics) {
+    if (_disposed) return;
+
     _latencyMetricsListener?.call(metrics);
     if (!_latencyMetricsController.isClosed) {
       _latencyMetricsController.add(metrics);
@@ -483,7 +494,9 @@ class LatencyTracker {
   }
 
   int? _calculateSignalingLatency(
-      Map<String, int> milestones, bool isOutbound) {
+    Map<String, int> milestones,
+    bool isOutbound,
+  ) {
     if (isOutbound) {
       final start = milestones[milestoneInviteSent];
       final end = milestones[milestoneRemoteSdpReceived];
@@ -498,8 +511,8 @@ class LatencyTracker {
   }
 
   int? _calculateMediaEstablishmentLatency(Map<String, int> milestones) {
-    final start = milestones[milestoneIceConnected] ??
-        milestones[milestonePeerConnected];
+    final start =
+        milestones[milestoneIceConnected] ?? milestones[milestonePeerConnected];
     if (start == null) return null;
     final end = milestones[milestoneFirstRtpReceived] ??
         milestones[milestoneFirstRtpSent] ??

--- a/packages/telnyx_webrtc/test/telnyx_client_lifecycle_test.dart
+++ b/packages/telnyx_webrtc/test/telnyx_client_lifecycle_test.dart
@@ -125,6 +125,36 @@ void main() {
 
     expect(fakeSocket.connectCount, 2);
   });
+
+  test('disconnect during reconnect does not leave attaching state stuck',
+      () async {
+    final states = <ConnectionStatus>[];
+
+    client
+      ..onConnectionStateChanged = states.add
+      ..connectWithCredential(_credentialConfig());
+
+    await pumpEventQueue();
+    fakeConnectivityPlatform.emit([ConnectivityResult.wifi]);
+    await pumpEventQueue();
+    fakeConnectivityPlatform.emit([ConnectivityResult.mobile]);
+    await pumpEventQueue();
+
+    expect(states.where((state) => state == ConnectionStatus.reconnecting),
+        hasLength(1));
+
+    client.disconnect();
+    client.connectWithCredential(_credentialConfig(sipUser: 'second'));
+
+    await pumpEventQueue();
+    fakeConnectivityPlatform.emit([ConnectivityResult.wifi]);
+    await pumpEventQueue();
+    fakeConnectivityPlatform.emit([ConnectivityResult.mobile]);
+    await pumpEventQueue();
+
+    expect(states.where((state) => state == ConnectionStatus.reconnecting),
+        hasLength(2));
+  });
 }
 
 CredentialConfig _credentialConfig({

--- a/packages/telnyx_webrtc/test/telnyx_client_lifecycle_test.dart
+++ b/packages/telnyx_webrtc/test/telnyx_client_lifecycle_test.dart
@@ -1,0 +1,205 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart'
+    show ConnectivityResult;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_webrtc/model/connection_status.dart';
+import 'package:telnyx_webrtc/model/latency_metrics.dart';
+import 'package:telnyx_webrtc/model/region.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/tx_socket.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeConnectivityPlatform fakeConnectivityPlatform;
+  late TelnyxClient client;
+  late FakeTxSocket fakeSocket;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    fakeConnectivityPlatform = FakeConnectivityPlatform();
+
+    fakeSocket = FakeTxSocket();
+    client = TelnyxClient(
+      connectivityChanges: fakeConnectivityPlatform.connectivityChanges,
+    )..txSocket = fakeSocket;
+  });
+
+  tearDown(() async {
+    client.dispose();
+    await fakeConnectivityPlatform.dispose();
+  });
+
+  test(
+    'disconnect cancels connectivity updates and ignores socket callbacks',
+    () async {
+      final states = <ConnectionStatus>[];
+      var socketMessages = 0;
+
+      client
+        ..onConnectionStateChanged = states.add
+        ..onSocketMessageReceived = (_) {
+          socketMessages++;
+        }
+        ..connectWithCredential(_credentialConfig());
+
+      await pumpEventQueue();
+      fakeConnectivityPlatform.emit([ConnectivityResult.wifi]);
+      await pumpEventQueue();
+      fakeConnectivityPlatform.emit([ConnectivityResult.mobile]);
+      await pumpEventQueue();
+
+      expect(states, contains(ConnectionStatus.reconnecting));
+
+      client.disconnect();
+      await pumpEventQueue();
+
+      final stateCountAfterDisconnect = states.length;
+      expect(fakeConnectivityPlatform.cancelCount, 1);
+
+      fakeConnectivityPlatform.emit([ConnectivityResult.wifi]);
+      fakeSocket.emitMessage('{"method":"telnyx_rtc.clientReady"}');
+      await pumpEventQueue();
+
+      expect(states, hasLength(stateCountAfterDisconnect));
+      expect(socketMessages, 0);
+    },
+  );
+
+  test('dispose is idempotent and disposes latency tracking', () async {
+    final emittedMetrics = <LatencyMetrics>[];
+
+    client
+      ..latencyTracker.setLatencyMetricsListener(emittedMetrics.add)
+      ..connectWithCredential(_credentialConfig());
+
+    await pumpEventQueue();
+
+    client
+      ..dispose()
+      ..dispose();
+    await pumpEventQueue();
+
+    expect(fakeSocket.closeCount, 1);
+    expect(fakeConnectivityPlatform.cancelCount, 1);
+
+    client.latencyTracker
+      ..startRegistrationTracking()
+      ..completeRegistrationTracking();
+
+    expect(emittedMetrics, isEmpty);
+  });
+
+  test('TxSocket.close is safe before the underlying socket opens', () {
+    final socket = TxSocket('wss://example.test');
+
+    expect(socket.close, returnsNormally);
+  });
+
+  test('stale region fallback timers do not reconnect newer sessions',
+      () async {
+    client.connectWithCredential(
+      _credentialConfig(
+        sipUser: 'first',
+        region: Region.eu,
+        fallbackOnRegionFailure: true,
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(fakeSocket.connectCount, 1);
+
+    fakeSocket.emitClose(500, 'region failure');
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    client.connectWithCredential(_credentialConfig(sipUser: 'second'));
+    await pumpEventQueue();
+
+    expect(fakeSocket.connectCount, 2);
+
+    await Future<void>.delayed(const Duration(milliseconds: 1100));
+
+    expect(fakeSocket.connectCount, 2);
+  });
+}
+
+CredentialConfig _credentialConfig({
+  String sipUser = 'test',
+  Region region = Region.auto,
+  bool fallbackOnRegionFailure = false,
+}) {
+  return CredentialConfig(
+    sipUser: sipUser,
+    sipPassword: 'test',
+    sipCallerIDName: 'test',
+    sipCallerIDNumber: 'test',
+    notificationToken: 'test',
+    region: region,
+    fallbackOnRegionFailure: fallbackOnRegionFailure,
+    autoReconnect: true,
+    logLevel: LogLevel.info,
+    debug: false,
+  );
+}
+
+class FakeConnectivityPlatform {
+  int listenCount = 0;
+  int cancelCount = 0;
+
+  late final StreamController<List<ConnectivityResult>> _controller =
+      StreamController<List<ConnectivityResult>>.broadcast(
+    onListen: () {
+      listenCount++;
+    },
+    onCancel: () {
+      cancelCount++;
+    },
+  );
+
+  Stream<List<ConnectivityResult>> connectivityChanges() {
+    return _controller.stream;
+  }
+
+  void emit(List<ConnectivityResult> results) {
+    _controller.add(results);
+  }
+
+  Future<void> dispose() {
+    return _controller.close();
+  }
+}
+
+class FakeTxSocket extends TxSocket {
+  FakeTxSocket() : super('wss://example.test');
+
+  int connectCount = 0;
+  int closeCount = 0;
+  final sentMessages = <dynamic>[];
+
+  @override
+  void connect() {
+    connectCount++;
+  }
+
+  @override
+  void close() {
+    closeCount++;
+  }
+
+  @override
+  void send(dynamic data) {
+    sentMessages.add(data);
+  }
+
+  void emitMessage(dynamic data) {
+    onMessage(data);
+  }
+
+  void emitClose(int code, String reason) {
+    onClose(code, reason);
+  }
+}


### PR DESCRIPTION
Ticket: VSDK-328 / FLT-020

## Summary
- Adds explicit `TelnyxClient` teardown for connectivity monitoring, reconnect timers, pending answer timers, socket callbacks, and latency tracking.
- Adds idempotent `dispose()` handling and guards stale callbacks by connection generation so old timers cannot act on newer sessions.
- Updates demo-owned clients and temporary decline clients to dispose their resources.

## Behaviors

### Before changes
`TelnyxClient` subscribed to connectivity changes without retaining/cancelling the subscription, stale reconnect/socket callbacks could run after disconnect, and `LatencyTracker.dispose()` was not called by the client.

### After changes
Connectivity subscriptions are retained and cancelled, delayed reconnect/fallback work is cancelled or ignored after teardown, stale socket opens close their captured sockets, and `latencyTracker` is disposed idempotently.

## Manual testing
1. `fvm dart format packages/telnyx_webrtc/lib/telnyx_client.dart packages/telnyx_webrtc/lib/utils/latency_tracker.dart packages/telnyx_webrtc/test/telnyx_client_lifecycle_test.dart`
2. `cd packages/telnyx_webrtc && fvm flutter test test/telnyx_client_lifecycle_test.dart test/utils/latency_tracker_test.dart`
3. `cd packages/telnyx_webrtc && fvm dart analyze lib/telnyx_client.dart lib/utils/latency_tracker.dart test/telnyx_client_lifecycle_test.dart`
4. `fvm dart format packages/telnyx_webrtc/lib/tx_socket.dart packages/telnyx_webrtc/lib/tx_socket_web.dart packages/telnyx_webrtc/lib/telnyx_client.dart lib/service/android_push_notification_handler.dart lib/service/ios_push_notification_handler.dart`
5. `fvm flutter test packages/telnyx_webrtc/test/telnyx_client_lifecycle_test.dart`
6. `git diff --check`

## Notes
- Targeted package analyzer exited 0 with existing info-level lint output in touched library files.
