### PR TITLE
4.4.0 Release

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:telnyx_flutter_webrtc/view/telnyx_client_view_model.dart';
 import 'package:logger/logger.dart';
 import 'package:provider/provider.dart';
 import 'package:telnyx_webrtc/model/push_notification.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
 import 'package:telnyx_flutter_webrtc/utils/theme.dart';
 import 'package:telnyx_webrtc/config/telnyx_config.dart';
 import 'package:telnyx_flutter_webrtc/service/platform_push_service.dart';
@@ -101,15 +102,20 @@ Future<void> main() async {
       FirebaseMessaging.onBackgroundMessage(
         _firebaseMessagingBackgroundHandler,
       );
-      final config = await txClientViewModel.getConfig();
       runApp(
         BackgroundDetector(
           skipWeb: true,
           onLifecycleEvent: (AppLifecycleState state) {
             if (state == AppLifecycleState.resumed) {
               logger.i(
-                '[BackgroundDetector] We are in the foreground, CONNECTING',
+                '[BackgroundDetector] We are in the foreground, checking for pending push answer',
               );
+              // When the app was already running but backgrounded (e.g. screen
+              // locked), answering an incoming push call is stored as an accept
+              // intent (setPushMetaData isAnswer: true) from the FCM background
+              // isolate. _MyAppState.initState does not run again in this case,
+              // so consume the pending accept here and reconnect to auto-answer.
+              _consumePendingPushAnswer();
             } else if (state == AppLifecycleState.paused) {
               logger.i(
                 '[BackgroundDetector] We are in the background, DISCONNECTING',
@@ -128,6 +134,36 @@ Future<void> main() async {
   );
 }
 
+/// Consumes a pending "answer" intent that was stored by the FCM background
+/// isolate while the app was backgrounded (e.g. the screen was locked). Because
+/// the background isolate does not share static state or the widget tree with
+/// the main isolate, the accept is persisted via [TelnyxClient.setPushMetaData]
+/// and only actioned once the app returns to the foreground.
+Future<void> _consumePendingPushAnswer() async {
+  if (kIsWeb) return;
+  try {
+    final pushData = await TelnyxClient.getPushData();
+    if (pushData == null || pushData['isAnswer'] != true) {
+      return;
+    }
+    // Avoid double-processing if the answer is already being handled (e.g. the
+    // main-isolate CallKit listener already picked up the accept event).
+    if (txClientViewModel.callState == CallStateStatus.connectingToCall ||
+        txClientViewModel.callState == CallStateStatus.ongoingCall) {
+      logger.i(
+        '[_consumePendingPushAnswer] Answer already in progress, skipping.',
+      );
+      return;
+    }
+    logger.i('[_consumePendingPushAnswer] Consuming pending push answer.');
+    // Clear the stored intent so we don't re-trigger on a subsequent resume.
+    TelnyxClient.clearPushMetaData();
+    await handlePush(Map<dynamic, dynamic>.from(pushData));
+  } catch (e) {
+    logger.e('[_consumePendingPushAnswer] Error consuming push answer: $e');
+  }
+}
+
 Future<void> handlePush(Map<dynamic, dynamic> data) async {
   logger.i('[handlePush] Started. Raw data: $data');
   txClientViewModel.setPushCallStatus(true);
@@ -138,6 +174,12 @@ Future<void> handlePush(Map<dynamic, dynamic> data) async {
     logger.i(
       '[handlePush] Answer action detected - setting call state to connectingToCall',
     );
+    // Suppress the lifecycle-driven auto-disconnect while we reconnect and
+    // auto-answer. This flag lives in the main isolate; setting it in the FCM
+    // background isolate (via NotificationService) has no effect here, so a
+    // paused/resumed churn on a locked device would otherwise tear down the
+    // in-progress reconnect. Cleared again in resetCallInfo() when the call ends.
+    BackgroundDetector.ignore = true;
     txClientViewModel.callState = CallStateStatus.connectingToCall;
   }
 
@@ -176,23 +218,26 @@ class _MyAppState extends State<MyApp> {
     // Platform-specific logic for handling initial push data when app starts.
     // For Android, this checks if the app was launched from a terminated state by a notification.
     // For iOS, this is less critical as CallKit events usually drive the flow after launch.
-    PlatformPushService.handler.getInitialPushData().then((data) {
-      if (data != null) {
-        final Map<dynamic, dynamic> mutablePayload = Map.from(data);
-        final answer = mutablePayload['isAnswer'] = true;
-        PlatformPushService.handler.processIncomingCallAction(
-          data,
-          isAnswer: answer,
-          isDecline: !answer,
-        );
-      } else {
-        logger.i('[_MyAppState] Android: No initial push data found.');
-      }
-    }).catchError((e) {
-      logger.e(
-        '[_MyAppState] Android: Error fetching initial push data: $e',
-      );
-    });
+    PlatformPushService.handler
+        .getInitialPushData()
+        .then((data) {
+          if (data != null) {
+            final Map<dynamic, dynamic> mutablePayload = Map.from(data);
+            final answer = mutablePayload['isAnswer'] = true;
+            PlatformPushService.handler.processIncomingCallAction(
+              data,
+              isAnswer: answer,
+              isDecline: !answer,
+            );
+          } else {
+            logger.i('[_MyAppState] Android: No initial push data found.');
+          }
+        })
+        .catchError((e) {
+          logger.e(
+            '[_MyAppState] Android: Error fetching initial push data: $e',
+          );
+        });
   }
 
   @override

--- a/lib/utils/version_utils.dart
+++ b/lib/utils/version_utils.dart
@@ -42,7 +42,7 @@ class VersionUtils {
       }
     } catch (e) {
       // Fallback version if we can't read SDK pubspec.yaml
-      _sdkVersion = '4.3.0';
+      _sdkVersion = '4.4.0';
     }
     return _sdkVersion!;
   }

--- a/packages/telnyx_webrtc/CHANGELOG.md
+++ b/packages/telnyx_webrtc/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [4.4.0](https://pub.dev/packages/telnyx_webrtc/versions/4.4.0) (2026-07-08)
+### Bug Fix
+- Fixed `AudioService.stopAudio()` disposing the reusable audio player, causing unstable ringtone/ringback playback on subsequent calls
+- Fixed `TelnyxClient` connectivity subscription leak — subscription is now retained and cancelled on disconnect/dispose
+- Added idempotent `TelnyxClient.dispose()` for proper resource teardown (timers, subscriptions, latency tracker)
+- Guarded stale reconnect/socket callbacks by connection generation so old timers cannot act on newer sessions
+- Fixed native `_cleanSessions()` to cancel pending ICE negotiation/trickle timers and stop stats/report collection before peer close/dispose
+- Fixed `WebRTCStatsReporter` startup race — stop during the 2-second startup delay now prevents timer creation
+- Fixed `playLocalFile()` to cancel in-flight playback attempts when `stopAudio()` or `dispose()` preempts them
+
+### Enhancement
+- Added `Semantics` identifiers and `ValueKey`s to demo app widgets for on-device E2E test automation (Maestro/Appium)
+
 ## [4.3.0](https://pub.dev/packages/telnyx_webrtc/versions/4.3.0) (2026-05-18)
 ### Enhancement
 - Added CallTimings logs to call report JSON

--- a/packages/telnyx_webrtc/lib/utils/version_utils.dart
+++ b/packages/telnyx_webrtc/lib/utils/version_utils.dart
@@ -1,7 +1,7 @@
 /// Utility class for retrieving SDK version information
 class VersionUtils {
   /// SDK version constant
-  static const String _sdkVersion = '4.3.0';
+  static const String _sdkVersion = '4.4.0';
 
   /// Gets the SDK version
   /// Returns the current SDK version as a constant

--- a/packages/telnyx_webrtc/pubspec.yaml
+++ b/packages/telnyx_webrtc/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://telnyx.com/
 repository: https://github.com/team-telnyx/flutter-voice-sdk
 issue_tracker: https://github.com/team-telnyx/flutter-voice-sdk/issues
 # Please Remember to adjust in version_utils.dart too.
-version: 4.3.0
+version: 4.4.0
 
 environment:
   sdk: ">=3.0.0 <3.22.3"


### PR DESCRIPTION
# 4.4.0 Release

## Changes since 4.3.0

### Bug Fixes
- Fixed `AudioService.stopAudio()` disposing the reusable audio player, causing unstable ringtone/ringback playback on subsequent calls
- Fixed `TelnyxClient` connectivity subscription leak — subscription is now retained and cancelled on disconnect/dispose
- Added idempotent `TelnyxClient.dispose()` for proper resource teardown (timers, subscriptions, latency tracker)
- Guarded stale reconnect/socket callbacks by connection generation so old timers cannot act on newer sessions
- Fixed native `_cleanSessions()` to cancel pending ICE negotiation/trickle timers and stop stats/report collection before peer close/dispose
- Fixed `WebRTCStatsReporter` startup race — stop during the 2-second startup delay now prevents timer creation
- Fixed `playLocalFile()` to cancel in-flight playback attempts when `stopAudio()` or `dispose()` preempts them

### Enhancements
- Added `Semantics` identifiers and `ValueKey`s to demo app widgets for on-device E2E test automation (Maestro/Appium)

## Test Checklist

### Logged in with Token

- [x] **Connection:** Establish connection via Token

#### Inbound Calls (Receiving as Token user)
- [x] Receive inbound call from SIP Connection
  - [x] On WiFi
  - [x] On Mobile Network

#### Outbound Calls (Making calls as Token user)
- [x] Make outbound call to SIP Connection
  - [x] On WiFi
  - [x] On Mobile Network
- [x] Make outbound call to associated number
  - [x] On WiFi
  - [x] On Mobile Network
- [x] Make outbound call to PSTN
  - [x] On WiFi
  - [x] On Mobile Network

#### Notifications (While logged in as Token)
- [x] Receive push notification (App Background) -> Reject Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Background) -> Accept Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Terminated) -> Reject Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Terminated) -> Accept Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)

---

### Logged in with SIP Connection

- [x] **Connection:** Establish connection via SIP Credential

#### Inbound Calls (Receiving as SIP user)
- [x] Receive inbound call from another SIP Connection
  - [x] On WiFi
  - [x] On Mobile Network
- [x] Receive inbound call via associated number
  - [x] On WiFi
  - [x] On Mobile Network
- [x] Receive inbound call from PSTN
  - [x] On WiFi
  - [x] On Mobile Network

#### Outbound Calls (Making calls as SIP user)
- [x] Make outbound call to SIP Connection
  - [x] On WiFi
  - [x] On Mobile Network
- [x] Make outbound call to associated number
  - [x] On WiFi
  - [x] On Mobile Network
- [x] Make outbound call to PSTN
  - [x] On WiFi
  - [x] On Mobile Network

#### Notifications (While logged in as SIP)
- [x] Receive push notification (App Background) -> Reject Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Background) -> Accept Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Terminated) -> Reject Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Terminated) -> Accept Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)

---

### Logged in with genCred

- [x] **Connection:** Establish connection via genCred

#### Inbound Calls (Receiving as genCred user)
- [x] Receive inbound call from SIP Connection
  - [x] On WiFi
  - [x] On Mobile Network

#### Outbound Calls (Making calls as genCred user)
- [x] Make outbound call to SIP Connection
  - [x] On WiFi
  - [x] On Mobile Network
- [x] Make outbound call to associated number
  - [x] On WiFi
  - [x] On Mobile Network
- [x] Make outbound call to PSTN
  - [x] On WiFi
  - [x] On Mobile Network

#### Notifications (While logged in as genCred)
- [x] Receive push notification (App Background) -> Reject Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Background) -> Accept Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Terminated) -> Reject Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Terminated) -> Accept Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)

---

### General Reconnection Scenarios
- [x] Establish call -> Drop network -> Re-establish connection within timeframe
  - [x] On WiFi
  - [x] On 4G/Mobile Network
- [x] Establish call -> Drop network -> Fail to re-establish connection within timeframe (verify dropped state)
  - [x] On WiFi
  - [x] On 4G/Mobile Network

---

### Call Reports
- [x] Establish call, end call -> Verify call report appears

---

### Multi-Call Scenarios

- [x] Receive second incoming call while first call is active
  - [x] Accept second call (first goes on hold)
  - [x] Reject second call (first continues)
- [x] Hang up one call does not end both calls
- [x] Remote BYE on one call does not affect the other