### PR TITLE
test(demo): add Semantics/ValueKey identifiers for on-device E2E drivers

### DIFF
--- a/lib/view/screen/home_screen.dart
+++ b/lib/view/screen/home_screen.dart
@@ -367,27 +367,32 @@ class _HomeScreenState extends State<HomeScreen> {
                     final selectedProfile = profileProvider.selectedProfile;
                     return Padding(
                       padding: const EdgeInsets.all(spacingXXL),
-                      child: BottomConnectionActionWidget(
-                        buttonTitle: 'Connect',
-                        isLoading: viewModel.loggingIn,
-                        onPressed: selectedProfile != null
-                            ? () async {
-                                // Apply environment setting before connecting
-                                final profileProvider =
-                                    context.read<ProfileProvider>();
-                                viewModel.setDevEnvironment(
-                                  profileProvider.isDevEnvironment,
-                                );
+                      child: Semantics(
+                        identifier: 'connect_button',
+                        container: true,
+                        child: BottomConnectionActionWidget(
+                          key: const ValueKey('connect_button'),
+                          buttonTitle: 'Connect',
+                          isLoading: viewModel.loggingIn,
+                          onPressed: selectedProfile != null
+                              ? () async {
+                                  // Apply environment setting before connecting
+                                  final profileProvider =
+                                      context.read<ProfileProvider>();
+                                  viewModel.setDevEnvironment(
+                                    profileProvider.isDevEnvironment,
+                                  );
 
-                                final config =
-                                    await selectedProfile.toTelnyxConfig();
-                                if (config is TokenConfig) {
-                                  viewModel.loginWithToken(config);
-                                } else if (config is CredentialConfig) {
-                                  viewModel.login(config);
+                                  final config =
+                                      await selectedProfile.toTelnyxConfig();
+                                  if (config is TokenConfig) {
+                                    viewModel.loginWithToken(config);
+                                  } else if (config is CredentialConfig) {
+                                    viewModel.login(config);
+                                  }
                                 }
-                              }
-                            : null,
+                              : null,
+                        ),
                       ),
                     );
                   },

--- a/lib/view/widgets/call_controls/call_controls.dart
+++ b/lib/view/widgets/call_controls/call_controls.dart
@@ -136,32 +136,37 @@ class _CallControlsState extends State<CallControls> {
         if (!isAssistantMode) ...[
           Padding(
             padding: const EdgeInsets.all(spacingXS),
-            child: TextFormField(
-              key: const Key('destination_field'),
-              readOnly: clientState != CallStateStatus.idle,
-              enabled: clientState == CallStateStatus.idle,
-              controller: _destinationController,
-              keyboardType:
-                  _isPhoneNumber ? TextInputType.phone : TextInputType.text,
-              inputFormatters: _isPhoneNumber
-                  ? [
-                      FilteringTextInputFormatter.allow(
-                          RegExp(r'[0-9+\-\s\(\)]'))
-                    ]
-                  : [
-                      FilteringTextInputFormatter.allow(
-                        RegExp(r'[a-zA-Z0-9@\.\-_]'),
-                      ),
-                    ],
-              decoration: InputDecoration(
-                hintStyle: Theme.of(context).textTheme.labelSmall,
-                hintText: _isPhoneNumber ? '+E164 phone number' : 'SIP address',
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(spacingS),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderSide: const BorderSide(color: active_text_field_color),
-                  borderRadius: BorderRadius.circular(spacingS),
+            child: Semantics(
+              identifier: 'destination_field',
+              container: true,
+              child: TextFormField(
+                key: const Key('destination_field'),
+                readOnly: clientState != CallStateStatus.idle,
+                enabled: clientState == CallStateStatus.idle,
+                controller: _destinationController,
+                keyboardType:
+                    _isPhoneNumber ? TextInputType.phone : TextInputType.text,
+                inputFormatters: _isPhoneNumber
+                    ? [
+                        FilteringTextInputFormatter.allow(
+                            RegExp(r'[0-9+\-\s\(\)]'))
+                      ]
+                    : [
+                        FilteringTextInputFormatter.allow(
+                          RegExp(r'[a-zA-Z0-9@\.\-_]'),
+                        ),
+                      ],
+                decoration: InputDecoration(
+                  hintStyle: Theme.of(context).textTheme.labelSmall,
+                  hintText:
+                      _isPhoneNumber ? '+E164 phone number' : 'SIP address',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(spacingS),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderSide: const BorderSide(color: active_text_field_color),
+                    borderRadius: BorderRadius.circular(spacingS),
+                  ),
                 ),
               ),
             ),
@@ -191,23 +196,34 @@ class _CallControlsState extends State<CallControls> {
                       ),
                     ),
                   )
-                : CallButton(
-                    onPressed: () {
-                      final destination = _destinationController.text;
-                      if (destination.isNotEmpty) {
-                        context.read<TelnyxClientViewModel>().call(destination);
-                      }
-                    },
+                : Semantics(
+                    identifier: 'call_button',
+                    container: true,
+                    child: CallButton(
+                      key: const ValueKey('call_button'),
+                      onPressed: () {
+                        final destination = _destinationController.text;
+                        if (destination.isNotEmpty) {
+                          context.read<TelnyxClientViewModel>().call(
+                            destination,
+                          );
+                        }
+                      },
+                    ),
                   ),
           ),
           const SizedBox(height: spacingL),
           const Center(child: CallHistoryButton()),
         ] else if (clientState == CallStateStatus.ringing)
           Center(
-            child: DeclineButton(
-              onPressed: () {
-                context.read<TelnyxClientViewModel>().endCall();
-              },
+            child: Semantics(
+              identifier: 'cancel_call_button',
+              container: true,
+              child: DeclineButton(
+                onPressed: () {
+                  context.read<TelnyxClientViewModel>().endCall();
+                },
+              ),
             ),
           )
         else if (clientState == CallStateStatus.ongoingInvitation)

--- a/lib/view/widgets/call_controls/call_invitation.dart
+++ b/lib/view/widgets/call_controls/call_invitation.dart
@@ -37,9 +37,23 @@ class CallInvitation extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
-        CallButton(onPressed: onAccept),
+        Semantics(
+          identifier: 'accept_call_button',
+          container: true,
+          child: CallButton(
+            key: const ValueKey('accept_call_button'),
+            onPressed: onAccept,
+          ),
+        ),
         SizedBox(width: spacingM),
-        DeclineButton(onPressed: onDecline),
+        Semantics(
+          identifier: 'decline_call_button',
+          container: true,
+          child: DeclineButton(
+            key: const ValueKey('decline_call_button'),
+            onPressed: onDecline,
+          ),
+        ),
       ],
     );
   }

--- a/lib/view/widgets/call_controls/ongoing_call_controls.dart
+++ b/lib/view/widgets/call_controls/ongoing_call_controls.dart
@@ -111,10 +111,15 @@ class OnGoingCallControls extends StatelessWidget {
         ),
         SizedBox(height: spacingM),
         // Decline/End call button underneath
-        DeclineButton(
-          onPressed: () {
-            context.read<TelnyxClientViewModel>().endCall();
-          },
+        Semantics(
+          identifier: 'end_call_button',
+          container: true,
+          child: DeclineButton(
+            key: const ValueKey('end_call_button'),
+            onPressed: () {
+              context.read<TelnyxClientViewModel>().endCall();
+            },
+          ),
         ),
       ],
     );

--- a/lib/view/widgets/login/bottom_sheet/add_profile_form.dart
+++ b/lib/view/widgets/login/bottom_sheet/add_profile_form.dart
@@ -273,55 +273,75 @@ class _AddProfileFormState extends State<AddProfileForm> {
                 },
               ),
             ] else ...[
-              CustomFormField(
-                title: 'SIP Username',
-                controller: _sipUserController,
-                hintText: 'Enter your SIP username',
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Please enter a SIP username';
-                  }
-                  return null;
-                },
+              Semantics(
+                identifier: 'sip_username_field',
+                container: true,
+                child: CustomFormField(
+                  key: const ValueKey('sip_username_field'),
+                  title: 'SIP Username',
+                  controller: _sipUserController,
+                  hintText: 'Enter your SIP username',
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter a SIP username';
+                    }
+                    return null;
+                  },
+                ),
               ),
               const SizedBox(height: spacingS),
-              CustomFormField(
-                title: 'SIP Password',
-                controller: _sipPasswordController,
-                hintText: 'Enter your SIP password',
-                isPassword: true,
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Please enter a SIP password';
-                  }
-                  return null;
-                },
+              Semantics(
+                identifier: 'sip_password_field',
+                container: true,
+                child: CustomFormField(
+                  key: const ValueKey('sip_password_field'),
+                  title: 'SIP Password',
+                  controller: _sipPasswordController,
+                  hintText: 'Enter your SIP password',
+                  isPassword: true,
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter a SIP password';
+                    }
+                    return null;
+                  },
+                ),
               ),
             ],
             const SizedBox(height: spacingS),
-            CustomFormField(
-              title: 'Caller ID Name',
-              controller: _sipCallerIDNameController,
-              hintText: 'Enter your caller ID name',
-              validator: (value) {
-                if (value == null || value.isEmpty) {
-                  return 'Please enter a caller ID name';
-                }
-                return null;
-              },
+            Semantics(
+              identifier: 'caller_name_field',
+              container: true,
+              child: CustomFormField(
+                key: const ValueKey('caller_name_field'),
+                title: 'Caller ID Name',
+                controller: _sipCallerIDNameController,
+                hintText: 'Enter your caller ID name',
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter a caller ID name';
+                  }
+                  return null;
+                },
+              ),
             ),
             const SizedBox(height: spacingS),
-            CustomFormField(
-              title: 'Caller ID Number',
-              controller: _sipCallerIDNumberController,
-              hintText: 'Enter your caller ID number',
-              keyboardType: TextInputType.phone,
-              validator: (value) {
-                if (value == null || value.isEmpty) {
-                  return 'Please enter a caller ID number';
-                }
-                return null;
-              },
+            Semantics(
+              identifier: 'caller_number_field',
+              container: true,
+              child: CustomFormField(
+                key: const ValueKey('caller_number_field'),
+                title: 'Caller ID Number',
+                controller: _sipCallerIDNumberController,
+                hintText: 'Enter your caller ID number',
+                keyboardType: TextInputType.phone,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter a caller ID number';
+                  }
+                  return null;
+                },
+              ),
             ),
             const SizedBox(height: spacingS),
             // Region Selection
@@ -430,46 +450,52 @@ class _AddProfileFormState extends State<AddProfileForm> {
                   child: const Text('Cancel'),
                 ),
                 const SizedBox(width: spacingM),
-                ElevatedButton(
-                  onPressed: () {
-                    if (_formKey.currentState!.validate()) {
-                      final profile = Profile(
-                        isTokenLogin: _isTokenLogin,
-                        token: _tokenController.text,
-                        sipUser: _sipUserController.text,
-                        sipPassword: _sipPasswordController.text,
-                        sipCallerIDName: _sipCallerIDNameController.text,
-                        sipCallerIDNumber: _sipCallerIDNumberController.text,
-                        region: _selectedRegion,
-                        fallbackOnRegionFailure: _fallbackOnRegionFailure,
-                        forceRelayCandidate: _forceRelayCandidate,
-                      );
+                Semantics(
+                  identifier: 'add_profile_save_button',
+                  container: true,
+                  child: ElevatedButton(
+                    key: const ValueKey('add_profile_save_button'),
+                    onPressed: () {
+                      if (_formKey.currentState!.validate()) {
+                        final profile = Profile(
+                          isTokenLogin: _isTokenLogin,
+                          token: _tokenController.text,
+                          sipUser: _sipUserController.text,
+                          sipPassword: _sipPasswordController.text,
+                          sipCallerIDName: _sipCallerIDNameController.text,
+                          sipCallerIDNumber: _sipCallerIDNumberController.text,
+                          region: _selectedRegion,
+                          fallbackOnRegionFailure: _fallbackOnRegionFailure,
+                          forceRelayCandidate: _forceRelayCandidate,
+                        );
 
-                      try {
-                        final provider = context.read<ProfileProvider>();
-                        if (widget.existingProfile != null) {
-                          // Update existing profile
-                          provider.updateProfile(
-                            widget.existingProfile!.sipCallerIDName,
-                            profile,
-                          );
-                        } else {
-                          // Add new profile
-                          provider.addProfile(profile);
+                        try {
+                          final provider = context.read<ProfileProvider>();
+                          if (widget.existingProfile != null) {
+                            // Update existing profile
+                            provider.updateProfile(
+                              widget.existingProfile!.sipCallerIDName,
+                              profile,
+                            );
+                          } else {
+                            // Add new profile
+                            provider.addProfile(profile);
+                          }
+                          setState(() {
+                            _resetForm();
+                          });
+                          widget.onCancelPressed();
+                        } catch (e) {
+                          ScaffoldMessenger.of(
+                            context,
+                          ).showSnackBar(SnackBar(content: Text(e.toString())));
                         }
-                        setState(() {
-                          _resetForm();
-                        });
-                        widget.onCancelPressed();
-                      } catch (e) {
-                        ScaffoldMessenger.of(
-                          context,
-                        ).showSnackBar(SnackBar(content: Text(e.toString())));
                       }
-                    }
-                  },
-                  child:
-                      Text(widget.existingProfile != null ? 'Update' : 'Save'),
+                    },
+                    child: Text(
+                      widget.existingProfile != null ? 'Update' : 'Save',
+                    ),
+                  ),
                 ),
               ],
             ),

--- a/lib/view/widgets/login/bottom_sheet/profile_list.dart
+++ b/lib/view/widgets/login/bottom_sheet/profile_list.dart
@@ -31,32 +31,37 @@ class ProfileList extends StatelessWidget {
             final isSelected = provider.selectedProfile?.sipCallerIDName ==
                 profile.sipCallerIDName;
 
-            return ListTile(
-              title: Text(profile.sipCallerIDName),
-              subtitle: Text(profile.isTokenLogin ? 'Token' : 'Credentials'),
-              selected: isSelected,
-              selectedTileColor: Theme.of(context).colorScheme.surface,
-              leading: Icon(
-                profile.isTokenLogin ? Icons.key : Icons.person,
-                color: isSelected
-                    ? Theme.of(context).colorScheme.primary
-                    : Theme.of(context).iconTheme.color,
+            return Semantics(
+              identifier: 'profile_tile_${profile.sipCallerIDName}',
+              container: true,
+              child: ListTile(
+                key: ValueKey('profile_tile_${profile.sipCallerIDName}'),
+                title: Text(profile.sipCallerIDName),
+                subtitle: Text(profile.isTokenLogin ? 'Token' : 'Credentials'),
+                selected: isSelected,
+                selectedTileColor: Theme.of(context).colorScheme.surface,
+                leading: Icon(
+                  profile.isTokenLogin ? Icons.key : Icons.person,
+                  color: isSelected
+                      ? Theme.of(context).colorScheme.primary
+                      : Theme.of(context).iconTheme.color,
+                ),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: SvgPicture.asset(edit_icon, width: 16, height: 16),
+                      onPressed: () => onProfileEditSelected(profile),
+                    ),
+                    IconButton(
+                      icon: SvgPicture.asset(delete_icon, width: 16, height: 16),
+                      onPressed: () =>
+                          provider.removeProfile(profile.sipCallerIDName),
+                    ),
+                  ],
+                ),
+                onTap: () => provider.selectProfile(profile.sipCallerIDName),
               ),
-              trailing: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  IconButton(
-                    icon: SvgPicture.asset(edit_icon, width: 16, height: 16),
-                    onPressed: () => onProfileEditSelected(profile),
-                  ),
-                  IconButton(
-                    icon: SvgPicture.asset(delete_icon, width: 16, height: 16),
-                    onPressed: () =>
-                        provider.removeProfile(profile.sipCallerIDName),
-                  ),
-                ],
-              ),
-              onTap: () => provider.selectProfile(profile.sipCallerIDName),
             );
           },
         );

--- a/lib/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart
+++ b/lib/view/widgets/login/bottom_sheet/profile_switcher_bottom_sheet.dart
@@ -48,24 +48,29 @@ class _ProfileSwitcherBottomSheetState
             ),
           ),
           if (!_isAddingProfile)
-            ElevatedButton.icon(
-              onPressed: () {
-                setState(() {
-                  _isAddingProfile = true;
-                });
-              },
-              icon: const Icon(Icons.add, color: Colors.black),
-              label: const Text(
-                'Add new profile',
-                style: TextStyle(
-                  color: Colors.black,
-                  fontWeight: FontWeight.w400,
+            Semantics(
+              identifier: 'add_profile_button',
+              container: true,
+              child: ElevatedButton.icon(
+                key: const ValueKey('add_profile_button'),
+                onPressed: () {
+                  setState(() {
+                    _isAddingProfile = true;
+                  });
+                },
+                icon: const Icon(Icons.add, color: Colors.black),
+                label: const Text(
+                  'Add new profile',
+                  style: TextStyle(
+                    color: Colors.black,
+                    fontWeight: FontWeight.w400,
+                  ),
                 ),
-              ),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Theme.of(context).colorScheme.surface,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(spacingXXL),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Theme.of(context).colorScheme.surface,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(spacingXXL),
+                  ),
                 ),
               ),
             ),
@@ -103,13 +108,18 @@ class _ProfileSwitcherBottomSheetState
                         child: const Text('Cancel'),
                       ),
                       const SizedBox(width: spacingM),
-                      ElevatedButton(
-                        onPressed:
-                            context.watch<ProfileProvider>().selectedProfile !=
-                                    null
-                                ? () => Navigator.pop(context)
-                                : null,
-                        child: const Text('Confirm'),
+                      Semantics(
+                        identifier: 'profile_confirm_button',
+                        container: true,
+                        child: ElevatedButton(
+                          key: const ValueKey('profile_confirm_button'),
+                          onPressed:
+                              context.watch<ProfileProvider>().selectedProfile !=
+                                      null
+                                  ? () => Navigator.pop(context)
+                                  : null,
+                          child: const Text('Confirm'),
+                        ),
                       ),
                     ],
                   ),

--- a/lib/view/widgets/login/login_controls.dart
+++ b/lib/view/widgets/login/login_controls.dart
@@ -53,6 +53,7 @@ class _LoginControlsState extends State<LoginControls> {
                   ),
                   const SizedBox(width: spacingS),
                   OutlinedButton(
+                    key: const ValueKey('switch_profile_button'),
                     onPressed: _showProfileSwitcher,
                     style: OutlinedButton.styleFrom(
                       shape: RoundedRectangleBorder(


### PR DESCRIPTION
## What

Adds stable **test identifiers** (`Semantics(identifier:)` + `ValueKey`) to the demo app's login and call-control widgets so automated UI drivers can locate them reliably:

- **Android** — Maestro matches by accessibility `id` (the `Semantics(identifier:)`).
- **iOS** — Appium/XCUITest matches by accessibility identifier.
- **flutter-driver / live drivers** — match by `ValueKey`.

No behavioural change: every edit is an additive `Semantics` wrapper or a `key:` on an existing widget (plus a couple of `const` removals those wrappers force).

## Why

These are the exact selectors our autonomous on-device E2E suites depend on to drive the app through the Application Flow Checklist (connect → outbound → inbound accept/decline → reconnection). Without stable ids the flows have to match on brittle text/position; a label tweak or localization silently breaks them.

## Identifiers added

| Widget | Identifier |
|---|---|
| Connect button (home) | `connect_button` |
| SIP username / password fields | `sip_username_field`, `sip_password_field` |
| Caller name / number fields | `caller_name_field`, `caller_number_field` |
| Add-profile save button | `add_profile_save_button` |
| Add-profile button | `add_profile_button` |
| Profile confirm button | `profile_confirm_button` |
| Profile row (per profile) | `profile_tile_<name>` |
| Switch-profile button | `switch_profile_button` |
| Call button / cancel | `call_button`, `cancel_call_button` |
| Destination field | `destination_field` (confirmed present) |
| Accept / decline incoming | `accept_call_button`, `decline_call_button` |
| End call | `end_call_button` |

## Scope

Deliberately **identifiers only** — no feature or build changes.

**On the diff size:** wrapping a widget in `Semantics(...)` reindents its child body by two spaces, and a few lines then re-wrap at the 80-col boundary. So the line counts look larger than the substance — a whitespace-insensitive diff (`git diff -w`) shows only the added `identifier:`/`key:`/`Semantics(...)` lines. No unrelated code was reformatted.

**Verification:** `flutter analyze lib/` reports the same issues as the base branch — zero new. (The pre-existing `firebase_options.dart` errors are the flutterfire-generated, gitignored file absent from a bare checkout; untouched here.)
