### PR TITLE
feat(macos): add a supported voice integration path

### DIFF
--- a/.github/workflows/macos_smoke.yml
+++ b/.github/workflows/macos_smoke.yml
@@ -1,0 +1,52 @@
+name: macOS Smoke Build
+
+on:
+  push:
+    paths:
+      - "packages/telnyx_webrtc/**"
+      - ".github/workflows/macos_smoke.yml"
+  pull_request:
+    paths:
+      - "packages/telnyx_webrtc/**"
+      - ".github/workflows/macos_smoke.yml"
+
+jobs:
+  macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Run package tests on macOS
+        working-directory: packages/telnyx_webrtc
+        run: |
+          flutter pub get
+          flutter test
+
+      - name: Build an isolated macOS integration app
+        run: |
+          flutter create \
+            --platforms=macos \
+            --project-name telnyx_macos_smoke \
+            "$RUNNER_TEMP/telnyx_macos_smoke"
+          cd "$RUNNER_TEMP/telnyx_macos_smoke"
+          flutter pub add telnyx_webrtc \
+            --path "$GITHUB_WORKSPACE/packages/telnyx_webrtc"
+          cat > lib/main.dart <<'DART'
+          import 'package:flutter/widgets.dart';
+          import 'package:telnyx_webrtc/telnyx_client.dart';
+
+          void main() {
+            final Type sdkType = TelnyxClient;
+            runApp(
+              Directionality(
+                textDirection: TextDirection.ltr,
+                child: Text(sdkType.toString()),
+              ),
+            );
+          }
+          DART
+          flutter build macos --debug

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Telnyx Flutter Voice SDK
 
-Enable Telnyx real-time communication services on Flutter applications (Android / iOS / Web) 📞 🔥
+Enable Telnyx real-time communication services on Flutter applications (Android / iOS / macOS / Web) 📞 🔥
 
 ## Quick Start with Telnyx Common (Beta)
 
@@ -23,6 +23,7 @@ This is the quickest way to implement the SDK with minimal setup and configurati
   - [Platform Specific Configuration](#platform-specific-configuration)
     - [Android](#android)
     - [iOS](#ios)
+    - [macOS](#macos)
 - [Basic Usage](#basic-usage)
   - [Telnyx Client](#telnyx-client)
   - [Logging Configuration](#logging-configuration)
@@ -92,6 +93,34 @@ on the iOS platform, you need to add the microphone permission to your Info.plis
     <key>NSMicrophoneUsageDescription</key>
     <string>$(PRODUCT_NAME) Microphone Usage!</string>
 ```
+
+## macOS
+
+macOS voice calls are supported while the application is running and connected
+to the Telnyx WebSocket. PushKit and CallKit integration documented below is
+iOS-only.
+
+Add a microphone usage description to `macos/Runner/Info.plist`:
+
+```xml
+    <key>NSMicrophoneUsageDescription</key>
+    <string>$(PRODUCT_NAME) Microphone Usage!</string>
+```
+
+For sandboxed applications, add microphone and outbound network access to both
+`macos/Runner/DebugProfile.entitlements` and
+`macos/Runner/Release.entitlements`:
+
+```xml
+    <key>com.apple.security.device.microphone</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+```
+
+The SDK currently resolves `flutter_webrtc` 1.4.1 on all platforms while the
+[macOS duplex-audio regression in 1.5.x](https://github.com/flutter-webrtc/flutter-webrtc/issues/2111)
+is investigated upstream.
 
 
 ## Basic Usage

--- a/packages/telnyx_webrtc/README.md
+++ b/packages/telnyx_webrtc/README.md
@@ -3,7 +3,7 @@
 
 # Telnyx Flutter Voice SDK
 
-Enable Telnyx real-time communication services on Flutter applications (Android / iOS / Web) :telephone_receiver: :fire:
+Enable Telnyx real-time communication services on Flutter applications (Android / iOS / macOS / Web) :telephone_receiver: :fire:
 
 ## Quick Start with Telnyx Common (Beta)
 
@@ -23,6 +23,7 @@ This is the quickest way to implement the SDK with minimal setup and configurati
   - [Platform Specific Configuration](#platform-specific-configuration)
     - [Android](#android)
     - [iOS](#ios)
+    - [macOS](#macos)
 - [Basic Usage](#basic-usage)
   - [Telnyx Client](#telnyx-client)
   - [Logging Configuration](#logging-configuration)
@@ -89,6 +90,35 @@ on the iOS platform, you need to add the microphone permission to your Info.plis
     <key>NSMicrophoneUsageDescription</key>
     <string>$(PRODUCT_NAME) Microphone Usage!</string>
 ```
+
+## macOS
+
+macOS voice calls are supported while the application is running and connected
+to the Telnyx WebSocket. PushKit and CallKit integration documented below is
+iOS-only.
+
+Add a microphone usage description to `macos/Runner/Info.plist`:
+
+```xml
+    <key>NSMicrophoneUsageDescription</key>
+    <string>$(PRODUCT_NAME) Microphone Usage!</string>
+```
+
+For sandboxed applications, add microphone and outbound network access to both
+`macos/Runner/DebugProfile.entitlements` and
+`macos/Runner/Release.entitlements`:
+
+```xml
+    <key>com.apple.security.device.microphone</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+```
+
+The SDK currently resolves `flutter_webrtc` 1.4.1 on all platforms while the
+[macOS duplex-audio regression in 1.5.x](https://github.com/flutter-webrtc/flutter-webrtc/issues/2111)
+is investigated upstream.
+
 
 ## Basic Usage
 
@@ -878,4 +908,3 @@ Questions? Comments? Building something rad? [Join our Slack channel](https://jo
 ## License
 
 [`MIT Licence`](./LICENSE) © [Telnyx](https://github.com/team-telnyx)
-

--- a/packages/telnyx_webrtc/example/readme.md
+++ b/packages/telnyx_webrtc/example/readme.md
@@ -5,7 +5,7 @@ For the example app implementation please visit this [root repository](https://g
 
 # Telnyx Flutter Voice SDK
 
-Enable Telnyx real-time communication services on Flutter applications (Android / iOS / Web) :telephone_receiver: :fire:
+Enable Telnyx real-time communication services on Flutter applications (Android / iOS / macOS / Web) :telephone_receiver: :fire:
 
 ## Table of Contents
 
@@ -15,6 +15,7 @@ Enable Telnyx real-time communication services on Flutter applications (Android 
   - [Platform Specific Configuration](#platform-specific-configuration)
     - [Android](#android)
     - [iOS](#ios)
+    - [macOS](#macos)
   - [Telnyx Client](#telnyx-client)
   - [Logging into Telnyx Client](#logging-into-telnyx-client)
   - [Adding push notifications - Android platform](#adding-push-notifications---android-platform)
@@ -71,6 +72,35 @@ on the iOS platform, you need to add the microphone permission to your Info.plis
     <key>NSMicrophoneUsageDescription</key>
     <string>$(PRODUCT_NAME) Microphone Usage!</string>
 ```
+
+## macOS
+
+macOS voice calls are supported while the application is running and connected
+to the Telnyx WebSocket. PushKit and CallKit integration documented below is
+iOS-only.
+
+Add a microphone usage description to `macos/Runner/Info.plist`:
+
+```xml
+    <key>NSMicrophoneUsageDescription</key>
+    <string>$(PRODUCT_NAME) Microphone Usage!</string>
+```
+
+For sandboxed applications, add microphone and outbound network access to both
+`macos/Runner/DebugProfile.entitlements` and
+`macos/Runner/Release.entitlements`:
+
+```xml
+    <key>com.apple.security.device.microphone</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+```
+
+The SDK currently resolves `flutter_webrtc` 1.4.1 on all platforms while the
+[macOS duplex-audio regression in 1.5.x](https://github.com/flutter-webrtc/flutter-webrtc/issues/2111)
+is investigated upstream.
+
 
 ### Telnyx Client
 TelnyxClient() is the core class of the SDK, and can be used to connect to our backend socket connection, create calls, check state and disconnect, etc.
@@ -373,7 +403,6 @@ Questions? Comments? Building something rad? [Join our Slack channel](https://jo
 ## License
 
 [`MIT Licence`](./LICENSE) © [Telnyx](https://github.com/team-telnyx)
-
 
 
 

--- a/packages/telnyx_webrtc/pubspec.yaml
+++ b/packages/telnyx_webrtc/pubspec.yaml
@@ -1,5 +1,5 @@
 name: telnyx_webrtc
-description: Enable real-time communication with WebRTC and Telnyx. Create and receive calls on Android, iOS and Web platforms
+description: Enable real-time communication with WebRTC and Telnyx. Create and receive calls on Android, iOS, macOS and Web platforms
 homepage: https://telnyx.com/
 repository: https://github.com/team-telnyx/flutter-voice-sdk
 issue_tracker: https://github.com/team-telnyx/flutter-voice-sdk/issues
@@ -13,7 +13,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_webrtc: ^1.2.0
+  # 1.5.x moved macOS audio to AVAudioEngine and currently regresses duplex
+  # microphone capture. Keep the last verified CoreAudio-based release until
+  # https://github.com/flutter-webrtc/flutter-webrtc/issues/2111 is resolved.
+  flutter_webrtc: ">=1.2.0 <1.5.0"
   uuid: ^4.5.1
   just_audio: ^0.9.43
   shared_preferences: ^2.4.0


### PR DESCRIPTION
Companion to #298 and #297.

## What changed

- add macOS to the package's documented platform support
- document the required microphone permission and sandbox entitlements
- clarify that macOS incoming calls require the application to remain connected because PushKit and CallKit are iOS-only
- constrain `flutter_webrtc` to the last verified CoreAudio-based release while flutter-webrtc/flutter-webrtc#2111 is investigated
- add a macOS GitHub Actions job that runs the SDK tests and builds a fresh integration application against the local package

## Why

The SDK's Dart and WebRTC layers already compile and run on macOS, but the platform was not declared, its application permissions were undocumented, and CI did not exercise a macOS build. In addition, the unconstrained `^1.2.0` dependency currently resolves `flutter_webrtc` 1.5.2, whose AVAudioEngine path regresses microphone input in a real duplex call on macOS.

This change makes the supported path explicit and reproducible while keeping the 1.5.x regression visible and bounded.

## Impact

Developers get a documented macOS voice-call integration path and CI coverage for dependency resolution, native plugin registration, package compilation, and application linking. Mobile push behavior is unchanged.

## Validation

- `flutter test` — 276 tests passed
- isolated `flutter build macos --debug` — succeeded
- smoke application resolved `flutter_webrtc` 1.4.1
- `flutter pub publish --dry-run` — 0 warnings
- `actionlint .github/workflows/macos_smoke.yml` — passed
- `git diff --check` — passed

## Follow-up

Once flutter-webrtc/flutter-webrtc#2111 is fixed and verified in a real duplex call, the temporary `<1.5.0` upper bound can be removed.
