### PR TITLE
VSDK-329: FLT-021 Flutter audio player reuse-after-dispose

### DIFF
--- a/packages/telnyx_webrtc/lib/call.dart
+++ b/packages/telnyx_webrtc/lib/call.dart
@@ -82,11 +82,12 @@ class CallHandler {
   void changeState(CallState state) {
     call?.callState = state;
     onCallStateChanged(state);
-    
+
     // Post call report when call ends (regardless of who initiated the BYE)
     // Also post on dropped state (network loss) — matches iOS behaviour
     // Use unawaited - don't block state change on stats/network operations
     if (state == CallState.done || state == CallState.dropped) {
+      call?._disposeAudio();
       unawaited(call?._stopStatsAndPostReport());
     }
   }
@@ -95,6 +96,7 @@ class CallHandler {
 /// The Call class which is used for call related methods such as hold/mute or
 /// creating invitations, declining calls, etc.
 class Call {
+  /// Creates a call instance.
   Call(
     this.txSocket,
     this._txClient,
@@ -103,8 +105,9 @@ class Call {
     this.ringBackFile,
     this.callHandler,
     this.callEnded,
-    this.debug,
-  );
+    this.debug, {
+    AudioService? audioService,
+  }) : _audioService = audioService;
 
   /// **CallHandler Instance - Single Source of Truth for State Management**
   ///
@@ -136,6 +139,10 @@ class Call {
   /// AudioService instance to handle audio playback (lazy initialized)
   AudioService get audioService => _audioService ??= AudioService();
   AudioService? _audioService;
+
+  /// Whether this call has allocated audio playback resources.
+  @visibleForTesting
+  bool get hasAudioService => _audioService != null;
 
   /// Debug mode flag to enable call quality metrics
   final bool debug;
@@ -394,7 +401,7 @@ class Call {
     );
     _txClient.onSocketMessageReceived.call(message);
   }
-  
+
   /// Stops stats collection and posts the call report to voice-sdk-proxy.
   /// Called automatically when call state transitions to DONE (via CallHandler).
   /// This handles both local hangup (endCall) and remote hangup (BYE received).
@@ -402,25 +409,33 @@ class Call {
     if (peerConnection == null || callId == null) {
       return;
     }
-    
+
     // Stop stats collection - await to ensure final stats are captured
     await peerConnection!.stopStats(callId!);
-    
+
     // Determine direction based on whether we have a destination number
     // If sessionDestinationNumber is set, it's an outbound call
     // If sessionCallerNumber is set but not destination, it's likely inbound
-    final direction = sessionDestinationNumber.isNotEmpty ? 'outbound' : 'inbound';
-    
+    final direction =
+        sessionDestinationNumber.isNotEmpty ? 'outbound' : 'inbound';
+
     // Post call report (don't block call cleanup on network issues)
-    peerConnection!.postCallReport(
-      callId: callId!,
-      direction: direction,
-      destinationNumber: sessionDestinationNumber.isNotEmpty ? sessionDestinationNumber : null,
-      callerNumber: sessionCallerNumber.isNotEmpty ? sessionCallerNumber : null,
-      state: callState.toString().split('.').last,
-    ).catchError((error) {
-      GlobalLogger().e('Failed to post call report: $error');
-    });
+    unawaited(
+      peerConnection!
+          .postCallReport(
+        callId: callId!,
+        direction: direction,
+        destinationNumber: sessionDestinationNumber.isNotEmpty
+            ? sessionDestinationNumber
+            : null,
+        callerNumber:
+            sessionCallerNumber.isNotEmpty ? sessionCallerNumber : null,
+        state: callState.toString().split('.').last,
+      )
+          .catchError((error) {
+        GlobalLogger().e('Failed to post call report: $error');
+      }),
+    );
   }
 
   /// Sends a DTMF message with the chosen [tone] to the call
@@ -576,7 +591,8 @@ class Call {
     String message, {
     List<String>? base64Images,
     @Deprecated(
-        'Use base64Images parameter instead for better support of multiple images')
+      'Use base64Images parameter instead for better support of multiple images',
+    )
     String? base64Image,
   }) {
     final uuid = const Uuid().v4();
@@ -608,10 +624,12 @@ class Call {
             imageDataUrl = 'data:image/jpeg;base64,$imageData';
           }
 
-          content.add(ConversationContentData(
-            type: 'image_url',
-            imageUrl: ConversationImageUrl(url: imageDataUrl),
-          ));
+          content.add(
+            ConversationContentData(
+              type: 'image_url',
+              imageUrl: ConversationImageUrl(url: imageDataUrl),
+            ),
+          );
         }
       }
     }
@@ -658,26 +676,124 @@ class Call {
 
   /// Stops the currently playing audio.
   void stopAudio() {
-    audioService.stopAudio();
+    unawaited(_audioService?.stopAudio());
   }
+
+  void _disposeAudio() {
+    final audioService = _audioService;
+    if (audioService == null) {
+      return;
+    }
+
+    unawaited(audioService.dispose());
+    _audioService = null;
+  }
+}
+
+/// Factory for creating audio playback adapters.
+typedef AudioPlaybackFactory = AudioPlayback Function();
+
+/// Minimal playback surface used by [AudioService].
+abstract class AudioPlayback {
+  /// Loads an asset for playback.
+  Future<void> setAsset(String filePath);
+
+  /// Sets the looping behavior.
+  Future<void> setLoopMode(LoopMode loopMode);
+
+  /// Starts playback.
+  Future<void> play();
+
+  /// Stops playback.
+  Future<void> stop();
+
+  /// Releases playback resources.
+  Future<void> dispose();
+}
+
+/// just_audio-backed playback adapter.
+class JustAudioPlayback implements AudioPlayback {
+  /// Creates a playback adapter.
+  JustAudioPlayback({AudioPlayer? audioPlayer})
+      : _audioPlayer = audioPlayer ?? AudioPlayer();
+
+  final AudioPlayer _audioPlayer;
+
+  @override
+  Future<void> setAsset(String filePath) => _audioPlayer.setAsset(filePath);
+
+  @override
+  Future<void> setLoopMode(LoopMode loopMode) =>
+      _audioPlayer.setLoopMode(loopMode);
+
+  @override
+  Future<void> play() => _audioPlayer.play();
+
+  @override
+  Future<void> stop() => _audioPlayer.stop();
+
+  @override
+  Future<void> dispose() => _audioPlayer.dispose();
 }
 
 /// AudioService class to handle audio playback
 class AudioService {
-  final AudioPlayer _audioPlayer = AudioPlayer();
+  /// Creates an audio service.
+  AudioService({AudioPlaybackFactory? playbackFactory})
+      : _playbackFactory = playbackFactory ?? (() => JustAudioPlayback()) {
+    _playback = _playbackFactory();
+  }
+
+  final AudioPlaybackFactory _playbackFactory;
+  late AudioPlayback _playback;
+  bool _isDisposed = false;
+  int _playGeneration = 0;
 
   /// Plays a local audio file from the assets directory.
   Future<void> playLocalFile(String filePath) async {
+    if (_isDisposed) {
+      _playback = _playbackFactory();
+      _isDisposed = false;
+    }
+
+    final playGeneration = ++_playGeneration;
+    final playback = _playback;
+
     // Ensure the file path is correct and accessible from the web directory
-    await _audioPlayer.setAsset(filePath);
-    await _audioPlayer.setLoopMode(LoopMode.all);
-    await _audioPlayer.play();
+    await playback.setAsset(filePath);
+    if (!_isCurrentPlay(playGeneration, playback)) return;
+
+    await playback.setLoopMode(LoopMode.all);
+    if (!_isCurrentPlay(playGeneration, playback)) return;
+
+    await playback.play();
   }
 
   /// Stops the currently playing audio.
   Future<void> stopAudio() async {
+    _playGeneration++;
+    if (_isDisposed) {
+      return;
+    }
+
     // Ensure the file path is correct and accessible from the web directory
-    await _audioPlayer.stop();
-    await _audioPlayer.dispose();
+    await _playback.stop();
+  }
+
+  /// Releases audio playback resources.
+  Future<void> dispose() async {
+    _playGeneration++;
+    if (_isDisposed) {
+      return;
+    }
+
+    await _playback.dispose();
+    _isDisposed = true;
+  }
+
+  bool _isCurrentPlay(int generation, AudioPlayback playback) {
+    return !_isDisposed &&
+        generation == _playGeneration &&
+        identical(_playback, playback);
   }
 }

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -170,7 +170,7 @@ class TelnyxClient {
 
   /// The WebSocket host URL for deriving the call report endpoint.
   String? _socketHost;
-  
+
   /// Gets the WebSocket host URL (used for call report endpoint derivation).
   String? get socketHost => _socketHost;
 
@@ -550,7 +550,7 @@ class TelnyxClient {
   void _handleNetworkLost() {
     _updateConnectionState(false);
     for (var call in activeCalls().values) {
-      call.callHandler.onCallStateChanged.call(
+      call.callHandler.changeState(
         CallState.dropped.withNetworkReason(NetworkReason.networkLost),
       );
       // Start a reconnection timeout timer for this call
@@ -564,7 +564,7 @@ class TelnyxClient {
       GlobalLogger()
           .i('AutoReconnect is disabled, not attempting network reconnection');
       for (var call in activeCalls().values) {
-        call.callHandler.onCallStateChanged.call(
+        call.callHandler.changeState(
           CallState.dropped.withNetworkReason(NetworkReason.networkLost),
         );
         call.endCall();
@@ -579,7 +579,7 @@ class TelnyxClient {
 
     for (var call in activeCalls().values) {
       if (call.callState.isDropped) {
-        call.callHandler.onCallStateChanged.call(
+        call.callHandler.changeState(
           CallState.reconnecting.withNetworkReason(reason),
         );
 
@@ -611,7 +611,7 @@ class TelnyxClient {
           GlobalLogger().i('Reconnection timeout for call ${call.callId}');
 
           // Change the call state to dropped
-          call.callHandler.onCallStateChanged.call(
+          call.callHandler.changeState(
             CallState.dropped.withNetworkReason(NetworkReason.networkLost),
           );
 
@@ -1076,7 +1076,8 @@ class TelnyxClient {
           GlobalLogger().i(
             'TelnyxClient.connectWithToken (via _onOpen): Web Socket is now connected',
           );
-          latencyTracker.markRegistrationMilestone(LatencyTracker.milestoneSocketConnected);
+          latencyTracker.markRegistrationMilestone(
+              LatencyTracker.milestoneSocketConnected);
           _onOpen();
           tokenLogin(tokenConfig);
         }
@@ -1139,7 +1140,8 @@ class TelnyxClient {
           GlobalLogger().i(
             'TelnyxClient.connectWithCredential (via _onOpen): Web Socket is now connected',
           );
-          latencyTracker.markRegistrationMilestone(LatencyTracker.milestoneSocketConnected);
+          latencyTracker.markRegistrationMilestone(
+              LatencyTracker.milestoneSocketConnected);
           _onOpen();
           credentialLogin(credentialConfig);
         }
@@ -1613,7 +1615,8 @@ class TelnyxClient {
     inviteCall.peerConnection?.setCallReportConfig(
       callReportInterval: callReportConfig?.callReportInterval ?? 5000,
       callReportLogLevel: callReportConfig?.callReportLogLevel ?? 'debug',
-      callReportMaxLogEntries: callReportConfig?.callReportMaxLogEntries ?? 1000,
+      callReportMaxLogEntries:
+          callReportConfig?.callReportMaxLogEntries ?? 1000,
     );
     // Convert AudioCodec objects to Map format for the peer connection
     List<Map<String, dynamic>>? codecMaps;
@@ -1707,11 +1710,13 @@ class TelnyxClient {
       _getEffectiveIceServers(),
     );
     // Apply call report config from stored config
-    final answerCallReportConfig = _storedCredentialConfig ?? _storedTokenConfig;
+    final answerCallReportConfig =
+        _storedCredentialConfig ?? _storedTokenConfig;
     answerCall.peerConnection?.setCallReportConfig(
       callReportInterval: answerCallReportConfig?.callReportInterval ?? 5000,
       callReportLogLevel: answerCallReportConfig?.callReportLogLevel ?? 'debug',
-      callReportMaxLogEntries: answerCallReportConfig?.callReportMaxLogEntries ?? 1000,
+      callReportMaxLogEntries:
+          answerCallReportConfig?.callReportMaxLogEntries ?? 1000,
     );
 
     // Set up the session with the callback if debug is enabled
@@ -1933,14 +1938,16 @@ class TelnyxClient {
                       _invalidateGatewayResponseTimer();
                       _resetGatewayCounters();
                       gatewayState = GatewayState.reged;
-                      
+
                       // Complete registration latency tracking
                       latencyTracker.completeRegistrationTracking();
-                      
+
                       // Store call_report_id for call report authentication
-                      callReportId = stateMessage.resultParams?.stateParams?.callReportId;
+                      callReportId =
+                          stateMessage.resultParams?.stateParams?.callReportId;
                       if (callReportId != null) {
-                        GlobalLogger().d('CallReportId received: $callReportId');
+                        GlobalLogger()
+                            .d('CallReportId received: $callReportId');
                       }
                       _waitingForReg = false;
                       final message = TelnyxMessage(
@@ -2304,7 +2311,8 @@ class TelnyxClient {
 
                   // Mark latency milestones for answer received
                   if (answerCall.callId != null) {
-                    latencyTracker.markCallMilestone(answerCall.callId!, LatencyTracker.milestoneRemoteSdpReceived);
+                    latencyTracker.markCallMilestone(answerCall.callId!,
+                        LatencyTracker.milestoneRemoteSdpReceived);
                     latencyTracker.markCallAnsweredByRemote(answerCall.callId!);
                   }
 

--- a/packages/telnyx_webrtc/test/audio_service_test.dart
+++ b/packages/telnyx_webrtc/test/audio_service_test.dart
@@ -1,0 +1,200 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:telnyx_webrtc/call.dart';
+import 'package:telnyx_webrtc/model/call_state.dart';
+import 'package:telnyx_webrtc/model/network_reason.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/tx_socket.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('stopAudio stops without disposing the reusable player', () async {
+    final playback = FakeAudioPlayback();
+    final service = AudioService(playbackFactory: () => playback);
+
+    await service.playLocalFile('assets/audio/ringtone.wav');
+    await service.stopAudio();
+    await service.playLocalFile('assets/audio/ringback.wav');
+
+    expect(playback.assets, [
+      'assets/audio/ringtone.wav',
+      'assets/audio/ringback.wav',
+    ]);
+    expect(playback.stopCalls, 1);
+    expect(playback.disposeCalls, 0);
+    expect(playback.playCalls, 2);
+  });
+
+  test('stopAudio cancels an in-flight playLocalFile', () async {
+    final setAssetCompleter = Completer<void>();
+    final playback = FakeAudioPlayback(
+      setAssetCompleter: setAssetCompleter,
+    );
+    final service = AudioService(playbackFactory: () => playback);
+
+    final playFuture = service.playLocalFile('assets/audio/ringtone.wav');
+    await pumpEventQueue();
+
+    await service.stopAudio();
+    setAssetCompleter.complete();
+    await playFuture;
+
+    expect(playback.assets, ['assets/audio/ringtone.wav']);
+    expect(playback.stopCalls, 1);
+    expect(playback.setLoopModeCalls, 0);
+    expect(playback.playCalls, 0);
+  });
+
+  test('playLocalFile recreates playback after explicit dispose', () async {
+    final playbacks = <FakeAudioPlayback>[];
+    final service = AudioService(
+      playbackFactory: () {
+        final playback = FakeAudioPlayback();
+        playbacks.add(playback);
+        return playback;
+      },
+    );
+
+    await service.playLocalFile('assets/audio/ringtone.wav');
+    await service.dispose();
+    await service.playLocalFile('assets/audio/ringback.wav');
+
+    expect(playbacks, hasLength(2));
+    expect(playbacks.first.disposeCalls, 1);
+    expect(playbacks.last.assets, ['assets/audio/ringback.wav']);
+  });
+
+  test('Call.stopAudio does not allocate audio service', () {
+    final call = _createCall()..stopAudio();
+
+    expect(call.hasAudioService, isFalse);
+  });
+
+  test('terminal dropped call state disposes audio service once', () async {
+    final playback = FakeAudioPlayback();
+    final service = AudioService(playbackFactory: () => playback);
+    final call = _createCall(audioService: service)
+      ..playAudio('assets/audio/ringback.wav');
+    await pumpEventQueue();
+
+    call.callHandler
+      ..changeState(
+        CallState.dropped.withNetworkReason(NetworkReason.networkLost),
+      )
+      ..changeState(
+        CallState.dropped.withNetworkReason(NetworkReason.networkLost),
+      );
+    await pumpEventQueue();
+
+    expect(playback.disposeCalls, 1);
+    expect(call.hasAudioService, isFalse);
+  });
+
+  test('terminal call state disposes audio service once', () async {
+    final playback = FakeAudioPlayback();
+    final service = AudioService(playbackFactory: () => playback);
+    final call = _createCall(audioService: service)
+      ..playAudio('assets/audio/ringback.wav');
+    await pumpEventQueue();
+
+    call.callHandler
+      ..changeState(CallState.done)
+      ..changeState(CallState.done);
+    await pumpEventQueue();
+
+    expect(playback.disposeCalls, 1);
+    expect(call.hasAudioService, isFalse);
+  });
+}
+
+Call _createCall({AudioService? audioService}) {
+  final handler = CallHandler((_) {}, null);
+  final call = Call(
+    FakeTxSocket(),
+    TelnyxClient(),
+    'session-id',
+    'assets/audio/ringtone.wav',
+    'assets/audio/ringback.wav',
+    handler,
+    () {},
+    false,
+    audioService: audioService,
+  )..callState = CallState.active;
+  handler.call = call;
+  return call;
+}
+
+class FakeAudioPlayback implements AudioPlayback {
+  FakeAudioPlayback({this.setAssetCompleter});
+
+  final Completer<void>? setAssetCompleter;
+  final List<String> assets = <String>[];
+  int playCalls = 0;
+  int stopCalls = 0;
+  int disposeCalls = 0;
+  int setLoopModeCalls = 0;
+  bool disposed = false;
+
+  @override
+  Future<void> setAsset(String filePath) async {
+    if (disposed) {
+      throw StateError('playback is disposed');
+    }
+
+    assets.add(filePath);
+    await setAssetCompleter?.future;
+  }
+
+  @override
+  Future<void> setLoopMode(LoopMode loopMode) async {
+    if (disposed) {
+      throw StateError('playback is disposed');
+    }
+
+    setLoopModeCalls += 1;
+  }
+
+  @override
+  Future<void> play() async {
+    if (disposed) {
+      throw StateError('playback is disposed');
+    }
+
+    playCalls += 1;
+  }
+
+  @override
+  Future<void> stop() async {
+    if (disposed) {
+      throw StateError('playback is disposed');
+    }
+
+    stopCalls += 1;
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposeCalls += 1;
+    disposed = true;
+  }
+}
+
+class FakeTxSocket extends TxSocket {
+  FakeTxSocket() : super('wss://example.test');
+
+  final sentMessages = <dynamic>[];
+
+  @override
+  void connect() {}
+
+  @override
+  void close() {}
+
+  @override
+  void send(dynamic data) {
+    sentMessages.add(data);
+  }
+}


### PR DESCRIPTION
Ticket: VSDK-329 / FLT-021

## Summary
- Changes `AudioService.stopAudio()` so it stops playback without disposing the reusable player.
- Avoids allocating playback resources just to stop audio and disposes existing playback resources once on terminal call teardown.
- Adds explicit `AudioService.dispose()` behavior and focused regression coverage for replay after stop and recreation after explicit dispose.
- Routes network-drop/reconnect timeout transitions through `CallHandler.changeState` so dropped cleanup runs.
- Cancels in-flight `playLocalFile()` attempts when `stopAudio()` or `dispose()` runs.

## Behaviors

### Before changes
Stopping local audio could dispose the reusable playback resource, making later ringtone/ringback playback unstable or requiring accidental reallocation.

### After changes
Stop and dispose are separate lifecycle operations: stopping leaves playback reusable, explicit dispose releases resources, and terminal call teardown disposes once.

## Manual testing
1. `fvm dart format packages/telnyx_webrtc/lib/call.dart packages/telnyx_webrtc/test/audio_service_test.dart`
2. `fvm dart analyze packages/telnyx_webrtc/lib/call.dart packages/telnyx_webrtc/test/audio_service_test.dart`
3. `fvm flutter test packages/telnyx_webrtc/test/audio_service_test.dart`
4. `cd packages/telnyx_webrtc && fvm dart analyze lib/telnyx_client.dart lib/call.dart test/audio_service_test.dart`
5. `git diff --check`

## Notes
- No manual-device gate is recorded for this ticket beyond normal CI and review.
