### PR TITLE
fix(macos): wait for WebRTC trickle ICE completion

### DIFF
--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -12,6 +12,7 @@ import 'package:telnyx_webrtc/model/verto/send/end_of_candidates_message_body.da
 import 'package:telnyx_webrtc/model/verto/send/modify_message_body.dart';
 import 'package:telnyx_webrtc/peer/session.dart';
 import 'package:telnyx_webrtc/peer/signaling_state.dart';
+import 'package:telnyx_webrtc/peer/trickle_ice_completion.dart';
 import 'package:telnyx_webrtc/telnyx_client.dart';
 import 'package:telnyx_webrtc/tx_socket.dart'
     if (dart.library.js) 'package:telnyx_webrtc/tx_socket_web.dart';
@@ -82,11 +83,9 @@ class Peer {
   static const int _negotiationTimeout = 300; // 300ms timeout for negotiation
   Function()? _onNegotiationComplete;
 
-  // Add trickle ICE end-of-candidates timer fields
-  Timer? _trickleIceTimer;
-  static const int _trickleIceTimeout = 500; // 500ms timeout for trickle ICE
-  String? _currentTrickleCallId;
-  bool _endOfCandidatesSent = false;
+  // Trickle ICE completion is driven by WebRTC callbacks. A fixed silence
+  // timer can fire before slower srflx/relay candidates are discovered.
+  final TrickleIceCompletion _trickleIceCompletion = TrickleIceCompletion();
 
   final Map<String, Session> _sessions = {};
 
@@ -290,6 +289,10 @@ class Peer {
     List<Map<String, dynamic>>? preferredCodecs,
   ) async {
     try {
+      if (_useTrickleIce) {
+        _trickleIceCompletion.begin(callId);
+      }
+
       // For iOS/Web: Apply codec preferences before creating offer
       // For Android: We'll modify SDP after creation (setCodecPreferences doesn't work)
       if (preferredCodecs != null &&
@@ -621,6 +624,10 @@ class Peer {
     String? answeredDeviceToken,
   }) async {
     try {
+      if (_useTrickleIce) {
+        _trickleIceCompletion.begin(callId);
+      }
+
       session.peerConnection?.onIceCandidate = (candidate) async {
         if (session.peerConnection != null) {
           GlobalLogger().i(
@@ -678,7 +685,7 @@ class Peer {
             }
           } else if (_useTrickleIce) {
             // End of candidates signal for trickle ICE
-            _sendEndOfCandidates(callId);
+            _sendEndOfCandidatesIfComplete(callId);
           }
         } else {
           // Still collect candidates if peerConnection is not ready yet
@@ -993,9 +1000,6 @@ class Peer {
                 .markFirstSrflxRelayCandidate(callId, 'relay');
           }
           _sendTrickleCandidate(candidate, callId);
-
-          // Reset the trickle ICE timer when a candidate is generated
-          _startTrickleIceTimer(callId);
         } else {
           // Traditional ICE: filter and collect candidates
           final candidateString = candidate.candidate.toString();
@@ -1017,7 +1021,7 @@ class Peer {
         GlobalLogger().i('Peer :: onIceCandidate: complete!');
         if (_useTrickleIce) {
           // Send end of candidates signal when gathering completes naturally
-          _sendEndOfCandidatesAndCleanup(callId);
+          _sendEndOfCandidatesIfComplete(callId);
         }
       }
     };
@@ -1168,6 +1172,12 @@ class Peer {
         case RTCIceGatheringState.RTCIceGatheringStateComplete:
           _txClient.latencyTracker.markCallMilestone(
               callId, LatencyTracker.milestoneIceGatheringComplete);
+          if (_useTrickleIce) {
+            // Some WebRTC builds report gathering completion without a final
+            // null-candidate callback. The completion guard keeps this path
+            // idempotent with the candidate callback above.
+            _sendEndOfCandidatesIfComplete(callId);
+          }
           break;
         default:
           break;
@@ -1376,7 +1386,7 @@ class Peer {
 
   Future<void> _cleanSessions() async {
     _stopNegotiationTimer();
-    _stopTrickleIceTimer();
+    _trickleIceCompletion.reset();
     _statsManager?.stopStatsReporting();
     await _callReportCollector?.stop();
 
@@ -1397,7 +1407,7 @@ class Peer {
 
   Future<void> _closeSession(Session session) async {
     _stopNegotiationTimer();
-    _stopTrickleIceTimer();
+    _trickleIceCompletion.reset();
 
     _localStream?.getTracks().forEach((element) async {
       await element.stop();
@@ -1445,46 +1455,13 @@ class Peer {
     _negotiationTimer = null;
   }
 
-  /// Starts/resets the trickle ICE timer that sends endOfCandidates after inactivity
-  /// Uses a single delayed timer instead of periodic polling for better efficiency.
-  void _startTrickleIceTimer(String callId) {
-    // If this is a new call, initialize the call ID and reset flags
-    if (_currentTrickleCallId != callId) {
-      _currentTrickleCallId = callId;
-      _endOfCandidatesSent = false;
-    }
-
-    // Cancel existing timer and start a fresh one (resets on each candidate)
-    _trickleIceTimer?.cancel();
-    _trickleIceTimer = Timer(
-      const Duration(milliseconds: _trickleIceTimeout),
-      () {
-        if (!_endOfCandidatesSent && _currentTrickleCallId != null) {
-          GlobalLogger()
-              .i('Trickle ICE timeout reached - sending end of candidates');
-          _sendEndOfCandidatesAndCleanup(_currentTrickleCallId!);
-        }
-      },
-    );
-  }
-
-  /// Stops and cleans up the trickle ICE timer
-  void _stopTrickleIceTimer() {
-    _trickleIceTimer?.cancel();
-    _trickleIceTimer = null;
-    _currentTrickleCallId = null;
-    _endOfCandidatesSent = false;
-  }
-
-  /// Sends end of candidates signal and cleans up timer
-  void _sendEndOfCandidatesAndCleanup(String callId) {
-    if (!_endOfCandidatesSent) {
+  /// Sends end-of-candidates exactly once after WebRTC reports completion.
+  void _sendEndOfCandidatesIfComplete(String callId) {
+    if (_trickleIceCompletion.shouldSignal(callId)) {
       CallTimingBenchmark.mark('ice_gathering_complete');
       _sendEndOfCandidates(callId);
-      _endOfCandidatesSent = true;
-      _stopTrickleIceTimer();
       GlobalLogger().i(
-        'Peer :: End of candidates sent and timer cleaned up for call $callId',
+        'Peer :: End of candidates sent after gathering completed for call $callId',
       );
     }
   }

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -12,6 +12,7 @@ import 'package:telnyx_webrtc/model/verto/send/end_of_candidates_message_body.da
 import 'package:telnyx_webrtc/model/verto/send/modify_message_body.dart';
 import 'package:telnyx_webrtc/peer/session.dart';
 import 'package:telnyx_webrtc/peer/signaling_state.dart';
+import 'package:telnyx_webrtc/peer/trickle_ice_completion.dart';
 import 'package:telnyx_webrtc/telnyx_client.dart';
 import 'package:telnyx_webrtc/tx_socket.dart'
     if (dart.library.js) 'package:telnyx_webrtc/tx_socket_web.dart';
@@ -112,11 +113,9 @@ class Peer {
   static const int _negotiationTimeout = 300; // 300ms timeout for negotiation
   Function()? _onNegotiationComplete;
 
-  // Add trickle ICE end-of-candidates timer fields
-  Timer? _trickleIceTimer;
-  static const int _trickleIceTimeout = 500; // 500ms timeout for trickle ICE
-  String? _currentTrickleCallId;
-  bool _endOfCandidatesSent = false;
+  // Trickle ICE completion is driven by WebRTC callbacks. A fixed silence
+  // timer can fire before slower srflx/relay candidates are discovered.
+  final TrickleIceCompletion _trickleIceCompletion = TrickleIceCompletion();
 
   final Map<String, Session> _sessions = {};
 
@@ -332,6 +331,10 @@ class Peer {
     List<Map<String, dynamic>>? preferredCodecs,
   ) async {
     try {
+      if (_useTrickleIce) {
+        _trickleIceCompletion.begin(callId);
+      }
+
       // For iOS/Web: Apply codec preferences before creating offer
       // For Android: We'll modify SDP after creation (setCodecPreferences doesn't work)
       if (preferredCodecs != null &&
@@ -711,6 +714,10 @@ class Peer {
     String? answeredDeviceToken,
   }) async {
     try {
+      if (_useTrickleIce) {
+        _trickleIceCompletion.begin(callId);
+      }
+
       session.peerConnection?.onIceCandidate = (candidate) async {
         if (session.peerConnection != null) {
           GlobalLogger().i(
@@ -770,7 +777,7 @@ class Peer {
             }
           } else if (_useTrickleIce) {
             // End of candidates signal for trickle ICE
-            _sendEndOfCandidates(callId);
+            _sendEndOfCandidatesIfComplete(callId);
           }
         } else {
           // Still collect candidates if peerConnection is not ready yet
@@ -1197,9 +1204,6 @@ class Peer {
                 .markFirstSrflxRelayCandidate(callId, 'relay');
           }
           _sendTrickleCandidate(candidate, callId);
-
-          // Reset the trickle ICE timer when a candidate is generated
-          _startTrickleIceTimer(callId);
         } else {
           // Traditional ICE: filter and collect candidates
           final candidateString = candidate.candidate.toString();
@@ -1221,7 +1225,7 @@ class Peer {
         GlobalLogger().i('Peer :: onIceCandidate: complete!');
         if (_useTrickleIce) {
           // Send end of candidates signal when gathering completes naturally
-          _sendEndOfCandidatesAndCleanup(callId);
+          _sendEndOfCandidatesIfComplete(callId);
         }
       }
     };
@@ -1386,6 +1390,12 @@ class Peer {
             callId,
             LatencyTracker.milestoneIceGatheringComplete,
           );
+          if (_useTrickleIce) {
+            // Some WebRTC builds report gathering completion without a final
+            // null-candidate callback. The completion guard keeps this path
+            // idempotent with the candidate callback above.
+            _sendEndOfCandidatesIfComplete(callId);
+          }
           break;
         default:
           break;
@@ -1703,7 +1713,7 @@ class Peer {
 
   Future<void> _cleanSessions() async {
     _stopNegotiationTimer();
-    _stopTrickleIceTimer();
+    _trickleIceCompletion.reset();
     _statsManager?.stopStatsReporting();
     await _callReportCollector?.stop();
 
@@ -1724,7 +1734,7 @@ class Peer {
 
   Future<void> _closeSession(Session session) async {
     _stopNegotiationTimer();
-    _stopTrickleIceTimer();
+    _trickleIceCompletion.reset();
 
     _localStream?.getTracks().forEach((element) async {
       await element.stop();
@@ -1772,46 +1782,13 @@ class Peer {
     _negotiationTimer = null;
   }
 
-  /// Starts/resets the trickle ICE timer that sends endOfCandidates after inactivity
-  /// Uses a single delayed timer instead of periodic polling for better efficiency.
-  void _startTrickleIceTimer(String callId) {
-    // If this is a new call, initialize the call ID and reset flags
-    if (_currentTrickleCallId != callId) {
-      _currentTrickleCallId = callId;
-      _endOfCandidatesSent = false;
-    }
-
-    // Cancel existing timer and start a fresh one (resets on each candidate)
-    _trickleIceTimer?.cancel();
-    _trickleIceTimer = Timer(
-      const Duration(milliseconds: _trickleIceTimeout),
-      () {
-        if (!_endOfCandidatesSent && _currentTrickleCallId != null) {
-          GlobalLogger()
-              .i('Trickle ICE timeout reached - sending end of candidates');
-          _sendEndOfCandidatesAndCleanup(_currentTrickleCallId!);
-        }
-      },
-    );
-  }
-
-  /// Stops and cleans up the trickle ICE timer
-  void _stopTrickleIceTimer() {
-    _trickleIceTimer?.cancel();
-    _trickleIceTimer = null;
-    _currentTrickleCallId = null;
-    _endOfCandidatesSent = false;
-  }
-
-  /// Sends end of candidates signal and cleans up timer
-  void _sendEndOfCandidatesAndCleanup(String callId) {
-    if (!_endOfCandidatesSent) {
+  /// Sends end-of-candidates exactly once after WebRTC reports completion.
+  void _sendEndOfCandidatesIfComplete(String callId) {
+    if (_trickleIceCompletion.shouldSignal(callId)) {
       CallTimingBenchmark.mark('ice_gathering_complete');
       _sendEndOfCandidates(callId);
-      _endOfCandidatesSent = true;
-      _stopTrickleIceTimer();
       GlobalLogger().i(
-        'Peer :: End of candidates sent and timer cleaned up for call $callId',
+        'Peer :: End of candidates sent after gathering completed for call $callId',
       );
     }
   }

--- a/packages/telnyx_webrtc/lib/peer/trickle_ice_completion.dart
+++ b/packages/telnyx_webrtc/lib/peer/trickle_ice_completion.dart
@@ -1,0 +1,30 @@
+/// Tracks trickle ICE completion for the active call.
+///
+/// WebRTC can report completion either through a null candidate or through the
+/// ICE gathering state. This guard makes both paths safe to handle while
+/// ensuring the signaling layer emits `end-of-candidates` exactly once.
+final class TrickleIceCompletion {
+  String? _callId;
+  bool _completed = false;
+
+  /// Starts tracking ICE gathering for [callId].
+  void begin(String callId) {
+    _callId = callId;
+    _completed = false;
+  }
+
+  /// Returns whether completion should be signaled for [callId].
+  bool shouldSignal(String callId) {
+    if (_callId != callId || _completed) {
+      return false;
+    }
+    _completed = true;
+    return true;
+  }
+
+  /// Clears the active gathering state.
+  void reset() {
+    _callId = null;
+    _completed = false;
+  }
+}

--- a/packages/telnyx_webrtc/test/trickle_ice_completion_test.dart
+++ b/packages/telnyx_webrtc/test/trickle_ice_completion_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:telnyx_webrtc/peer/trickle_ice_completion.dart';
+
+void main() {
+  group('TrickleIceCompletion', () {
+    test('signals completion exactly once for the active call', () {
+      final completion = TrickleIceCompletion()..begin('call-a');
+
+      expect(completion.shouldSignal('call-a'), isTrue);
+      expect(completion.shouldSignal('call-a'), isFalse);
+    });
+
+    test('ignores stale callbacks from another call', () {
+      final completion = TrickleIceCompletion()..begin('call-b');
+
+      expect(completion.shouldSignal('call-a'), isFalse);
+      expect(completion.shouldSignal('call-b'), isTrue);
+    });
+
+    test('allows a new gathering cycle for the same call', () {
+      final completion = TrickleIceCompletion()..begin('call-a');
+
+      expect(completion.shouldSignal('call-a'), isTrue);
+
+      completion.begin('call-a');
+
+      expect(completion.shouldSignal('call-a'), isTrue);
+    });
+
+    test('reset ignores completion until gathering starts again', () {
+      final completion = TrickleIceCompletion()
+        ..begin('call-a')
+        ..reset();
+
+      expect(completion.shouldSignal('call-a'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #297.

## What changed

- remove the 500 ms candidate-inactivity timer used to signal trickle ICE completion
- signal `end-of-candidates` from WebRTC's null-candidate or completed gathering callbacks
- guard both callbacks so completion is emitted exactly once per gathering cycle
- reset completion state when sessions close
- add focused tests for idempotency, stale callbacks, repeated gathering, and cleanup

## Why

On macOS, a usable server-reflexive or relay candidate can arrive after a gap longer than 500 ms. The inactivity timer could therefore signal `end-of-candidates` while WebRTC was still gathering, causing intermittent one-way or missing audio when the later candidate was the usable route.

WebRTC already exposes authoritative completion callbacks. Using those callbacks avoids guessing when candidate gathering has finished.

## Impact

Trickle ICE calls wait for WebRTC to finish gathering instead of relying on a fixed delay. The completion guard keeps the null-candidate and gathering-state paths idempotent.

## Validation

- `flutter test` — 280 tests passed
- `dart analyze lib/peer/trickle_ice_completion.dart test/trickle_ice_completion_test.dart` — no issues
- `dart format --output=none --set-exit-if-changed lib/peer/trickle_ice_completion.dart test/trickle_ice_completion_test.dart` — clean
- `git diff --check` — clean
