### PR TITLE
[VSDK-415][VSDK-416][VSDK-417][VSDK-418] - WebRTC Runtime Recovery Integration

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:marionette_flutter/marionette_flutter.dart';
 import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
 import 'package:telnyx_flutter_webrtc/utils/background_detector.dart';
 import 'package:telnyx_flutter_webrtc/view/screen/home_screen.dart';
@@ -92,7 +93,15 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 Future<void> main() async {
   await runZonedGuarded(
     () async {
-      WidgetsFlutterBinding.ensureInitialized();
+      // Single binding rule: in debug builds initialize the Marionette binding
+      // (which is itself a WidgetsFlutterBinding) so the Marionette MCP server
+      // can drive the running app; in release builds use the standard binding.
+      // Only one binding is ever initialized within the existing zoned startup.
+      if (kDebugMode) {
+        MarionetteBinding.ensureInitialized();
+      } else {
+        WidgetsFlutterBinding.ensureInitialized();
+      }
 
       // Catch Flutter framework errors
       FlutterError.onError = (FlutterErrorDetails details) {

--- a/lib/utils/config_helper.dart
+++ b/lib/utils/config_helper.dart
@@ -33,6 +33,17 @@ class ConfigHelper {
           debug: false,
           reconnectionTimeout: 30000,
           forceRelayCandidate: forceRelayCandidate,
+          // Structured errors/warnings + signaling-health monitor are on by
+          // default; shown here explicitly for demonstration (VSDK-415/416).
+          enableStructuredErrors: true,
+          enableSignalingHealthMonitor: true,
+          // Opt into inbound media-permission recovery: if the mic permission
+          // is missing while answering, the SDK emits a recoverable event so
+          // the app can prompt the user and resume() the call (VSDK-417).
+          mediaPermissionsRecovery: const MediaPermissionsRecoveryConfig(
+            enabled: true,
+            timeout: 25000,
+          ),
         );
       }
     } catch (e) {

--- a/lib/utils/media_recovery_helper.dart
+++ b/lib/utils/media_recovery_helper.dart
@@ -1,0 +1,40 @@
+import 'package:permission_handler/permission_handler.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_event.dart';
+
+/// Requests a permission and reports whether it was granted. Injectable so the
+/// resume/reject decision can be unit-tested without the platform channel.
+typedef MicPermissionRequester = Future<bool> Function();
+
+/// Default microphone-permission requester backed by `permission_handler`.
+Future<bool> requestMicrophonePermission() async {
+  final status = await Permission.microphone.request();
+  return status.isGranted;
+}
+
+/// Resolves an inbound [TelnyxMediaRecoveryErrorEvent] (VSDK-417) by requesting
+/// the microphone permission and, when granted, calling [event.resume] to retry
+/// media acquisition — otherwise [event.reject] to abort the call.
+///
+/// Fail-safe: any thrown error results in a best-effort [event.reject] so the
+/// call never hangs waiting for the SDK's safety timeout. Logs no sensitive
+/// data (the caller decides what, if anything, to log).
+Future<void> resolveMediaRecovery(
+  TelnyxMediaRecoveryErrorEvent event, {
+  MicPermissionRequester requestMicPermission = requestMicrophonePermission,
+}) async {
+  try {
+    final granted = await requestMicPermission();
+    if (granted) {
+      await event.resume();
+    } else {
+      await event.reject();
+    }
+  } catch (_) {
+    // Never let a recovery-callback failure propagate; reject as a last resort.
+    try {
+      await event.reject();
+    } catch (_) {
+      // Nothing else we can safely do.
+    }
+  }
+}

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -19,6 +19,8 @@ import 'package:telnyx_webrtc/model/call_termination_reason.dart';
 import 'package:telnyx_webrtc/model/socket_method.dart';
 import 'package:telnyx_webrtc/model/telnyx_message.dart';
 import 'package:telnyx_webrtc/model/telnyx_socket_error.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_event.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_warning_event.dart';
 import 'package:telnyx_webrtc/utils/latency_tracker.dart';
 import 'package:telnyx_webrtc/model/verto/receive/received_message_body.dart';
 import 'package:telnyx_webrtc/telnyx_client.dart';
@@ -32,6 +34,7 @@ import 'package:telnyx_webrtc/model/audio_constraints.dart';
 import 'package:telnyx_webrtc/model/socket_connection_metrics.dart';
 import 'package:telnyx_webrtc/model/tx_server_configuration.dart';
 import 'package:telnyx_flutter_webrtc/utils/config_helper.dart';
+import 'package:telnyx_flutter_webrtc/utils/media_recovery_helper.dart';
 import 'package:telnyx_flutter_webrtc/service/notification_service.dart';
 import 'package:telnyx_webrtc/utils/logging/log_level.dart';
 
@@ -770,6 +773,32 @@ class TelnyxClientViewModel with ChangeNotifier {
             }
         }
         notifyListeners();
+      }
+      // Observe structured SDK errors (VSDK-415). These fire alongside the
+      // legacy onSocketErrorReceived above — never instead of it. A media
+      // recovery event is recoverable (offers resume()/reject()).
+      ..onTelnyxError = (Object event) {
+        if (event is TelnyxMediaRecoveryErrorEvent) {
+          logger.i(
+            'Structured recoverable media error [${event.error.code}] '
+            '${event.error.name} for call ${event.callId}',
+          );
+          // Recover the inbound call: request the mic permission and resume()
+          // when granted, otherwise reject() (VSDK-417). Fail-safe internally.
+          unawaited(resolveMediaRecovery(event));
+        } else if (event is TelnyxErrorEvent) {
+          logger.i(
+            'Structured error [${event.error.code}] ${event.error.name}: '
+            '${event.error.message}',
+          );
+        }
+      }
+      // Observe structured SDK warnings (VSDK-415/416).
+      ..onTelnyxWarning = (TelnyxWarningEvent event) {
+        logger.i(
+          'Structured warning [${event.warning.code}] ${event.warning.name}'
+          '${event.reason != null ? ' — ${event.reason}' : ''}',
+        );
       }
       // Observe Transcript Updates
       ..onTranscriptUpdate = (List<TranscriptItem> transcriptItems) {

--- a/packages/telnyx_webrtc/lib/call.dart
+++ b/packages/telnyx_webrtc/lib/call.dart
@@ -168,6 +168,11 @@ class Call {
   /// The unique identifier for the call, used to track the call session
   String? callId;
 
+  /// The call ID of a previous (pre-restart) call that this call was recovered
+  /// from, used to correlate a restored call with the one that was persisted in
+  /// the active-calls recovery marker (VSDK-418). Null for fresh calls.
+  String? recoveredCallId;
+
   /// The Peer connection instance used for WebRTC communication
   Peer? peerConnection;
 
@@ -518,6 +523,23 @@ class Call {
       onHold = true;
       callHandler.changeState(CallState.held);
     }
+  }
+
+  /// Triggers a WebRTC ICE restart for this call by starting an ICE
+  /// renegotiation on the underlying peer connection.
+  ///
+  /// Used by the [SignalingHealthMonitor] recovery authority when signaling is
+  /// healthy but media has degraded. Returns `true` when a restart could be
+  /// started (a peer connection and call ID are present).
+  bool restartIce() {
+    final peer = peerConnection;
+    final id = callId;
+    if (peer == null || id == null) {
+      return false;
+    }
+    // startIceRenegotiation is async and handles its own errors internally.
+    unawaited(peer.startIceRenegotiation(id, sessid));
+    return true;
   }
 
   /// Handles call quality metrics updates.

--- a/packages/telnyx_webrtc/lib/call.dart
+++ b/packages/telnyx_webrtc/lib/call.dart
@@ -134,7 +134,7 @@ class Call {
   /// - READ ONLY in practice - do not assign directly
   /// - Modified only through `callHandler.changeState()`
   /// - Represents states like: newCall, ringing, connecting, active, held, done, etc.
-  late CallState callState;
+  CallState callState = CallState.newCall;
 
   /// AudioService instance to handle audio playback (lazy initialized)
   AudioService get audioService => _audioService ??= AudioService();

--- a/packages/telnyx_webrtc/lib/config/telnyx_config.dart
+++ b/packages/telnyx_webrtc/lib/config/telnyx_config.dart
@@ -4,8 +4,13 @@ import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
 import 'package:telnyx_webrtc/model/region.dart';
 import 'package:telnyx_webrtc/model/tx_ice_server.dart';
 import 'package:telnyx_webrtc/model/tx_server_configuration.dart';
+import 'package:telnyx_webrtc/model/errors/media_permissions_recovery_config.dart';
 import 'package:telnyx_webrtc/config/debug_output.dart';
 import 'package:telnyx_webrtc/config/debug_log_level.dart';
+
+// Re-export MediaPermissionsRecoveryConfig so consumers can configure inbound
+// media-permission recovery from telnyx_config.dart directly.
+export 'package:telnyx_webrtc/model/errors/media_permissions_recovery_config.dart';
 
 // Re-export GlobalLogger so tests/consumers can import it from telnyx_config.dart
 export 'package:telnyx_webrtc/utils/logging/global_logger.dart';
@@ -50,6 +55,9 @@ class Config {
     this.autoRecoverCalls = true,
     this.hangupOnBeforeUnload = true,
     this.maxReconnectAttempts = 10,
+    this.enableStructuredErrors = true,
+    this.enableSignalingHealthMonitor = true,
+    this.mediaPermissionsRecovery,
   });
 
   /// Name associated with the SIP account
@@ -166,6 +174,26 @@ class Config {
   /// Maximum reconnection attempts before giving up; 0 means unlimited (default: 10)
   final int maxReconnectAttempts;
 
+  /// Whether the SDK emits structured [TelnyxError]/[TelnyxWarning] events via
+  /// the `onTelnyxError` / `onTelnyxWarning` callbacks (default: true).
+  ///
+  /// When disabled, the legacy `onSocketErrorReceived` behavior is preserved
+  /// but no structured error/warning callbacks are fired.
+  final bool enableStructuredErrors;
+
+  /// Whether the SDK runs the [SignalingHealthMonitor] during active calls to
+  /// detect signaling/media degradation and choose a single recovery path
+  /// (default: true).
+  final bool enableSignalingHealthMonitor;
+
+  /// Optional configuration for inbound media-permission recovery.
+  ///
+  /// When null or disabled, a failed `getUserMedia` while answering an inbound
+  /// call fails normally (with a structured error still emitted). When enabled,
+  /// the SDK emits a recoverable [TelnyxMediaRecoveryErrorEvent] so the app can
+  /// prompt the user to fix permissions and then `resume()` the call.
+  final MediaPermissionsRecoveryConfig? mediaPermissionsRecovery;
+
   /// Apply the [debugLogLevel] to the GlobalLogger by setting a level filter.
   /// Messages below the configured level are suppressed.
   void applyDebugLogLevel() {
@@ -243,6 +271,9 @@ class CredentialConfig extends Config {
     super.autoRecoverCalls = true,
     super.hangupOnBeforeUnload = true,
     super.maxReconnectAttempts = 10,
+    super.enableStructuredErrors = true,
+    super.enableSignalingHealthMonitor = true,
+    super.mediaPermissionsRecovery,
   });
 
   /// SIP username to log in with. Either a SIP Credential from the Portal or a Generated Credential from the API
@@ -314,6 +345,9 @@ class TokenConfig extends Config {
     super.autoRecoverCalls = true,
     super.hangupOnBeforeUnload = true,
     super.maxReconnectAttempts = 10,
+    super.enableStructuredErrors = true,
+    super.enableSignalingHealthMonitor = true,
+    super.mediaPermissionsRecovery,
   });
 
   /// Token to log in with. The token would be generated from a Generated Credential via the API

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -32,9 +32,26 @@ import 'package:telnyx_webrtc/model/audio_codec.dart';
 import 'package:telnyx_webrtc/model/audio_constraints.dart';
 import 'package:telnyx_webrtc/utils/call_timing_benchmark.dart';
 import 'package:telnyx_webrtc/utils/latency_tracker.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_factory.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_warning_codes.dart';
+import 'package:telnyx_webrtc/model/errors/media_permission_recovery.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
+/// Function signature for acquiring a local media stream. Allows tests to
+/// inject a deterministic `getUserMedia` implementation without a platform.
+typedef GetUserMediaFn = Future<MediaStream> Function(
+  Map<String, dynamic> constraints,
+);
 
 /// Represents a peer in the WebRTC communication.
 class Peer {
+  /// Optional override for `getUserMedia`, used to exercise the media-permission
+  /// recovery flow (VSDK-417) deterministically in tests. When null the real
+  /// `navigator.mediaDevices.getUserMedia` is used.
+  @visibleForTesting
+  GetUserMediaFn? getUserMediaOverride;
+
   /// The peer connection instance.
   RTCPeerConnection? peerConnection;
 
@@ -315,7 +332,9 @@ class Peer {
 
         // Latency milestones
         _txClient.latencyTracker.markCallMilestone(
-            callId, LatencyTracker.milestoneSdpNegotiationStarted);
+          callId,
+          LatencyTracker.milestoneSdpNegotiationStarted,
+        );
         _txClient.latencyTracker
             .markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
 
@@ -400,7 +419,9 @@ class Peer {
 
         // Latency milestones
         _txClient.latencyTracker.markCallMilestone(
-            callId, LatencyTracker.milestoneSdpNegotiationStarted);
+          callId,
+          LatencyTracker.milestoneSdpNegotiationStarted,
+        );
         _txClient.latencyTracker
             .markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
 
@@ -466,13 +487,21 @@ class Peer {
 
           // Latency milestones
           _txClient.latencyTracker.markCallMilestone(
-              callId, LatencyTracker.milestoneIceGatheringComplete);
+            callId,
+            LatencyTracker.milestoneIceGatheringComplete,
+          );
           _txClient.latencyTracker
               .markCallMilestone(callId, LatencyTracker.milestoneInviteSent);
         });
       }
     } catch (e) {
       GlobalLogger().e('Peer :: $e');
+      // Structured SDP offer/local-description failure (VSDK-415).
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpCreateOfferFailed,
+        originalError: e,
+        callId: callId,
+      );
     }
   }
 
@@ -485,9 +514,27 @@ class Peer {
     // Extract and cache remote ICE candidates from the SDP
     _callReportCollector?.cacheIceCandidatesFromSdp(sdp, isLocal: false);
 
-    await _sessions[_selfId]?.peerConnection?.setRemoteDescription(
-          RTCSessionDescription(sdp, 'answer'),
-        );
+    try {
+      await _sessions[_selfId]?.peerConnection?.setRemoteDescription(
+            RTCSessionDescription(sdp, 'answer'),
+          );
+    } catch (e) {
+      GlobalLogger().e('Peer :: setRemoteDescription failed: $e');
+      // Structured SDP remote-description failure (VSDK-415).
+      String? failedCallId;
+      for (final call in _txClient.calls.values) {
+        if (call.peerConnection == this) {
+          failedCallId = call.callId;
+          break;
+        }
+      }
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpSetRemoteDescriptionFailed,
+        originalError: e,
+        callId: failedCallId,
+      );
+      rethrow;
+    }
     CallTimingBenchmark.mark('remote_answer_sdp_set');
 
     // Latency milestones for outbound call remote SDP
@@ -501,9 +548,13 @@ class Peer {
     }
     if (remoteSdpCallId != null) {
       _txClient.latencyTracker.markCallMilestone(
-          remoteSdpCallId, LatencyTracker.milestoneRemoteSdpReceived);
+        remoteSdpCallId,
+        LatencyTracker.milestoneRemoteSdpReceived,
+      );
       _txClient.latencyTracker.markCallMilestone(
-          remoteSdpCallId, LatencyTracker.milestoneRemoteSdpSet);
+        remoteSdpCallId,
+        LatencyTracker.milestoneRemoteSdpSet,
+      );
     }
 
     // Process any queued candidates after setting remote SDP
@@ -560,8 +611,10 @@ class Peer {
 
     // Extract and cache remote ICE candidates from the SDP
     if (invite.sdp != null) {
-      _callReportCollector?.cacheIceCandidatesFromSdp(invite.sdp!,
-          isLocal: false);
+      _callReportCollector?.cacheIceCandidatesFromSdp(
+        invite.sdp!,
+        isLocal: false,
+      );
     }
 
     await session.peerConnection?.setRemoteDescription(
@@ -646,7 +699,9 @@ class Peer {
                   !currentMetrics.milestones
                       .containsKey(LatencyTracker.milestoneFirstIceCandidate)) {
                 _txClient.latencyTracker.markCallMilestone(
-                    callId, LatencyTracker.milestoneFirstIceCandidate);
+                  callId,
+                  LatencyTracker.milestoneFirstIceCandidate,
+                );
               }
               // Detect first srflx/relay candidate
               final candidateStr = candidate.candidate.toString().toLowerCase();
@@ -694,7 +749,9 @@ class Peer {
 
         // Latency milestones
         _txClient.latencyTracker.markCallMilestone(
-            callId, LatencyTracker.milestoneSdpNegotiationStarted);
+          callId,
+          LatencyTracker.milestoneSdpNegotiationStarted,
+        );
         _txClient.latencyTracker
             .markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
 
@@ -760,7 +817,9 @@ class Peer {
 
         // Latency milestones
         _txClient.latencyTracker.markCallMilestone(
-            callId, LatencyTracker.milestoneSdpNegotiationStarted);
+          callId,
+          LatencyTracker.milestoneSdpNegotiationStarted,
+        );
         _txClient.latencyTracker
             .markCallMilestone(callId, LatencyTracker.milestoneLocalSdpCreated);
 
@@ -813,13 +872,21 @@ class Peer {
 
           // Latency milestones
           _txClient.latencyTracker.markCallMilestone(
-              callId, LatencyTracker.milestoneIceGatheringComplete);
+            callId,
+            LatencyTracker.milestoneIceGatheringComplete,
+          );
           _txClient.latencyTracker
               .markCallMilestone(callId, LatencyTracker.milestoneAnswerSent);
         });
       }
     } catch (e) {
       GlobalLogger().e('Peer :: $e');
+      // Structured SDP answer/local-description failure (VSDK-415).
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpCreateAnswerFailed,
+        originalError: e,
+        callId: callId,
+      );
     }
   }
 
@@ -837,20 +904,112 @@ class Peer {
   /// Creates a local media stream.
   ///
   /// [media] The type of media to create (e.g., 'audio').
+  /// [isAnswer] whether this acquisition is for answering an inbound call —
+  /// only then does the inbound media-permission recovery flow apply (VSDK-417).
+  /// [callId] the call this stream belongs to, used for structured events.
   /// Returns a [Future] that completes with the [MediaStream].
-  Future<MediaStream> createStream(String media) async {
+  Future<MediaStream> createStream(
+    String media, {
+    bool isAnswer = false,
+    String? callId,
+  }) async {
     final Map<String, dynamic> mediaConstraints = {
       'audio': (_audioConstraints ?? AudioConstraints.enabled())
           .toMap(isAndroid: Platform.isAndroid),
       'video': false,
     };
 
-    final MediaStream stream = await navigator.mediaDevices.getUserMedia(
-      mediaConstraints,
-    );
+    final getUserMedia =
+        getUserMediaOverride ?? navigator.mediaDevices.getUserMedia;
+    try {
+      final MediaStream stream = await getUserMedia(mediaConstraints);
+      onLocalStream?.call(stream);
+      return stream;
+    } catch (error) {
+      return _handleGetUserMediaFailure(
+        error: error,
+        getUserMedia: getUserMedia,
+        mediaConstraints: mediaConstraints,
+        isAnswer: isAnswer,
+        callId: callId ?? currentSession?.sid ?? '',
+      );
+    }
+  }
 
-    onLocalStream?.call(stream);
-    return stream;
+  /// Handles a `getUserMedia` failure with structured error classification and,
+  /// for enabled inbound-answer paths, the media-permission recovery flow
+  /// (VSDK-417). Outbound/origination and disabled paths always emit a
+  /// structured error and rethrow (preserving normal failure behavior).
+  Future<MediaStream> _handleGetUserMediaFailure({
+    required Object error,
+    required GetUserMediaFn getUserMedia,
+    required Map<String, dynamic> mediaConstraints,
+    required bool isAnswer,
+    required String callId,
+  }) async {
+    final int errorCode = classifyMediaErrorCode(error);
+    final recovery = _txClient.mediaPermissionsRecovery;
+
+    if (recovery != null && recovery.enabled && isAnswer) {
+      // Recoverable flow — the error is non-fatal while recovery is active.
+      final telnyxError = createTelnyxError(
+        errorCode,
+        originalError: error,
+        fatal: false,
+      );
+      final flow = MediaPermissionRecovery.start(
+        config: recovery,
+        error: telnyxError,
+        sessionId: _txClient.sessid,
+        callId: callId,
+      );
+      // Emit the recoverable event so the app can prompt + resume/reject.
+      _txClient.emitTelnyxMediaRecoveryError(flow.toEvent());
+
+      final result = await flow.result;
+      flow.dispose();
+
+      switch (result) {
+        case MediaRecoveryResult.resumed:
+          try {
+            final MediaStream stream = await getUserMedia(mediaConstraints);
+            onLocalStream?.call(stream);
+            recovery.onSuccess?.call();
+            return stream;
+          } catch (retryError) {
+            // Retry failed — onError exactly once + structured error.
+            recovery.onError?.call(retryError);
+            _txClient.emitStructuredErrorCode(
+              classifyMediaErrorCode(retryError),
+              originalError: retryError,
+              callId: callId,
+            );
+            rethrow;
+          }
+        case MediaRecoveryResult.rejected:
+          final rejectedError = Exception(
+            'Call was rejected during media recovery flow',
+          );
+          recovery.onError?.call(rejectedError);
+          throw rejectedError;
+        case MediaRecoveryResult.timedOut:
+          final timeoutError = Exception('Media recovery flow timed out');
+          recovery.onError?.call(timeoutError);
+          throw timeoutError;
+        case MediaRecoveryResult.retryFailed:
+          final retryFailedError = Exception('Media recovery retry failed');
+          recovery.onError?.call(retryFailedError);
+          throw retryFailedError;
+      }
+    }
+
+    // Non-recovery path: emit a structured error and fail normally.
+    _txClient.emitStructuredErrorCode(
+      errorCode,
+      originalError: error,
+      callId: callId,
+    );
+    throw error;
   }
 
   Future<Session> _createSession(
@@ -870,7 +1029,11 @@ class Peer {
     if (media != 'data') {
       // Run both operations in parallel since they are independent
       final results = await Future.wait([
-        createStream(media),
+        createStream(
+          media,
+          isAnswer: direction == 'inbound',
+          callId: callId,
+        ),
         createPeerConnection(
           {
             ..._buildIceConfiguration(),
@@ -888,7 +1051,9 @@ class Peer {
 
       // Latency milestones
       _txClient.latencyTracker.markCallMilestone(
-          callId, LatencyTracker.milestoneMediaDevicesAcquired);
+        callId,
+        LatencyTracker.milestoneMediaDevicesAcquired,
+      );
       _txClient.latencyTracker
           .markCallMilestone(callId, LatencyTracker.milestonePeerCreated);
 
@@ -981,7 +1146,9 @@ class Peer {
               !currentMetrics.milestones
                   .containsKey(LatencyTracker.milestoneFirstIceCandidate)) {
             _txClient.latencyTracker.markCallMilestone(
-                callId, LatencyTracker.milestoneFirstIceCandidate);
+              callId,
+              LatencyTracker.milestoneFirstIceCandidate,
+            );
           }
           // Detect first srflx/relay candidate
           final candidateStr = candidate.candidate.toString().toLowerCase();
@@ -1094,19 +1261,25 @@ class Peer {
           // Cancel any reconnection timer for this call
           _txClient.onCallStateChangedToActive(callId);
         case RTCIceConnectionState.RTCIceConnectionStateFailed:
-          if (_previousIceConnectionState ==
-              RTCIceConnectionState.RTCIceConnectionStateDisconnected) {
-            GlobalLogger()
-                .i('Peer :: ICE connection failed, starting renegotiation...');
-            startIceRenegotiation(callId, newSession.sid);
-            break;
-          } else {
-            GlobalLogger().d(
-              'Peer :: ICE connection failed without prior disconnection, not renegotiating',
-            );
-            break;
-          }
+          // Route to the single recovery authority (VSDK-415/416). It emits a
+          // structured warning and takes exactly one action: the health
+          // monitor when enabled (ICE restart vs. socket reconnect by
+          // signaling health), otherwise a legacy direct renegotiation when
+          // the failure followed a disconnect.
+          _txClient.handlePeerIceConnectionFailed(
+            callId,
+            afterDisconnect: _previousIceConnectionState ==
+                RTCIceConnectionState.RTCIceConnectionStateDisconnected,
+          );
+          break;
         case RTCIceConnectionState.RTCIceConnectionStateDisconnected:
+          // Structured warning for lost ICE connectivity (VSDK-415).
+          _txClient.emitWarningCode(
+            TelnyxWarningCodes.iceConnectivityLost,
+            callId: callId,
+            reason: 'ICE connectivity lost',
+            source: 'peer',
+          );
           _statsManager?.stopStatsReporting();
           return;
         default:
@@ -1145,6 +1318,10 @@ class Peer {
             message: entry['message'] as String? ?? '',
           );
         }
+      } else if (state == RTCPeerConnectionState.RTCPeerConnectionStateFailed) {
+        // Structured warning + route to the single recovery authority
+        // (VSDK-415/416).
+        _txClient.handlePeerConnectionFailed(callId);
       }
     };
 
@@ -1163,11 +1340,15 @@ class Peer {
       switch (state) {
         case RTCIceGatheringState.RTCIceGatheringStateGathering:
           _txClient.latencyTracker.markCallMilestone(
-              callId, LatencyTracker.milestoneIceGatheringStarted);
+            callId,
+            LatencyTracker.milestoneIceGatheringStarted,
+          );
           break;
         case RTCIceGatheringState.RTCIceGatheringStateComplete:
           _txClient.latencyTracker.markCallMilestone(
-              callId, LatencyTracker.milestoneIceGatheringComplete);
+            callId,
+            LatencyTracker.milestoneIceGatheringComplete,
+          );
           break;
         default:
           break;
@@ -1233,6 +1414,7 @@ class Peer {
   /// Get the log collector for external event logging
   CallReportLogCollector? get callReportLogCollector => _callReportLogCollector;
 
+  /// Starts periodic WebRTC statistics collection for the given call.
   Future<bool> startStats(
     String callId,
     String peerId, {
@@ -1649,6 +1831,14 @@ class Peer {
       }
     } catch (e) {
       GlobalLogger().e('Peer :: Error during ICE renegotiation: $e');
+      // Structured ICE-restart failure (VSDK-415) + let the recovery authority
+      // escalate to a socket reconnect when the monitor is active (VSDK-416).
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.iceRestartFailed,
+        originalError: e,
+        callId: callId,
+      );
+      _txClient.healthMonitor?.onIceRestartFailed(callId);
     }
   }
 

--- a/packages/telnyx_webrtc/lib/peer/web/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/web/peer.dart
@@ -31,9 +31,25 @@ import 'package:telnyx_webrtc/utils/version_utils.dart';
 import 'package:uuid/uuid.dart';
 import 'package:telnyx_webrtc/model/audio_constraints.dart';
 import 'package:telnyx_webrtc/utils/call_timing_benchmark.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_factory.dart';
+import 'package:telnyx_webrtc/model/errors/media_permission_recovery.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_warning_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_codes.dart';
+
+/// Function signature for acquiring a local media stream, allowing tests to
+/// inject a deterministic `getUserMedia` implementation (web parity, VSDK-417).
+typedef GetUserMediaFn = Future<MediaStream> Function(
+  Map<String, dynamic> constraints,
+);
 
 /// Represents a peer in the WebRTC communication.
 class Peer {
+  /// Optional override for `getUserMedia`, used to exercise the media-permission
+  /// recovery flow (VSDK-417) deterministically in tests. When null the real
+  /// `navigator.mediaDevices.getUserMedia` is used.
+  @visibleForTesting
+  GetUserMediaFn? getUserMediaOverride;
+
   /// The peer connection instance.
   RTCPeerConnection? peerConnection;
 
@@ -797,18 +813,102 @@ class Peer {
   ///
   /// [media] The type of media to create (currently ignored, defaults to audio).
   /// Returns a [Future] that completes with the [MediaStream].
-  Future<MediaStream> createStream(String media) async {
+  Future<MediaStream> createStream(
+    String media, {
+    bool isAnswer = false,
+    String? callId,
+  }) async {
     GlobalLogger().i('Peer :: Creating stream');
     final Map<String, dynamic> mediaConstraints = {
       'audio': (_audioConstraints ?? AudioConstraints.enabled()).toMap(),
       'video': false,
     };
-    final MediaStream stream = await navigator.mediaDevices.getUserMedia(
-      mediaConstraints,
-    );
+    final getUserMedia =
+        getUserMediaOverride ?? navigator.mediaDevices.getUserMedia;
+    try {
+      final MediaStream stream = await getUserMedia(mediaConstraints);
+      onLocalStream?.call(stream);
+      return stream;
+    } catch (error) {
+      return _handleGetUserMediaFailure(
+        error: error,
+        getUserMedia: getUserMedia,
+        mediaConstraints: mediaConstraints,
+        isAnswer: isAnswer,
+        callId: callId ?? currentSession?.sid ?? '',
+      );
+    }
+  }
 
-    onLocalStream?.call(stream);
-    return stream;
+  /// Handles a `getUserMedia` failure with structured error classification and,
+  /// for enabled inbound-answer paths, the media-permission recovery flow
+  /// (VSDK-417). Mirrors the native [Peer] implementation for web parity.
+  Future<MediaStream> _handleGetUserMediaFailure({
+    required Object error,
+    required GetUserMediaFn getUserMedia,
+    required Map<String, dynamic> mediaConstraints,
+    required bool isAnswer,
+    required String callId,
+  }) async {
+    final int errorCode = classifyMediaErrorCode(error);
+    final recovery = _txClient.mediaPermissionsRecovery;
+
+    if (recovery != null && recovery.enabled && isAnswer) {
+      final telnyxError = createTelnyxError(
+        errorCode,
+        originalError: error,
+        fatal: false,
+      );
+      final flow = MediaPermissionRecovery.start(
+        config: recovery,
+        error: telnyxError,
+        sessionId: _txClient.sessid,
+        callId: callId,
+      );
+      _txClient.emitTelnyxMediaRecoveryError(flow.toEvent());
+
+      final result = await flow.result;
+      flow.dispose();
+
+      switch (result) {
+        case MediaRecoveryResult.resumed:
+          try {
+            final MediaStream stream = await getUserMedia(mediaConstraints);
+            onLocalStream?.call(stream);
+            recovery.onSuccess?.call();
+            return stream;
+          } catch (retryError) {
+            recovery.onError?.call(retryError);
+            _txClient.emitStructuredErrorCode(
+              classifyMediaErrorCode(retryError),
+              originalError: retryError,
+              callId: callId,
+            );
+            rethrow;
+          }
+        case MediaRecoveryResult.rejected:
+          final rejectedError = Exception(
+            'Call was rejected during media recovery flow',
+          );
+          recovery.onError?.call(rejectedError);
+          throw rejectedError;
+        case MediaRecoveryResult.timedOut:
+          final timeoutError = Exception('Media recovery flow timed out');
+          recovery.onError?.call(timeoutError);
+          throw timeoutError;
+        case MediaRecoveryResult.retryFailed:
+          final retryFailedError = Exception('Media recovery retry failed');
+          recovery.onError?.call(retryFailedError);
+          throw retryFailedError;
+      }
+    }
+
+    _txClient.emitStructuredErrorCode(
+      errorCode,
+      originalError: error,
+      callId: callId,
+    );
+    throw error;
   }
 
   /// Initializes the local and remote video renderers.
@@ -840,7 +940,11 @@ class Peer {
     if (media != 'data') {
       // Run both operations in parallel since they are independent
       final results = await Future.wait([
-        createStream(media),
+        createStream(
+          media,
+          isAnswer: direction == 'inbound',
+          callId: callId,
+        ),
         createPeerConnection(
           {
             ..._buildIceConfiguration(),
@@ -982,20 +1086,23 @@ class Peer {
             // Cancel any reconnection timer for this call
             _txClient.onCallStateChangedToActive(callId);
           case RTCIceConnectionState.RTCIceConnectionStateFailed:
-            if (_previousIceConnectionState ==
-                RTCIceConnectionState.RTCIceConnectionStateDisconnected) {
-              GlobalLogger().i(
-                'Peer :: ICE connection failed, starting renegotiation...',
-              );
-              startIceRenegotiation(callId, newSession.sid);
-              break;
-            } else {
-              GlobalLogger().d(
-                'Peer :: ICE connection failed without prior disconnection, not renegotiating',
-              );
-              break;
-            }
+            // Native/web parity (VSDK-415/416): route to the single recovery
+            // authority, which emits a structured warning and takes exactly
+            // one recovery action.
+            _txClient.handlePeerIceConnectionFailed(
+              callId,
+              afterDisconnect: _previousIceConnectionState ==
+                  RTCIceConnectionState.RTCIceConnectionStateDisconnected,
+            );
+            break;
           case RTCIceConnectionState.RTCIceConnectionStateDisconnected:
+            // Structured warning for lost ICE connectivity (VSDK-415 parity).
+            _txClient.emitWarningCode(
+              TelnyxWarningCodes.iceConnectivityLost,
+              callId: callId,
+              reason: 'ICE connectivity lost',
+              source: 'peer',
+            );
             _statsManager?.stopStatsReporting();
             return;
           default:
@@ -1010,6 +1117,11 @@ class Peer {
           currentCall?.callHandler.changeState(CallState.active);
           onCallStateChange?.call(newSession, CallState.active);
           CallTimingBenchmark.end();
+        } else if (state ==
+            RTCPeerConnectionState.RTCPeerConnectionStateFailed) {
+          // Native/web parity (VSDK-415/416): structured warning + route to
+          // the single recovery authority.
+          _txClient.handlePeerConnectionFailed(callId);
         }
       }
       ..onSignalingState = (state) {
@@ -1485,6 +1597,14 @@ class Peer {
       }
     } catch (e) {
       GlobalLogger().e('Web Peer :: Error during ICE renegotiation: $e');
+      // Native/web parity (VSDK-415/416): structured ICE-restart failure +
+      // escalate to a socket reconnect via the recovery authority.
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.iceRestartFailed,
+        originalError: e,
+        callId: callId,
+      );
+      _txClient.healthMonitor?.onIceRestartFailed(callId);
     }
   }
 

--- a/packages/telnyx_webrtc/lib/services/signaling_health_monitor.dart
+++ b/packages/telnyx_webrtc/lib/services/signaling_health_monitor.dart
@@ -39,6 +39,11 @@ abstract class ISignalingHealthSession {
 
   /// Trigger an ICE restart for the given call.
   TriggerIceRestartResult? triggerIceRestart(String? callId);
+
+  /// Send a lightweight signaling probe (a `telnyx_rtc.ping` message) so the
+  /// monitor can provoke a response and resolve "unknown" signaling health
+  /// instead of waiting passively for organic activity.
+  void sendProbe();
 }
 
 /// Monitors signaling and peer-connection health, deciding the right
@@ -57,6 +62,14 @@ abstract class ISignalingHealthSession {
 /// the last [_signalingHealthyWindow] (20 s).  When unknown, the monitor
 /// sends a lightweight probe (telnyx_rtc.ping) and waits for a response
 /// before deciding.
+///
+/// Producer status (VSDK-416): the wired production inputs today are
+/// [onSocketActivity] (every inbound message), [onPeerFailure] (ICE-failed /
+/// peer-connection-failed) and [onIceRestartFailed]. [onRequestTimeout] and
+/// [onNoRtp] are implemented event inputs that have no reliable production
+/// producer yet — see their doc comments. The "Request timeout" / "No RTP"
+/// rows above therefore describe the decision that *will* apply once such a
+/// producer exists; they are intentionally not driven by a synthesized timer.
 class SignalingHealthMonitor {
   /// Creates a monitor that inspects and controls signaling/peer health
   /// through [session].
@@ -141,10 +154,17 @@ class SignalingHealthMonitor {
 
   // ── Request timeout ────────────────────────────────────────────────
 
-  /// Called when a JSON-RPC request times out.
+  /// Event input: called when a JSON-RPC request times out.
   ///
   /// For critical methods (modify, bye, ping) when connected, triggers a
   /// full socket reconnect.
+  ///
+  /// NOTE (VSDK-416): this is a *producer-agnostic event input*. The SDK does
+  /// not currently track per-request response timeouts (requests are sent
+  /// fire-and-forget with no request-id→timer correlation), so there is no
+  /// production caller today. A future per-request timeout source can feed this
+  /// method directly without any change to the recovery logic here. Do not
+  /// synthesize an independent timer to drive it.
   void onRequestTimeout(
     String requestId,
     int timeoutMs,
@@ -179,12 +199,19 @@ class SignalingHealthMonitor {
     }
   }
 
-  /// Called when no RTP packets are received for a sustained period.
+  /// Event input: called when no RTP packets are received for a sustained
+  /// period.
   ///
   /// Same logic as [onPeerFailure]:
   /// - Healthy signaling → ICE restart.
   /// - Unknown signaling → probe and defer.
   /// - No active call → ignore.
+  ///
+  /// NOTE (VSDK-416): this is a *producer-agnostic event input*. RTP stats are
+  /// collected in production (call-report/stats reporters), but no reliable
+  /// "sustained no-inbound-RTP" event is emitted from them today, so there is
+  /// no production caller. A future RTP-stall detector can feed this method
+  /// directly. Do not synthesize an independent heuristic timer to drive it.
   void onNoRtp(String callId, String direction) {
     if (!_isRunning) return;
     if (_session.hasActiveCall() != true) return;
@@ -222,8 +249,17 @@ class SignalingHealthMonitor {
   /// signaling recovers, socket reconnect if it stays unhealthy).
   void _deferMediaRecovery(String callId) {
     _pendingMediaRecovery = callId;
-    _isProbeInFlight = true;
     _probeStartedAt = DateTime.now();
+    _startProbe();
+  }
+
+  /// Marks a probe in flight and actually sends a `telnyx_rtc.ping` so a
+  /// response can resolve "unknown" signaling health. Idempotent while a probe
+  /// is already outstanding.
+  void _startProbe() {
+    if (_isProbeInFlight) return;
+    _isProbeInFlight = true;
+    _session.sendProbe();
   }
 
   // ── Periodic check ─────────────────────────────────────────────────
@@ -257,7 +293,7 @@ class SignalingHealthMonitor {
 
     // If no socket activity for > 20s and no probe in flight, send a probe.
     if (!_isSignalingHealthy && !_isProbeInFlight) {
-      _isProbeInFlight = true;
+      _startProbe();
     }
   }
 

--- a/packages/telnyx_webrtc/lib/services/signaling_health_monitor.dart
+++ b/packages/telnyx_webrtc/lib/services/signaling_health_monitor.dart
@@ -73,9 +73,13 @@ abstract class ISignalingHealthSession {
 class SignalingHealthMonitor {
   /// Creates a monitor that inspects and controls signaling/peer health
   /// through [session].
-  SignalingHealthMonitor(this._session);
+  SignalingHealthMonitor(
+    this._session, {
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
 
   final ISignalingHealthSession _session;
+  final DateTime Function() _now;
 
   // ── Lifecycle ──────────────────────────────────────────────────────
 
@@ -120,7 +124,7 @@ class SignalingHealthMonitor {
 
   /// Call this whenever *any* inbound socket message arrives.
   void onSocketActivity() {
-    _lastInboundTimestamp = DateTime.now();
+    _lastInboundTimestamp = _now();
     // If a probe was in flight, a response has arrived — clear it.
     _isProbeInFlight = false;
   }
@@ -135,7 +139,7 @@ class SignalingHealthMonitor {
   bool get _isSignalingHealthy {
     final ts = _lastInboundTimestamp;
     if (ts == null) return false;
-    return DateTime.now().difference(ts) < _signalingHealthyWindow;
+    return _now().difference(ts) < _signalingHealthyWindow;
   }
 
   // ── Critical method classification ──────────────────────────────────
@@ -249,7 +253,7 @@ class SignalingHealthMonitor {
   /// signaling recovers, socket reconnect if it stays unhealthy).
   void _deferMediaRecovery(String callId) {
     _pendingMediaRecovery = callId;
-    _probeStartedAt = DateTime.now();
+    _probeStartedAt = _now();
     _startProbe();
   }
 
@@ -280,8 +284,7 @@ class SignalingHealthMonitor {
         return;
       }
       final startedAt = _probeStartedAt;
-      if (startedAt != null &&
-          DateTime.now().difference(startedAt) >= _probeTimeout) {
+      if (startedAt != null && _now().difference(startedAt) >= _probeTimeout) {
         // Probe window elapsed with signaling still unhealthy → reconnect.
         _clearPendingRecovery();
         _session.socketDisconnect();

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -29,7 +29,6 @@ import 'package:telnyx_webrtc/utils/codec_utils.dart';
 import 'package:telnyx_webrtc/utils/constants.dart';
 import 'package:telnyx_webrtc/utils/logging/custom_logger.dart';
 import 'package:telnyx_webrtc/utils/logging/default_logger.dart';
-import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
 import 'package:telnyx_webrtc/utils/logging/log_level.dart';
 import 'package:telnyx_webrtc/utils/preference_storage.dart';
 import 'package:telnyx_webrtc/utils/version_utils.dart';
@@ -51,12 +50,32 @@ import 'package:telnyx_webrtc/model/tx_server_configuration.dart';
 import 'package:telnyx_webrtc/model/audio_constraints.dart';
 import 'package:telnyx_webrtc/call_manager.dart';
 import 'package:telnyx_webrtc/utils/latency_tracker.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_event.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_factory.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_warning.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_warning_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_warning_factory.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_warning_event.dart';
+import 'package:telnyx_webrtc/services/signaling_health_monitor.dart';
+import 'package:telnyx_webrtc/services/reconnect_token_store.dart';
 
 /// Callback for when the socket receives a message
 typedef OnSocketMessageReceived = void Function(TelnyxMessage message);
 
 /// Callback for when the socket receives an error
 typedef OnSocketErrorReceived = void Function(TelnyxSocketError message);
+
+/// Callback for structured SDK error events (VSDK-415).
+///
+/// The [event] is either a [TelnyxErrorEvent] (non-recoverable) or a
+/// [TelnyxMediaRecoveryErrorEvent] (recoverable inbound media failure). Use
+/// [isMediaRecoveryErrorEvent] to discriminate.
+typedef OnTelnyxError = void Function(Object event);
+
+/// Callback for structured SDK warning events (VSDK-415).
+typedef OnTelnyxWarning = void Function(TelnyxWarningEvent event);
 
 /// Callback for when transcript updates occur
 typedef OnTranscriptUpdate = void Function(List<TranscriptItem> transcript);
@@ -88,6 +107,20 @@ class TelnyxClient {
 
   /// Callback for when the socket receives an error
   late OnSocketErrorReceived onSocketErrorReceived;
+
+  /// Optional callback for structured SDK error events (VSDK-415).
+  ///
+  /// Fires *alongside* the legacy [onSocketErrorReceived] — never instead of
+  /// it. Receives a [TelnyxErrorEvent] or a [TelnyxMediaRecoveryErrorEvent].
+  /// Only invoked when structured errors are enabled via
+  /// [Config.enableStructuredErrors] (default true).
+  OnTelnyxError? onTelnyxError;
+
+  /// Optional callback for structured SDK warning events (VSDK-415).
+  ///
+  /// Only invoked when structured errors are enabled via
+  /// [Config.enableStructuredErrors] (default true).
+  OnTelnyxWarning? onTelnyxWarning;
 
   /// Callback for when transcript updates occur
   /// Note: this is only relevant for Assistant AI conversations
@@ -267,6 +300,491 @@ class TelnyxClient {
         'Call $callId state changed to ACTIVE, cancelling reconnection timer',
       );
       _cancelReconnectionTimer(callId);
+    }
+    // Keep the signaling-health monitor lifecycle in sync with active calls.
+    _syncHealthMonitorLifecycle();
+    // Persist a narrow recovery marker for the current active calls.
+    _persistActiveCallsMarker();
+  }
+
+  // ── Structured error/warning surface (VSDK-415) ─────────────────────
+
+  /// Whether structured error/warning callbacks are enabled for the current
+  /// session. Set from [Config.enableStructuredErrors] during connect.
+  bool _enableStructuredErrors = true;
+
+  /// Whether the [SignalingHealthMonitor] is enabled for the current session.
+  bool _enableSignalingHealthMonitor = true;
+
+  /// The media-permission recovery configuration retained from [Config].
+  MediaPermissionsRecoveryConfig? _mediaPermissionsRecovery;
+
+  /// The media-permission recovery configuration for the current session, or
+  /// null when disabled. Consumed by the [Peer.createStream] answer path.
+  MediaPermissionsRecoveryConfig? get mediaPermissionsRecovery =>
+      _mediaPermissionsRecovery;
+
+  /// The signaling-health monitor instance, created when enabled.
+  SignalingHealthMonitor? _healthMonitor;
+
+  /// The signaling-health monitor for the current session (test/inspection).
+  SignalingHealthMonitor? get healthMonitor => _healthMonitor;
+
+  /// Captures the enable flags and recovery config from [config] at connect.
+  void _applyStructuredConfig(Config config) {
+    // A fresh connect is not an explicit logout — re-enable marker persistence.
+    _explicitDisconnectInProgress = false;
+    // Supersede any in-flight explicit-disconnect clear so it cannot erase the
+    // recovery data this new session is about to persist (VSDK-418).
+    _recoveryEpoch++;
+    _enableStructuredErrors = config.enableStructuredErrors;
+    _enableSignalingHealthMonitor = config.enableSignalingHealthMonitor;
+    _mediaPermissionsRecovery = config.mediaPermissionsRecovery;
+
+    // Instantiate the health monitor when enabled (idempotent per session).
+    if (_enableSignalingHealthMonitor) {
+      _healthMonitor ??= SignalingHealthMonitor(_TelnyxHealthSession(this));
+    } else {
+      _healthMonitor?.stop();
+      _healthMonitor = null;
+    }
+  }
+
+  /// Test seam: apply the structured-config flags/recovery from [config]
+  /// without opening a socket. Mirrors what the connect paths do.
+  @visibleForTesting
+  void applyStructuredConfigForTest(Config config) =>
+      _applyStructuredConfig(config);
+
+  /// Central helper: emit a structured [TelnyxErrorEvent] via [onTelnyxError].
+  ///
+  /// Respects the [Config.enableStructuredErrors] flag. Never throws — a
+  /// failing app callback must not break SDK internals.
+  void emitTelnyxError(TelnyxError error, {String? callId}) {
+    if (!_enableStructuredErrors) return;
+    final cb = onTelnyxError;
+    if (cb == null) return;
+    try {
+      cb(TelnyxErrorEvent(error: error, sessionId: sessid, callId: callId));
+    } catch (e) {
+      GlobalLogger().e('onTelnyxError callback threw: $e');
+    }
+  }
+
+  /// Central helper: emit a recoverable [TelnyxMediaRecoveryErrorEvent].
+  void emitTelnyxMediaRecoveryError(TelnyxMediaRecoveryErrorEvent event) {
+    if (!_enableStructuredErrors) return;
+    final cb = onTelnyxError;
+    if (cb == null) return;
+    try {
+      cb(event);
+    } catch (e) {
+      GlobalLogger().e('onTelnyxError callback threw: $e');
+    }
+  }
+
+  /// Central helper: emit a structured [TelnyxWarningEvent] via
+  /// [onTelnyxWarning]. Respects the feature flag and never throws.
+  void emitTelnyxWarning(
+    TelnyxWarning warning, {
+    String? callId,
+    String? reason,
+    String? source,
+  }) {
+    if (!_enableStructuredErrors) return;
+    final cb = onTelnyxWarning;
+    if (cb == null) return;
+    try {
+      cb(
+        TelnyxWarningEvent(
+          warning: warning,
+          reason: reason,
+          source: source,
+          sessionId: sessid,
+          callId: callId,
+        ),
+      );
+    } catch (e) {
+      GlobalLogger().e('onTelnyxWarning callback threw: $e');
+    }
+  }
+
+  /// Convenience: build a structured warning from [code] and emit it.
+  void emitWarningCode(
+    int code, {
+    String? callId,
+    String? reason,
+    String? source,
+  }) {
+    if (!_enableStructuredErrors) return;
+    emitTelnyxWarning(
+      createTelnyxWarning(code),
+      callId: callId,
+      reason: reason,
+      source: source,
+    );
+  }
+
+  /// Convenience: build a structured error from [code] and emit it.
+  void emitStructuredErrorCode(
+    int code, {
+    Object? originalError,
+    String? message,
+    bool? fatal,
+    String? callId,
+  }) {
+    emitTelnyxError(
+      createTelnyxError(
+        code,
+        originalError: originalError,
+        message: message,
+        fatal: fatal,
+      ),
+      callId: callId,
+    );
+  }
+
+  /// Maps a legacy [TelnyxSocketError] (from a server `error` message) onto a
+  /// structured error code and emits it alongside the legacy callback.
+  void _emitStructuredForSocketError(TelnyxSocketError error) {
+    if (!_enableStructuredErrors) return;
+    final int code;
+    switch (error.errorCode) {
+      case TelnyxErrorConstants.credentialErrorCode:
+        code = TelnyxErrorCodes.invalidCredentials;
+        break;
+      case TelnyxErrorConstants.tokenErrorCode:
+        code = TelnyxErrorCodes.authenticationRequired;
+        break;
+      case TelnyxErrorConstants.gatewayFailedErrorCode:
+      case TelnyxErrorConstants.gatewayTimeoutErrorCode:
+        code = TelnyxErrorCodes.gatewayFailed;
+        break;
+      default:
+        // An unrecognized server error is NOT necessarily a login failure —
+        // map it to a generic code and carry the raw server context (VSDK-415).
+        code = TelnyxErrorCodes.unexpectedError;
+    }
+    emitStructuredErrorCode(
+      code,
+      message: error.errorMessage,
+      originalError: 'server error ${error.errorCode}: ${error.errorMessage}',
+    );
+  }
+
+  // ── Signaling-health session hooks (VSDK-416) ───────────────────────
+  //
+  // TelnyxClient owns a lightweight production adapter
+  // ([_TelnyxHealthSession]) that implements [ISignalingHealthSession] and
+  // delegates to these methods. An adapter is used instead of `implements`
+  // because the interface's `isConnected` getter would collide with the
+  // long-standing public `isConnected()` method.
+
+  /// Signaling recovery authority: force a socket reconnect/reattach when
+  /// signaling is unhealthy. Never also triggers ICE restart — the monitor
+  /// guarantees exactly one recovery path.
+  void _healthSocketDisconnect() {
+    GlobalLogger().i(
+      'SignalingHealthMonitor requested socket reconnect (signaling unhealthy)',
+    );
+    emitTelnyxWarning(
+      createTelnyxWarning(TelnyxWarningCodes.signalingRecoveryRequired),
+      reason: 'Signaling unhealthy — reconnecting socket',
+      source: 'health_monitor',
+    );
+    if (_autoReconnectLogin) {
+      _reconnectToSocket();
+    } else {
+      _closeSocketSafely();
+    }
+  }
+
+  /// Media recovery authority: restart ICE for [callId] when signaling is
+  /// healthy but media has degraded.
+  TriggerIceRestartResult _healthTriggerIceRestart(String? callId) {
+    if (callId == null) {
+      return const TriggerIceRestartResult(started: false);
+    }
+    final call = calls[callId];
+    if (call == null) {
+      return const TriggerIceRestartResult(started: false);
+    }
+    emitTelnyxWarning(
+      createTelnyxWarning(TelnyxWarningCodes.mediaRecoveryRequired),
+      callId: callId,
+      reason: 'Signaling healthy, media degraded — restarting ICE',
+      source: 'health_monitor',
+    );
+    final started = call.restartIce();
+    if (!started) {
+      // Structured ICE-restart failure (VSDK-415) + escalate to a socket
+      // reconnect via the recovery authority (VSDK-416).
+      emitStructuredErrorCode(
+        TelnyxErrorCodes.iceRestartFailed,
+        message: 'ICE restart could not be started for call $callId',
+        callId: callId,
+      );
+      _healthMonitor?.onIceRestartFailed(callId);
+    }
+    return TriggerIceRestartResult(started: started);
+  }
+
+  /// Signaling probe authority: send a `telnyx_rtc.ping` on the current socket
+  /// so the [SignalingHealthMonitor] can resolve "unknown" signaling health by
+  /// provoking a response (VSDK-416). The JSON is the standard, already
+  /// supported ping request — only the SDK is now the sender.
+  void _sendSignalingProbe() {
+    try {
+      final probe = <String, dynamic>{
+        'jsonrpc': JsonRPCConstant.jsonrpc,
+        'id': const Uuid().v4(),
+        'method': SocketMethod.ping,
+        'params': <String, dynamic>{},
+      };
+      txSocket.send(jsonEncode(probe));
+    } catch (e) {
+      GlobalLogger().w('Failed to send signaling probe: $e');
+    }
+  }
+
+  /// Start the health monitor when a call becomes active; stop it when there
+  /// are no active calls. Idempotent — safe to call repeatedly.
+  void _syncHealthMonitorLifecycle() {
+    final monitor = _healthMonitor;
+    if (monitor == null) return;
+    if (activeCalls().isNotEmpty) {
+      monitor.start();
+    } else {
+      monitor.stop();
+    }
+  }
+
+  /// Single recovery authority for a peer-connection ICE failure (VSDK-416).
+  ///
+  /// Called by both the native and web [Peer] implementations so the recovery
+  /// behavior is identical across platforms. Emits a structured
+  /// `peerConnectionFailed` warning, then takes *exactly one* recovery action:
+  ///
+  /// - When the signaling-health monitor is enabled it is the sole authority —
+  ///   it decides ICE restart (healthy signaling) vs. socket reconnect
+  ///   (unhealthy). The peer must NOT also renegotiate directly.
+  /// - When the monitor is disabled, the legacy self-heal applies: a direct ICE
+  ///   restart, but only when the failure followed a disconnect
+  ///   ([afterDisconnect]).
+  void handlePeerIceConnectionFailed(
+    String callId, {
+    required bool afterDisconnect,
+  }) {
+    emitWarningCode(
+      TelnyxWarningCodes.peerConnectionFailed,
+      callId: callId,
+      reason: 'ICE connection failed',
+      source: 'peer_failure',
+    );
+    final monitor = _healthMonitor;
+    if (monitor != null) {
+      // The monitor owns recovery — it decides ICE restart vs. socket
+      // reconnect. Do NOT also renegotiate directly (would double-restart).
+      monitor.onPeerFailure(callId, PeerFailureEvidence.iceFailed);
+      return;
+    }
+    // Legacy self-heal when the monitor is disabled: direct ICE restart, but
+    // only when the failure followed a disconnect.
+    if (afterDisconnect) {
+      calls[callId]?.restartIce();
+    }
+  }
+
+  /// Single recovery authority for a peer-connection state failure (VSDK-416).
+  ///
+  /// Emits a structured `peerConnectionFailed` warning and routes the failure
+  /// to the health monitor (when enabled). Shared by native and web peers.
+  void handlePeerConnectionFailed(String callId) {
+    emitWarningCode(
+      TelnyxWarningCodes.peerConnectionFailed,
+      callId: callId,
+      reason: 'Peer connection failed',
+      source: 'peer_failure',
+    );
+    _healthMonitor?.onPeerFailure(callId, PeerFailureEvidence.connectionFailed);
+  }
+
+  // ── Reconnect / session persistence (VSDK-418) ──────────────────────
+
+  /// Whether an explicit user disconnect/logout is in progress. When true,
+  /// active-call marker persistence is suppressed so an explicit clear is not
+  /// immediately re-populated. Internal network recovery does NOT set this.
+  bool _explicitDisconnectInProgress = false;
+
+  /// Monotonic epoch bumped on every connect (in [_applyStructuredConfig]).
+  ///
+  /// An explicit disconnect captures the current epoch and hands it to
+  /// [_clearPersistedRecovery]; if a rapid subsequent connect bumps the epoch
+  /// before the (asynchronous) clear runs, the clear is superseded and skipped
+  /// so it cannot erase the new session's freshly persisted recovery data
+  /// (VSDK-418).
+  int _recoveryEpoch = 0;
+
+  /// Test-only awaitable that gates [_clearPersistedRecovery] so a deterministic
+  /// test can hold an in-flight clear open while a reconnect persists new data.
+  /// Null in production (zero overhead).
+  @visibleForTesting
+  Future<void>? recoveryClearGate;
+
+  /// The recovery marker read at startup, awaiting reattachment after login.
+  StoredActiveCalls? _pendingReattach;
+
+  /// The startup recovery marker awaiting reattachment (inspection/testing).
+  StoredActiveCalls? get pendingReattach => _pendingReattach;
+
+  /// Defensively read a fresh persisted reconnect session id for URL injection.
+  /// Returns null (leaving the URL unchanged) on any storage failure or when
+  /// nothing fresh is stored.
+  Future<String?> _resolveReconnectVoiceSdkId() async {
+    try {
+      return await ReconnectTokenStore.getReconnectSessionId();
+    } catch (e) {
+      GlobalLogger().w('Failed to read reconnect session id: $e');
+      return null;
+    }
+  }
+
+  /// Persist the server-provided voice_sdk_id, current session id, and a
+  /// timestamp after a successful registration/login (VSDK-418).
+  Future<void> _persistReconnectSession({String? voiceSdkIdOverride}) async {
+    try {
+      final serverVoiceSdkId = voiceSdkIdOverride ?? voiceSdkId;
+      if (serverVoiceSdkId != null && serverVoiceSdkId.isNotEmpty) {
+        await ReconnectTokenStore.setReconnectToken(serverVoiceSdkId);
+      }
+      await ReconnectTokenStore.setReconnectSessionId(sessid);
+    } catch (e) {
+      GlobalLogger().w('Failed to persist reconnect session: $e');
+    }
+  }
+
+  /// Test/inspection seam for [_persistReconnectSession].
+  @visibleForTesting
+  Future<void> persistReconnectSessionForTest() => _persistReconnectSession();
+
+  /// Build a narrow projection of the current active calls — only the call ID
+  /// and custom headers. Never credentials, access tokens, SDP, ICE/TURN data,
+  /// media streams, peer objects, or arbitrary call state (VSDK-418 security).
+  List<StoredActiveCall> _activeCallProjection() {
+    return activeCalls()
+        .values
+        .where((c) => c.callId != null)
+        .map(
+          (c) => StoredActiveCall(
+            id: c.callId!,
+            customHeaders: [Map<String, String>.from(c.customHeaders)],
+          ),
+        )
+        .toList();
+  }
+
+  /// Persist (or clear when empty) the active-calls recovery marker (VSDK-418).
+  void _persistActiveCallsMarker() {
+    if (_explicitDisconnectInProgress) return;
+    final projection = _activeCallProjection();
+    final currentSessid = sessid;
+    unawaited(() async {
+      try {
+        if (projection.isEmpty) {
+          await ReconnectTokenStore.clearActiveCallsRecoveryMarker();
+        } else {
+          await ReconnectTokenStore.setActiveCallsRecoveryMarker(
+            projection,
+            currentSessid,
+          );
+        }
+      } catch (e) {
+        GlobalLogger().w('Failed to persist active-calls marker: $e');
+      }
+    }());
+  }
+
+  /// Whether the cold-start recovery marker has been auto-loaded for this
+  /// client instance. Reset only by constructing a new client.
+  bool _startupRecoveryMarkerLoaded = false;
+
+  /// Auto-load the persisted active-calls recovery marker exactly once per
+  /// client lifetime (cold start), before the first registration completes.
+  ///
+  /// This makes [_attemptPendingReattach] reachable after REGED on a real
+  /// connect path without the app having to invoke
+  /// [readRecoveryMarkerAtStartup] manually (VSDK-418). Subsequent in-session
+  /// reconnects are no-ops so the client never reattaches against markers it
+  /// persisted itself during the current session.
+  Future<void> _ensureStartupRecoveryMarkerLoaded() async {
+    if (_startupRecoveryMarkerLoaded) return;
+    _startupRecoveryMarkerLoaded = true;
+    await readRecoveryMarkerAtStartup();
+  }
+
+  /// Read a fresh active-calls recovery marker at startup and stash it for a
+  /// reattachment attempt once login completes (VSDK-418).
+  Future<StoredActiveCalls?> readRecoveryMarkerAtStartup() async {
+    try {
+      _pendingReattach =
+          await ReconnectTokenStore.getActiveCallsRecoveryMarker();
+      return _pendingReattach;
+    } catch (e) {
+      GlobalLogger().w('Failed to read recovery marker at startup: $e');
+      return null;
+    }
+  }
+
+  /// Attempt reattachment for a pending startup marker after login.
+  ///
+  /// The Flutter SDK reattaches through the existing `attach_call` login flow
+  /// (see [SocketMethod.attach]); there is no bespoke Verto reattach RPC. This
+  /// method therefore correlates the persisted call IDs against the calls the
+  /// backend re-established for the current session: matched calls get their
+  /// [Call.recoveredCallId] set; unmatched calls surface a structured
+  /// `SESSION_NOT_REATTACHED` (48501) error. The stale marker is always cleared.
+  Future<void> _attemptPendingReattach() async {
+    final marker = _pendingReattach;
+    if (marker == null) return;
+    _pendingReattach = null;
+
+    for (final stored in marker.calls) {
+      final reestablished = calls[stored.id];
+      if (reestablished != null) {
+        reestablished.recoveredCallId = stored.id;
+      } else {
+        emitStructuredErrorCode(
+          TelnyxErrorCodes.sessionNotReattached,
+          message:
+              'Session/call ${stored.id} was not reattached by the backend',
+          callId: stored.id,
+        );
+      }
+    }
+
+    try {
+      await ReconnectTokenStore.clearActiveCallsRecoveryMarker();
+    } catch (e) {
+      GlobalLogger().w('Failed to clear stale recovery marker: $e');
+    }
+  }
+
+  /// Test/inspection seam for [_attemptPendingReattach].
+  @visibleForTesting
+  Future<void> attemptPendingReattachForTest() => _attemptPendingReattach();
+
+  /// Clear all persisted recovery data. Called on explicit user
+  /// disconnect/logout only — never from internal network recovery.
+  Future<void> _clearPersistedRecovery(int epoch) async {
+    try {
+      // Test-only delay hook (null in production).
+      final gate = recoveryClearGate;
+      if (gate != null) await gate;
+      // Superseded by a newer connect → skip so we don't erase its fresh data.
+      if (epoch != _recoveryEpoch) return;
+      await ReconnectTokenStore.clearAll();
+    } catch (e) {
+      GlobalLogger().w('Failed to clear persisted recovery data: $e');
     }
   }
 
@@ -1159,6 +1677,57 @@ class TelnyxClient {
     }
   }
 
+  /// Wires the [txSocket] callbacks for the given [connectionGeneration] and
+  /// opens the connection to [hostAddress]. Shared by the token and credential
+  /// connect paths. [onOpenLogin] performs the appropriate login once open;
+  /// [updateStateOnClose] preserves the historical per-path close behavior.
+  void _wireSocketAndConnect({
+    required int connectionGeneration,
+    required String hostAddress,
+    required void Function() onOpenLogin,
+    required String onOpenLogTag,
+    required bool updateStateOnClose,
+  }) {
+    txSocket.hostAddress = hostAddress;
+    _socketHost = hostAddress; // Store for call report endpoint
+    GlobalLogger().i('connecting to WebSocket $hostAddress');
+    txSocket
+      ..onOpen = () {
+        if (!_isActiveConnectionGeneration(connectionGeneration)) {
+          return;
+        }
+        _closed = false;
+        _updateConnectionState(true);
+        _isRegionFallbackAttempt =
+            false; // Reset fallback flag on successful connection
+        GlobalLogger().i('$onOpenLogTag (via _onOpen): Web Socket is now '
+            'connected');
+        latencyTracker.markRegistrationMilestone(
+          LatencyTracker.milestoneSocketConnected,
+        );
+        _onOpen();
+        onOpenLogin();
+      }
+      ..onMessage = (dynamic data) {
+        if (!_isActiveConnectionGeneration(connectionGeneration)) return;
+        _onMessage(data);
+      }
+      ..onClose = (int closeCode, String closeReason) {
+        if (!_isActiveConnectionGeneration(connectionGeneration)) return;
+        GlobalLogger().i('Closed [$closeCode, $closeReason]!');
+        if (updateStateOnClose) {
+          _updateConnectionState(false);
+        }
+        final wasClean = WebSocketUtils.isCleanClose(closeCode, closeReason);
+        _onClose(wasClean, closeCode, closeReason);
+      }
+      ..onPing = (SocketConnectionMetrics metrics) {
+        if (!_isActiveConnectionGeneration(connectionGeneration)) return;
+        onConnectionMetricsUpdate?.call(metrics);
+      }
+      ..connect();
+  }
+
   /// Connects to the WebSocket using the provided [tokenConfig]
   void connectWithToken(TokenConfig tokenConfig) {
     if (!_prepareForConnection()) return;
@@ -1166,6 +1735,10 @@ class TelnyxClient {
 
     // Store current config for potential fallback
     _currentConfig = tokenConfig;
+    _applyStructuredConfig(tokenConfig);
+    // Auto-load the cold-start recovery marker so reattach can fire after REGED
+    // without the app calling readRecoveryMarkerAtStartup manually (VSDK-418).
+    unawaited(_ensureStartupRecoveryMarkerLoaded());
 
     // Start registration latency tracking
     latencyTracker.startRegistrationTracking();
@@ -1183,55 +1756,36 @@ class TelnyxClient {
         LogLevel.info,
         'connecting to WebSocket $_serverConfiguration.socketUrl',
       );
-    try {
-      // Build the host address with region support
-      final hostAddress = _buildHostAddress(
-        tokenConfig,
-        voiceSdkId: _pushMetaData?.voiceSdkId,
-      );
-
-      txSocket.hostAddress = hostAddress;
-      _socketHost = hostAddress; // Store for call report endpoint
-      GlobalLogger().i('connecting to WebSocket $hostAddress');
-      txSocket
-        ..onOpen = () {
-          if (!_isActiveConnectionGeneration(connectionGeneration)) {
-            return;
-          }
-          _closed = false;
-          _updateConnectionState(true);
-          _isRegionFallbackAttempt =
-              false; // Reset fallback flag on successful connection
-          GlobalLogger().i(
-            'TelnyxClient.connectWithToken (via _onOpen): Web Socket is now connected',
-          );
-          latencyTracker.markRegistrationMilestone(
-            LatencyTracker.milestoneSocketConnected,
-          );
-          _onOpen();
-          tokenLogin(tokenConfig);
-        }
-        ..onMessage = (dynamic data) {
-          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
-          _onMessage(data);
-        }
-        ..onClose = (int closeCode, String closeReason) {
-          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
-          GlobalLogger().i('Closed [$closeCode, $closeReason]!');
-          _updateConnectionState(false);
-          final wasClean = WebSocketUtils.isCleanClose(closeCode, closeReason);
-          _onClose(wasClean, closeCode, closeReason);
-        }
-        ..onPing = (SocketConnectionMetrics metrics) {
-          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
-          onConnectionMetricsUpdate?.call(metrics);
-        }
-        ..connect();
-    } catch (e) {
-      GlobalLogger().e(e.toString());
-      _updateConnectionState(false);
-      GlobalLogger().e('WebSocket $_serverConfiguration.socketUrl error: $e');
-    }
+    // Defensively read a fresh persisted reconnect session id (VSDK-418) and
+    // inject it as voice_sdk_id before the initial connection. Push metadata
+    // takes precedence; a missing/failed read leaves the URL unchanged.
+    unawaited(() async {
+      final resolvedVoiceSdkId =
+          _pushMetaData?.voiceSdkId ?? await _resolveReconnectVoiceSdkId();
+      if (!_isActiveConnectionGeneration(connectionGeneration)) return;
+      try {
+        final hostAddress = _buildHostAddress(
+          tokenConfig,
+          voiceSdkId: resolvedVoiceSdkId,
+        );
+        _wireSocketAndConnect(
+          connectionGeneration: connectionGeneration,
+          hostAddress: hostAddress,
+          onOpenLogin: () => tokenLogin(tokenConfig),
+          onOpenLogTag: 'TelnyxClient.connectWithToken',
+          updateStateOnClose: true,
+        );
+      } catch (e) {
+        GlobalLogger().e(e.toString());
+        _updateConnectionState(false);
+        GlobalLogger().e('WebSocket $_serverConfiguration.socketUrl error: $e');
+        // Structured WebSocket connect failure (VSDK-415).
+        emitStructuredErrorCode(
+          TelnyxErrorCodes.webSocketConnectionFailed,
+          originalError: e,
+        );
+      }
+    }());
   }
 
   /// Connects to the WebSocket using the provided [CredentialConfig]
@@ -1241,6 +1795,10 @@ class TelnyxClient {
 
     // Store current config for potential fallback
     _currentConfig = credentialConfig;
+    _applyStructuredConfig(credentialConfig);
+    // Auto-load the cold-start recovery marker so reattach can fire after REGED
+    // without the app calling readRecoveryMarkerAtStartup manually (VSDK-418).
+    unawaited(_ensureStartupRecoveryMarkerLoaded());
 
     // Start registration latency tracking
     latencyTracker.startRegistrationTracking();
@@ -1257,57 +1815,36 @@ class TelnyxClient {
     _logger
       ..setLogLevel(credentialConfig.logLevel)
       ..log(LogLevel.info, 'connect()');
-    try {
-      // Build the host address with region support
-      final hostAddress = _buildHostAddress(
-        credentialConfig,
-        voiceSdkId: _pushMetaData?.voiceSdkId,
-      );
-
-      txSocket.hostAddress = hostAddress;
-      _socketHost = hostAddress; // Store for call report endpoint
-      GlobalLogger().i('connecting to WebSocket $hostAddress');
-      txSocket
-        ..onOpen = () {
-          if (!_isActiveConnectionGeneration(connectionGeneration)) {
-            return;
-          }
-          _closed = false;
-          _updateConnectionState(true);
-          _isRegionFallbackAttempt =
-              false; // Reset fallback flag on successful connection
-          GlobalLogger().i(
-            'TelnyxClient.connectWithCredential (via _onOpen): Web Socket is now connected',
-          );
-          latencyTracker.markRegistrationMilestone(
-            LatencyTracker.milestoneSocketConnected,
-          );
-          _onOpen();
-          credentialLogin(credentialConfig);
-        }
-        ..onMessage = (dynamic data) {
-          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
-          _onMessage(data);
-        }
-        ..onClose = (int closeCode, String closeReason) {
-          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
-          GlobalLogger().i('Closed [$closeCode, $closeReason]!');
-          final bool wasClean = WebSocketUtils.isCleanClose(
-            closeCode,
-            closeReason,
-          );
-          _onClose(wasClean, closeCode, closeReason);
-        }
-        ..onPing = (SocketConnectionMetrics metrics) {
-          if (!_isActiveConnectionGeneration(connectionGeneration)) return;
-          onConnectionMetricsUpdate?.call(metrics);
-        }
-        ..connect();
-    } catch (e) {
-      GlobalLogger().e(e.toString());
-      _updateConnectionState(false);
-      GlobalLogger().e('WebSocket $_serverConfiguration.socketUrl error: $e');
-    }
+    // Defensively read a fresh persisted reconnect session id (VSDK-418) and
+    // inject it as voice_sdk_id before the initial connection. Push metadata
+    // takes precedence; a missing/failed read leaves the URL unchanged.
+    unawaited(() async {
+      final resolvedVoiceSdkId =
+          _pushMetaData?.voiceSdkId ?? await _resolveReconnectVoiceSdkId();
+      if (!_isActiveConnectionGeneration(connectionGeneration)) return;
+      try {
+        final hostAddress = _buildHostAddress(
+          credentialConfig,
+          voiceSdkId: resolvedVoiceSdkId,
+        );
+        _wireSocketAndConnect(
+          connectionGeneration: connectionGeneration,
+          hostAddress: hostAddress,
+          onOpenLogin: () => credentialLogin(credentialConfig),
+          onOpenLogTag: 'TelnyxClient.connectWithCredential',
+          updateStateOnClose: false,
+        );
+      } catch (e) {
+        GlobalLogger().e(e.toString());
+        _updateConnectionState(false);
+        GlobalLogger().e('WebSocket $_serverConfiguration.socketUrl error: $e');
+        // Structured WebSocket connect failure (VSDK-415).
+        emitStructuredErrorCode(
+          TelnyxErrorCodes.webSocketConnectionFailed,
+          originalError: e,
+        );
+      }
+    }());
   }
 
   @Deprecated(
@@ -1325,6 +1862,13 @@ class TelnyxClient {
     }
     if (!_prepareForConnection()) return;
     final connectionGeneration = _connectionGeneration;
+
+    // Reapply the structured-error / health-monitor / media-recovery config
+    // from the stored config so a bare reconnect stays consistent with the
+    // last connectWith* call (VSDK-415/416/418).
+    if (_currentConfig != null) {
+      _applyStructuredConfig(_currentConfig!);
+    }
 
     GlobalLogger().i('connecting to WebSocket $_serverConfiguration.socketUrl');
     try {
@@ -1812,8 +2356,9 @@ class TelnyxClient {
     inviteCall.callHandler.changeState(CallState.newCall);
 
     // Register the outbound call with CallManager and set as current.
-    callManager.registerCall(inviteCall);
-    callManager.setCurrentCall(inviteCall);
+    callManager
+      ..registerCall(inviteCall)
+      ..setCurrentCall(inviteCall);
 
     return inviteCall;
   }
@@ -1866,12 +2411,13 @@ class TelnyxClient {
     final destinationNum = invite.callerIdNumber;
 
     // Start latency tracking for inbound call
-    latencyTracker.startCallTracking(
-      answerCall.callId!,
-      isOutbound: false,
-      useTrickleIce: useTrickleIce,
-    );
-    latencyTracker.markAnswerInitiated(answerCall.callId!);
+    latencyTracker
+      ..startCallTracking(
+        answerCall.callId!,
+        isOutbound: false,
+        useTrickleIce: useTrickleIce,
+      )
+      ..markAnswerInitiated(answerCall.callId!);
 
     // Create the peer connection
     answerCall.peerConnection = Peer(
@@ -1918,8 +2464,9 @@ class TelnyxClient {
     // Register the accepted call with CallManager and set it as the current
     // active call. If there was a previous currentCall it should already have
     // been put on hold by holdCurrentAndAcceptIncoming before this point.
-    callManager.registerCall(answerCall);
-    callManager.setCurrentCall(answerCall);
+    callManager
+      ..registerCall(answerCall)
+      ..setCurrentCall(answerCall);
 
     clearPushMetaData();
     return answerCall;
@@ -2073,6 +2620,11 @@ class TelnyxClient {
     _cancelConnectivitySubscription();
     clearPushMetaData();
     GlobalLogger().i('disconnect()');
+    // Explicit user disconnect/logout clears all persisted recovery data
+    // (VSDK-418) and stops the signaling-health monitor (VSDK-416).
+    _explicitDisconnectInProgress = true;
+    _healthMonitor?.stop();
+    unawaited(_clearPersistedRecovery(_recoveryEpoch));
     if (_closed) {
       GlobalLogger().i('WebSocket is already closed');
       closeCallback?.call(0, 'Client send disconnect');
@@ -2101,6 +2653,11 @@ class TelnyxClient {
     _cancelConnectivitySubscription();
     clearPushMetaData();
     GlobalLogger().i('disconnect()');
+    // Explicit user disconnect/logout clears all persisted recovery data
+    // (VSDK-418) and stops the signaling-health monitor (VSDK-416).
+    _explicitDisconnectInProgress = true;
+    _healthMonitor?.stop();
+    unawaited(_clearPersistedRecovery(_recoveryEpoch));
     if (_closed) return;
     // Don't wait for the WebSocket 'close' event, do it now.
     _closed = true;
@@ -2118,6 +2675,7 @@ class TelnyxClient {
     final shouldCloseSocket = !_closed;
     _disposed = true;
     _closed = true;
+    _healthMonitor?.stop();
     _invalidateConnectionGeneration();
     _invalidateGatewayResponseTimer();
     _resetGatewayCounters();
@@ -2148,6 +2706,11 @@ class TelnyxClient {
     GlobalLogger().i('WebSocket closed');
     if (wasClean == false) {
       GlobalLogger().i('WebSocket abrupt disconnection');
+      // Structured (non-fatal) WebSocket runtime error (VSDK-415).
+      emitStructuredErrorCode(
+        TelnyxErrorCodes.webSocketError,
+        message: 'WebSocket closed unexpectedly [$code, $reason]',
+      );
     }
 
     // Handle region fallback if connection failed and fallback is enabled
@@ -2219,6 +2782,9 @@ class TelnyxClient {
   void _onMessage(dynamic data) async {
     if (_isTornDown) return;
 
+    // Every inbound WebSocket message is signaling-health activity (VSDK-416).
+    _healthMonitor?.onSocketActivity();
+
     GlobalLogger().i(
       'TelnyxClient._onMessage: RAW WebSocket data received: ${data?.toString().trim()}',
     );
@@ -2245,6 +2811,8 @@ class TelnyxClient {
               errorMessage: errorResult.error?.errorMessage ?? 'Unknown error',
             );
             onSocketErrorReceived.call(error);
+            // Structured error alongside the legacy callback (VSDK-415).
+            _emitStructuredForSocketError(error);
           } else if (messageJson.containsKey('result')) {
             final paramJson = jsonEncode(messageJson);
             _logger.log(
@@ -2285,6 +2853,10 @@ class TelnyxClient {
                         );
                       }
                       _waitingForReg = false;
+                      // Capture the server-provided voice_sdk_id *before* the
+                      // push-driven path clears _pushMetaData below, otherwise
+                      // the reconnect token would be lost (VSDK-418).
+                      final registeredVoiceSdkId = voiceSdkId;
                       final message = TelnyxMessage(
                         socketMethod: SocketMethod.clientReady,
                         message: mainMessage,
@@ -2320,6 +2892,16 @@ class TelnyxClient {
                       }
                       _registered = true;
                       _updateConnectionStatus();
+
+                      // Persist reconnect session identifiers and attempt any
+                      // pending startup reattachment (VSDK-418). The captured
+                      // voice_sdk_id survives the push-path clear above.
+                      unawaited(
+                        _persistReconnectSession(
+                          voiceSdkIdOverride: registeredVoiceSdkId,
+                        ),
+                      );
+                      unawaited(_attemptPendingReattach());
                     }
                     break;
                   }
@@ -2345,6 +2927,11 @@ class TelnyxClient {
                         errorMessage: TelnyxErrorConstants.gatewayFailedError,
                       );
                       onSocketErrorReceived(error);
+                      // Structured error alongside legacy callback (VSDK-415).
+                      emitStructuredErrorCode(
+                        TelnyxErrorCodes.gatewayFailed,
+                        message: TelnyxErrorConstants.gatewayFailedError,
+                      );
                     }
                     break;
                   }
@@ -2365,12 +2952,18 @@ class TelnyxClient {
                       _attemptReconnection();
                     } else {
                       _invalidateGatewayResponseTimer();
+                      const failWaitMessage =
+                          'Gateway registration has received fail wait response';
                       final error = TelnyxSocketError(
                         errorCode: TelnyxErrorConstants.gatewayFailedErrorCode,
-                        errorMessage:
-                            'Gateway registration has received fail wait response',
+                        errorMessage: failWaitMessage,
                       );
                       onSocketErrorReceived(error);
+                      // Structured error alongside legacy callback (VSDK-415).
+                      emitStructuredErrorCode(
+                        TelnyxErrorCodes.gatewayFailed,
+                        message: failWaitMessage,
+                      );
                     }
                     break;
                   }
@@ -2535,11 +3128,12 @@ class TelnyxClient {
 
                   // Mark invite received for latency tracking
                   if (offerCall.callId != null) {
-                    latencyTracker.startCallTracking(
-                      offerCall.callId!,
-                      isOutbound: false,
-                    );
-                    latencyTracker.markInviteReceived(offerCall.callId!);
+                    latencyTracker
+                      ..startCallTracking(
+                        offerCall.callId!,
+                        isOutbound: false,
+                      )
+                      ..markInviteReceived(offerCall.callId!);
                   }
 
                   onSocketMessageReceived.call(message);
@@ -2675,11 +3269,12 @@ class TelnyxClient {
 
                   // Mark latency milestones for answer received
                   if (answerCall.callId != null) {
-                    latencyTracker.markCallMilestone(
-                      answerCall.callId!,
-                      LatencyTracker.milestoneRemoteSdpReceived,
-                    );
-                    latencyTracker.markCallAnsweredByRemote(answerCall.callId!);
+                    latencyTracker
+                      ..markCallMilestone(
+                        answerCall.callId!,
+                        LatencyTracker.milestoneRemoteSdpReceived,
+                      )
+                      ..markCallAnsweredByRemote(answerCall.callId!);
                   }
 
                   final message = TelnyxMessage(
@@ -3118,6 +3713,11 @@ class TelnyxClient {
         errorMessage: 'Maximum reconnection attempts reached',
       );
       onSocketErrorReceived(error);
+      // Structured error alongside legacy callback (VSDK-415).
+      emitStructuredErrorCode(
+        TelnyxErrorCodes.reconnectionExhausted,
+        message: 'Maximum reconnection attempts reached',
+      );
       return;
     }
 
@@ -3162,4 +3762,29 @@ class TelnyxClient {
   SocketConnectionMetrics getConnectionMetrics() {
     return txSocket.getConnectionMetrics();
   }
+}
+
+/// Production adapter that exposes a [TelnyxClient] to the
+/// [SignalingHealthMonitor] via the [ISignalingHealthSession] interface
+/// (VSDK-416). Owned by the client; delegates every call back to it.
+class _TelnyxHealthSession implements ISignalingHealthSession {
+  _TelnyxHealthSession(this._client);
+
+  final TelnyxClient _client;
+
+  @override
+  bool? get isConnected => _client.isConnected();
+
+  @override
+  bool? hasActiveCall() => _client.activeCalls().isNotEmpty;
+
+  @override
+  void socketDisconnect() => _client._healthSocketDisconnect();
+
+  @override
+  TriggerIceRestartResult? triggerIceRestart(String? callId) =>
+      _client._healthTriggerIceRestart(callId);
+
+  @override
+  void sendProbe() => _client._sendSignalingProbe();
 }

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -330,6 +330,10 @@ class TelnyxClient {
   /// The signaling-health monitor for the current session (test/inspection).
   SignalingHealthMonitor? get healthMonitor => _healthMonitor;
 
+  /// The reconnect policy currently applied to health-triggered recovery.
+  @visibleForTesting
+  bool get autoReconnectLoginForTest => _autoReconnectLogin;
+
   /// Captures the enable flags and recovery config from [config] at connect.
   void _applyStructuredConfig(Config config) {
     // A fresh connect is not an explicit logout — re-enable marker persistence.
@@ -341,12 +345,28 @@ class TelnyxClient {
     _enableSignalingHealthMonitor = config.enableSignalingHealthMonitor;
     _mediaPermissionsRecovery = config.mediaPermissionsRecovery;
 
+    // Apply autoReconnect immediately (?? true) so the health monitor and
+    // reconnect logic never read a prior session's stale value before the
+    // login message is sent (VSDK-415/416 adversarial hardening).
+    _autoReconnectLogin = config.autoReconnect ?? true;
+
     // Instantiate the health monitor when enabled (idempotent per session).
     if (_enableSignalingHealthMonitor) {
       _healthMonitor ??= SignalingHealthMonitor(_TelnyxHealthSession(this));
     } else {
       _healthMonitor?.stop();
       _healthMonitor = null;
+    }
+
+    // Reset health-monitor transient state on every fresh/reconnect config
+    // application so no pending/probe state from a prior session survives a
+    // reconnect. Stop clears all transient state (probe-in-flight, pending
+    // media recovery, last-inbound timestamp), then lifecycle sync restarts it
+    // only when an initialized active call exists.
+    final monitor = _healthMonitor;
+    if (monitor != null) {
+      monitor.stop();
+      _syncHealthMonitorLifecycle();
     }
   }
 
@@ -355,6 +375,13 @@ class TelnyxClient {
   @visibleForTesting
   void applyStructuredConfigForTest(Config config) =>
       _applyStructuredConfig(config);
+
+  /// Test seam: build a copy of [config] with the region changed to
+  /// [Region.auto], preserving every other Config option. Mirrors the
+  /// region-fallback path in [_onClose].
+  @visibleForTesting
+  Config copyConfigWithAutoRegionForTest(Config config) =>
+      _copyConfigWithAutoRegion(config);
 
   /// Central helper: emit a structured [TelnyxErrorEvent] via [onTelnyxError].
   ///
@@ -2713,7 +2740,11 @@ class TelnyxClient {
       );
     }
 
-    // Handle region fallback if connection failed and fallback is enabled
+    // Handle region fallback if connection failed and fallback is enabled.
+    // Uses a typed copy helper to preserve *every* Config option from the
+    // current config, only changing the region to Region.auto. This prevents
+    // silent option loss (e.g. enableStructuredErrors, ICE servers, timeouts)
+    // that the prior hand-written constructors dropped (VSDK-415/416 B1).
     if (!wasClean &&
         _currentConfig != null &&
         _currentConfig!.region != Region.auto &&
@@ -2724,59 +2755,123 @@ class TelnyxClient {
       );
       _isRegionFallbackAttempt = true;
 
-      // Create a fallback config with auto region
-      Config fallbackConfig;
-      if (_currentConfig is TokenConfig) {
-        final tokenConfig = _currentConfig as TokenConfig;
-        fallbackConfig = TokenConfig(
-          sipToken: tokenConfig.sipToken,
-          sipCallerIDName: tokenConfig.sipCallerIDName,
-          sipCallerIDNumber: tokenConfig.sipCallerIDNumber,
-          notificationToken: tokenConfig.notificationToken,
-          region: Region.auto,
-          // Force auto region for fallback
-          fallbackOnRegionFailure: tokenConfig.fallbackOnRegionFailure,
-          logLevel: tokenConfig.logLevel,
-          customLogger: tokenConfig.customLogger,
-          reconnectionTimeout: tokenConfig.reconnectionTimeout,
-          debug: tokenConfig.debug,
-        );
+      // Capture the auto-region fallback config NOW, before scheduling, so the
+      // timer callback does not dereference the mutable _currentConfig field
+      // (which may be reassigned by a concurrent connect/disconnect before the
+      // timer fires). A captured immutable copy is race-free (VSDK-415/416).
+      final fallbackConfig = _copyConfigWithAutoRegion(_currentConfig!);
 
-        // Retry connection with auto region
-        _scheduleConnectionTimer(
-          const Duration(milliseconds: 1000),
-          () {
-            connectWithToken(fallbackConfig as TokenConfig);
-          },
-          generation: connectionGeneration,
-        );
-      } else if (_currentConfig is CredentialConfig) {
-        final credConfig = _currentConfig as CredentialConfig;
-        fallbackConfig = CredentialConfig(
-          sipUser: credConfig.sipUser,
-          sipPassword: credConfig.sipPassword,
-          sipCallerIDName: credConfig.sipCallerIDName,
-          sipCallerIDNumber: credConfig.sipCallerIDNumber,
-          notificationToken: credConfig.notificationToken,
-          region: Region.auto,
-          // Force auto region for fallback
-          fallbackOnRegionFailure: credConfig.fallbackOnRegionFailure,
-          logLevel: credConfig.logLevel,
-          customLogger: credConfig.customLogger,
-          reconnectionTimeout: credConfig.reconnectionTimeout,
-          debug: credConfig.debug,
-        );
-
-        // Retry connection with auto region
-        _scheduleConnectionTimer(
-          const Duration(milliseconds: 1000),
-          () {
-            connectWithCredential(fallbackConfig as CredentialConfig);
-          },
-          generation: connectionGeneration,
-        );
-      }
+      // Retry connection with the auto-region copy after a short delay.
+      _scheduleConnectionTimer(
+        const Duration(milliseconds: 1000),
+        () {
+          if (fallbackConfig is TokenConfig) {
+            connectWithToken(fallbackConfig);
+          } else if (fallbackConfig is CredentialConfig) {
+            connectWithCredential(fallbackConfig);
+          }
+        },
+        generation: connectionGeneration,
+      );
     }
+  }
+
+  /// Build a copy of [config] with the region changed to [Region.auto],
+  /// preserving every other Config option exactly.
+  ///
+  /// Used by the region-fallback path in [_onClose] so no option is silently
+  /// dropped. A single typed helper prevents omissions that a hand-written
+  /// constructor list would be prone to (VSDK-415/416 B1).
+  Config _copyConfigWithAutoRegion(Config config) {
+    if (config is TokenConfig) {
+      return _copyTokenConfigWithRegion(config, Region.auto);
+    } else if (config is CredentialConfig) {
+      return _copyCredentialConfigWithRegion(config, Region.auto);
+    }
+    // Unreachable for the two concrete Config subclasses in use; defensive.
+    return config;
+  }
+
+  /// Copies a [TokenConfig] preserving every field except [region].
+  TokenConfig _copyTokenConfigWithRegion(
+    TokenConfig c,
+    Region region,
+  ) {
+    return TokenConfig(
+      sipToken: c.sipToken,
+      sipCallerIDName: c.sipCallerIDName,
+      sipCallerIDNumber: c.sipCallerIDNumber,
+      notificationToken: c.notificationToken,
+      autoReconnect: c.autoReconnect,
+      logLevel: c.logLevel,
+      debug: c.debug,
+      ringTonePath: c.ringTonePath,
+      ringbackPath: c.ringbackPath,
+      customLogger: c.customLogger,
+      reconnectionTimeout: c.reconnectionTimeout,
+      pushAnswerTimeout: c.pushAnswerTimeout,
+      region: region,
+      fallbackOnRegionFailure: c.fallbackOnRegionFailure,
+      forceRelayCandidate: c.forceRelayCandidate,
+      iceServers: c.iceServers,
+      serverConfiguration: c.serverConfiguration,
+      callReportInterval: c.callReportInterval,
+      callReportLogLevel: c.callReportLogLevel,
+      callReportMaxLogEntries: c.callReportMaxLogEntries,
+      enableCallReports: c.enableCallReports,
+      debugOutput: c.debugOutput,
+      debugLogLevel: c.debugLogLevel,
+      debugLogMaxEntries: c.debugLogMaxEntries,
+      callReportFlushInterval: c.callReportFlushInterval,
+      prefetchIceCandidates: c.prefetchIceCandidates,
+      autoRecoverCalls: c.autoRecoverCalls,
+      hangupOnBeforeUnload: c.hangupOnBeforeUnload,
+      maxReconnectAttempts: c.maxReconnectAttempts,
+      enableStructuredErrors: c.enableStructuredErrors,
+      enableSignalingHealthMonitor: c.enableSignalingHealthMonitor,
+      mediaPermissionsRecovery: c.mediaPermissionsRecovery,
+    );
+  }
+
+  CredentialConfig _copyCredentialConfigWithRegion(
+    CredentialConfig c,
+    Region region,
+  ) {
+    return CredentialConfig(
+      sipUser: c.sipUser,
+      sipPassword: c.sipPassword,
+      sipCallerIDName: c.sipCallerIDName,
+      sipCallerIDNumber: c.sipCallerIDNumber,
+      notificationToken: c.notificationToken,
+      autoReconnect: c.autoReconnect,
+      logLevel: c.logLevel,
+      debug: c.debug,
+      ringTonePath: c.ringTonePath,
+      ringbackPath: c.ringbackPath,
+      customLogger: c.customLogger,
+      reconnectionTimeout: c.reconnectionTimeout,
+      pushAnswerTimeout: c.pushAnswerTimeout,
+      region: region,
+      fallbackOnRegionFailure: c.fallbackOnRegionFailure,
+      forceRelayCandidate: c.forceRelayCandidate,
+      iceServers: c.iceServers,
+      serverConfiguration: c.serverConfiguration,
+      callReportInterval: c.callReportInterval,
+      callReportLogLevel: c.callReportLogLevel,
+      callReportMaxLogEntries: c.callReportMaxLogEntries,
+      enableCallReports: c.enableCallReports,
+      debugOutput: c.debugOutput,
+      debugLogLevel: c.debugLogLevel,
+      debugLogMaxEntries: c.debugLogMaxEntries,
+      callReportFlushInterval: c.callReportFlushInterval,
+      prefetchIceCandidates: c.prefetchIceCandidates,
+      autoRecoverCalls: c.autoRecoverCalls,
+      hangupOnBeforeUnload: c.hangupOnBeforeUnload,
+      maxReconnectAttempts: c.maxReconnectAttempts,
+      enableStructuredErrors: c.enableStructuredErrors,
+      enableSignalingHealthMonitor: c.enableSignalingHealthMonitor,
+      mediaPermissionsRecovery: c.mediaPermissionsRecovery,
+    );
   }
 
   void _onMessage(dynamic data) async {

--- a/packages/telnyx_webrtc/test/peer/media_permission_recovery_test.dart
+++ b/packages/telnyx_webrtc/test/peer/media_permission_recovery_test.dart
@@ -1,103 +1,230 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_event.dart';
+import 'package:telnyx_webrtc/peer/peer.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/tx_socket.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+
+class _FakeMediaStream extends Fake implements MediaStream {}
+
+CredentialConfig _config({
+  bool recoveryEnabled = true,
+  int timeout = 25000,
+  void Function()? onSuccess,
+  void Function(Object error)? onError,
+  bool enableStructuredErrors = true,
+}) {
+  return CredentialConfig(
+    sipUser: 'user',
+    sipPassword: 'pass',
+    sipCallerIDName: 'name',
+    sipCallerIDNumber: 'number',
+    logLevel: LogLevel.none,
+    debug: false,
+    enableStructuredErrors: enableStructuredErrors,
+    enableSignalingHealthMonitor: false,
+    mediaPermissionsRecovery: MediaPermissionsRecoveryConfig(
+      enabled: recoveryEnabled,
+      timeout: timeout,
+      onSuccess: onSuccess,
+      onError: onError,
+    ),
+  );
+}
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late TelnyxClient client;
+  late Peer peer;
+  late List<Object> capturedErrors;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    capturedErrors = <Object>[];
+    client = TelnyxClient(connectivityChanges: () => const Stream.empty())
+      ..onTelnyxError = capturedErrors.add;
+    peer = Peer(TxSocket('wss://example.test'), false, client, false, false);
+  });
+
+  tearDown(() => client.dispose());
+
+  PlatformException permissionError() =>
+      PlatformException(code: 'NotAllowedError', message: 'permission denied');
+
   group('VSDK-417: Media permission recovery in Peer.createStream', () {
-    // These tests describe the expected behavior of the media permission
-    // recovery flow when integrated into Peer.createStream().
-    // They serve as TDD tests for the implementation.
-
     test(
-        'createStream with recovery enabled and isAnswer=true emits '
-        'TelnyxMediaRecoveryErrorEvent on getUserMedia failure', () {
-      // This test documents the contract: when getUserMedia fails during
-      // an inbound call answer with recovery enabled, the SDK must emit
-      // a TelnyxMediaRecoveryErrorEvent (not a standard error event).
-      // The event must have recoverable: true, resume(), reject(),
-      // and retryDeadline.
-      //
-      // Implementation must:
-      // 1. Check if recovery is enabled and isAnswer == true
-      // 2. Classify the media error via classifyMediaErrorCode()
-      // 3. Create TelnyxError with fatal: false (override)
-      // 4. Emit TelnyxMediaRecoveryErrorEvent with resume/reject callbacks
+        'recovery enabled + isAnswer=true emits recoverable '
+        'TelnyxMediaRecoveryErrorEvent on getUserMedia failure', () async {
+      client.applyStructuredConfigForTest(_config());
+      peer.getUserMediaOverride = (_) async => throw permissionError();
+
+      final future = peer.createStream('audio', isAnswer: true, callId: 'c1');
+      // Swallow the eventual failure — we assert on the emitted event.
+      unawaited(future.catchError((_) => _FakeMediaStream()));
+      await pumpEventQueue();
+
+      expect(capturedErrors, hasLength(1));
+      final event = capturedErrors.single;
+      expect(event, isA<TelnyxMediaRecoveryErrorEvent>());
+      final recovery = event as TelnyxMediaRecoveryErrorEvent;
+      expect(recovery.recoverable, isTrue);
+      expect(recovery.callId, 'c1');
       expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires Peer integration',
+        recovery.error.code,
+        TelnyxErrorCodes.mediaMicrophonePermissionDenied,
+      );
+      expect(
+        recovery.error.fatal,
+        isFalse,
+        reason: 'recovery active => non-fatal override',
+      );
+      expect(
+        recovery.retryDeadline,
+        greaterThan(DateTime.now().millisecondsSinceEpoch),
+      );
+
+      await recovery.reject();
+      await expectLater(future, throwsA(anything));
+    });
+
+    test('resume() retries getUserMedia, returns stream, invokes onSuccess',
+        () async {
+      var successCalls = 0;
+      client.applyStructuredConfigForTest(
+        _config(onSuccess: () => successCalls++),
+      );
+      final fakeStream = _FakeMediaStream();
+      var attempts = 0;
+      peer.getUserMediaOverride = (_) async {
+        attempts++;
+        if (attempts == 1) throw permissionError();
+        return fakeStream;
+      };
+
+      final future = peer.createStream('audio', isAnswer: true, callId: 'c1');
+      await pumpEventQueue();
+      final recovery = capturedErrors.single as TelnyxMediaRecoveryErrorEvent;
+
+      await recovery.resume();
+      final stream = await future;
+
+      expect(stream, same(fakeStream));
+      expect(successCalls, 1);
+      expect(attempts, 2);
+    });
+
+    test('reject() invokes onError exactly once and propagates failure',
+        () async {
+      final errors = <Object>[];
+      client.applyStructuredConfigForTest(_config(onError: errors.add));
+      peer.getUserMediaOverride = (_) async => throw permissionError();
+
+      final future = peer.createStream('audio', isAnswer: true, callId: 'c1');
+      unawaited(future.catchError((_) => _FakeMediaStream()));
+      await pumpEventQueue();
+      final recovery = capturedErrors.single as TelnyxMediaRecoveryErrorEvent;
+
+      await recovery.reject();
+      await expectLater(future, throwsA(anything));
+      expect(errors, hasLength(1));
+    });
+
+    test('timeout invokes onError once and propagates failure', () async {
+      final errors = <Object>[];
+      client.applyStructuredConfigForTest(
+        _config(timeout: 40, onError: errors.add),
+      );
+      peer.getUserMediaOverride = (_) async => throw permissionError();
+
+      final future = peer.createStream('audio', isAnswer: true, callId: 'c1');
+
+      await expectLater(future, throwsA(anything));
+      expect(errors, hasLength(1));
+    });
+
+    test('retry failure after resume invokes onError once and rethrows',
+        () async {
+      final errors = <Object>[];
+      client.applyStructuredConfigForTest(_config(onError: errors.add));
+      peer.getUserMediaOverride = (_) async => throw permissionError();
+
+      final future = peer.createStream('audio', isAnswer: true, callId: 'c1');
+      unawaited(future.catchError((_) => _FakeMediaStream()));
+      await pumpEventQueue();
+      final recovery = capturedErrors.single as TelnyxMediaRecoveryErrorEvent;
+
+      await recovery.resume(); // retry still throws
+      await expectLater(future, throwsA(anything));
+      expect(errors, hasLength(1));
+    });
+
+    test('recovery disabled emits standard structured error, no recoverable',
+        () async {
+      client.applyStructuredConfigForTest(_config(recoveryEnabled: false));
+      peer.getUserMediaOverride = (_) async => throw permissionError();
+
+      await expectLater(
+        peer.createStream('audio', isAnswer: true, callId: 'c1'),
+        throwsA(anything),
+      );
+
+      expect(capturedErrors, hasLength(1));
+      final event = capturedErrors.single;
+      expect(event, isA<TelnyxErrorEvent>());
+      expect((event as TelnyxErrorEvent).recoverable, isFalse);
+      expect(
+        event.error.code,
+        TelnyxErrorCodes.mediaMicrophonePermissionDenied,
       );
     });
 
-    test(
-        'recovery disabled does not emit recoverable event — falls through '
-        'to standard error handling', () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires Peer integration',
+    test('recovery enabled but outbound (isAnswer=false) is not recoverable',
+        () async {
+      client.applyStructuredConfigForTest(_config());
+      peer.getUserMediaOverride = (_) async => throw permissionError();
+
+      await expectLater(
+        peer.createStream('audio', isAnswer: false, callId: 'c1'),
+        throwsA(anything),
       );
+
+      expect(capturedErrors, hasLength(1));
+      expect(capturedErrors.single, isA<TelnyxErrorEvent>());
     });
 
-    test(
-        'recovery enabled but isAnswer=false (outbound call) does not emit '
-        'recoverable event', () {
-      // Recovery flow only applies to inbound call answers, not outbound calls.
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires Peer integration',
-      );
+    test('successful getUserMedia does not trigger recovery', () async {
+      client.applyStructuredConfigForTest(_config());
+      final fakeStream = _FakeMediaStream();
+      peer.getUserMediaOverride = (_) async => fakeStream;
+
+      final stream =
+          await peer.createStream('audio', isAnswer: true, callId: 'c1');
+
+      expect(stream, same(fakeStream));
+      expect(capturedErrors, isEmpty);
     });
 
-    test('successful getUserMedia does not trigger recovery flow', () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires Peer integration',
+    test('feature flag disabled suppresses structured error emission',
+        () async {
+      client.applyStructuredConfigForTest(
+        _config(recoveryEnabled: false, enableStructuredErrors: false),
       );
-    });
+      peer.getUserMediaOverride = (_) async => throw permissionError();
 
-    test(
-        'recovery event error has fatal: false (overridden from registry default)',
-        () {
-      // Media errors (42001-42003) default to fatal: true in the registry,
-      // but the recovery flow overrides fatal to false.
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires Peer integration',
+      await expectLater(
+        peer.createStream('audio', isAnswer: true, callId: 'c1'),
+        throwsA(anything),
       );
-    });
 
-    test('onSuccess callback called on successful resume', () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires Peer integration',
-      );
-    });
-
-    test('onError callback called on reject', () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires Peer integration',
-      );
-    });
-
-    test('onError callback called on timeout', () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires Peer integration',
-      );
-    });
-
-    test('onError callback called on retry failure', () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires Peer integration',
-      );
+      expect(capturedErrors, isEmpty);
     });
   });
 }

--- a/packages/telnyx_webrtc/test/region_fallback_config_test.dart
+++ b/packages/telnyx_webrtc/test/region_fallback_config_test.dart
@@ -1,0 +1,171 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_webrtc/model/region.dart';
+import 'package:telnyx_webrtc/model/tx_ice_server.dart';
+import 'package:telnyx_webrtc/model/tx_server_configuration.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+
+void _expectCommonFieldsPreserved(Config source, Config copy) {
+  expect(copy.sipCallerIDName, source.sipCallerIDName);
+  expect(copy.sipCallerIDNumber, source.sipCallerIDNumber);
+  expect(copy.notificationToken, source.notificationToken);
+  expect(copy.autoReconnect, source.autoReconnect);
+  expect(copy.logLevel, source.logLevel);
+  expect(copy.debug, source.debug);
+  expect(copy.customLogger, same(source.customLogger));
+  expect(copy.ringTonePath, source.ringTonePath);
+  expect(copy.ringbackPath, source.ringbackPath);
+  expect(copy.reconnectionTimeout, source.reconnectionTimeout);
+  expect(copy.pushAnswerTimeout, source.pushAnswerTimeout);
+  expect(copy.region, Region.auto);
+  expect(copy.fallbackOnRegionFailure, source.fallbackOnRegionFailure);
+  expect(copy.forceRelayCandidate, source.forceRelayCandidate);
+  expect(copy.iceServers, same(source.iceServers));
+  expect(copy.serverConfiguration, same(source.serverConfiguration));
+  expect(copy.callReportInterval, source.callReportInterval);
+  expect(copy.callReportLogLevel, source.callReportLogLevel);
+  expect(copy.callReportMaxLogEntries, source.callReportMaxLogEntries);
+  expect(copy.enableCallReports, source.enableCallReports);
+  expect(copy.debugOutput, source.debugOutput);
+  expect(copy.debugLogLevel, source.debugLogLevel);
+  expect(copy.debugLogMaxEntries, source.debugLogMaxEntries);
+  expect(copy.callReportFlushInterval, source.callReportFlushInterval);
+  expect(copy.prefetchIceCandidates, source.prefetchIceCandidates);
+  expect(copy.autoRecoverCalls, source.autoRecoverCalls);
+  expect(copy.hangupOnBeforeUnload, source.hangupOnBeforeUnload);
+  expect(copy.maxReconnectAttempts, source.maxReconnectAttempts);
+  expect(copy.enableStructuredErrors, source.enableStructuredErrors);
+  expect(
+    copy.enableSignalingHealthMonitor,
+    source.enableSignalingHealthMonitor,
+  );
+  expect(
+    copy.mediaPermissionsRecovery,
+    same(source.mediaPermissionsRecovery),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  final iceServers = <TxIceServer>[
+    const TxIceServer(
+      urls: <String>['turn:example.test'],
+      username: 'user',
+      credential: 'credential',
+    ),
+  ];
+  final serverConfiguration = TxServerConfiguration(
+    host: 'rtc.example.test',
+    port: 7443,
+    webRTCIceServers: iceServers,
+  );
+  const mediaRecovery = MediaPermissionsRecoveryConfig(
+    enabled: true,
+    timeout: 12345,
+  );
+
+  group('VSDK-415 region fallback config copy', () {
+    test('TokenConfig changes only region', () {
+      final source = TokenConfig(
+        sipToken: 'token',
+        sipCallerIDName: 'caller',
+        sipCallerIDNumber: 'number',
+        notificationToken: 'notification',
+        autoReconnect: false,
+        logLevel: LogLevel.warning,
+        debug: true,
+        ringTonePath: 'ringtone',
+        ringbackPath: 'ringback',
+        reconnectionTimeout: 111,
+        pushAnswerTimeout: 222,
+        region: Region.eu,
+        fallbackOnRegionFailure: true,
+        forceRelayCandidate: true,
+        iceServers: iceServers,
+        serverConfiguration: serverConfiguration,
+        callReportInterval: 333,
+        callReportLogLevel: 'error',
+        callReportMaxLogEntries: 444,
+        enableCallReports: false,
+        debugOutput: DebugOutput.file,
+        debugLogLevel: DebugLogLevel.error,
+        debugLogMaxEntries: 555,
+        callReportFlushInterval: 666,
+        prefetchIceCandidates: false,
+        autoRecoverCalls: false,
+        hangupOnBeforeUnload: false,
+        maxReconnectAttempts: 7,
+        enableStructuredErrors: false,
+        enableSignalingHealthMonitor: false,
+        mediaPermissionsRecovery: mediaRecovery,
+      );
+      final client =
+          TelnyxClient(connectivityChanges: () => const Stream.empty());
+      addTearDown(() async {
+        client.dispose();
+        await pumpEventQueue();
+      });
+
+      final copy = client.copyConfigWithAutoRegionForTest(source);
+
+      expect(copy, isA<TokenConfig>());
+      expect((copy as TokenConfig).sipToken, source.sipToken);
+      _expectCommonFieldsPreserved(source, copy);
+    });
+
+    test('CredentialConfig changes only region', () {
+      final source = CredentialConfig(
+        sipUser: 'user',
+        sipPassword: 'password',
+        sipCallerIDName: 'caller',
+        sipCallerIDNumber: 'number',
+        notificationToken: 'notification',
+        autoReconnect: false,
+        logLevel: LogLevel.warning,
+        debug: true,
+        ringTonePath: 'ringtone',
+        ringbackPath: 'ringback',
+        reconnectionTimeout: 111,
+        pushAnswerTimeout: 222,
+        region: Region.apac,
+        fallbackOnRegionFailure: true,
+        forceRelayCandidate: true,
+        iceServers: iceServers,
+        serverConfiguration: serverConfiguration,
+        callReportInterval: 333,
+        callReportLogLevel: 'error',
+        callReportMaxLogEntries: 444,
+        enableCallReports: false,
+        debugOutput: DebugOutput.file,
+        debugLogLevel: DebugLogLevel.error,
+        debugLogMaxEntries: 555,
+        callReportFlushInterval: 666,
+        prefetchIceCandidates: false,
+        autoRecoverCalls: false,
+        hangupOnBeforeUnload: false,
+        maxReconnectAttempts: 7,
+        enableStructuredErrors: false,
+        enableSignalingHealthMonitor: false,
+        mediaPermissionsRecovery: mediaRecovery,
+      );
+      final client =
+          TelnyxClient(connectivityChanges: () => const Stream.empty());
+      addTearDown(() async {
+        client.dispose();
+        await pumpEventQueue();
+      });
+
+      final copy = client.copyConfigWithAutoRegionForTest(source);
+
+      expect(copy, isA<CredentialConfig>());
+      expect((copy as CredentialConfig).sipUser, source.sipUser);
+      expect(copy.sipPassword, source.sipPassword);
+      _expectCommonFieldsPreserved(source, copy);
+    });
+  });
+}

--- a/packages/telnyx_webrtc/test/services/reconnect_token_store_test.dart
+++ b/packages/telnyx_webrtc/test/services/reconnect_token_store_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -355,6 +356,150 @@ void main() {
             await ReconnectTokenStore.getActiveCallsRecoveryMarker(now: now);
 
         expect(marker, isNull);
+      });
+    });
+
+    // Adversarial regression: malformed persisted data must not crash callers
+    // and must be deleted so subsequent reads return null (VSDK-418 B2).
+    // The reviewer claimed StoredActiveCalls.fromJson was outside the
+    // try/catch; these tests prove the current behavior is safe —
+    // getActiveCallsRecoveryMarker returns null AND deletes the bad entry.
+    group('malformed recovery marker (VSDK-418 B2)', () {
+      Future<void> seedMalformed(String raw) async {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString(
+          'telnyx-voice-sdk-active-calls',
+          raw,
+        );
+      }
+
+      Future<bool> markerKeyPresent() async {
+        final prefs = await SharedPreferences.getInstance();
+        return prefs.containsKey('telnyx-voice-sdk-active-calls');
+      }
+
+      test('non-JSON raw returns null and deletes the entry', () async {
+        await seedMalformed('this is not json');
+
+        final marker = await ReconnectTokenStore.getActiveCallsRecoveryMarker();
+
+        expect(marker, isNull);
+        expect(
+          await markerKeyPresent(),
+          isFalse,
+          reason: 'malformed data must be deleted',
+        );
+      });
+
+      test(
+          'calls list with a non-string id throws inside fromJson, returns '
+          'null and deletes the entry', () async {
+        final now = DateTime.now().millisecondsSinceEpoch;
+        await seedMalformed(
+          jsonEncode({
+            'sessionId': 's',
+            'calls': [
+              {'id': 123, 'customHeaders': <Map<String, String>>[]},
+            ],
+            'storedAt': now,
+          }),
+        );
+
+        final marker = await ReconnectTokenStore.getActiveCallsRecoveryMarker(
+          now: now,
+        );
+
+        expect(marker, isNull);
+        expect(await markerKeyPresent(), isFalse);
+      });
+
+      test(
+          'calls list with a non-Map header element throws inside fromJson, '
+          'returns null and deletes the entry', () async {
+        final now = DateTime.now().millisecondsSinceEpoch;
+        await seedMalformed(
+          jsonEncode({
+            'sessionId': 's',
+            'calls': [
+              {
+                'id': 'c1',
+                'customHeaders': [42],
+              },
+            ],
+            'storedAt': now,
+          }),
+        );
+
+        final marker = await ReconnectTokenStore.getActiveCallsRecoveryMarker(
+          now: now,
+        );
+
+        expect(marker, isNull);
+        expect(await markerKeyPresent(), isFalse);
+      });
+
+      test(
+          'sessionId of wrong type throws inside fromJson, returns null '
+          'and deletes the entry', () async {
+        final now = DateTime.now().millisecondsSinceEpoch;
+        await seedMalformed(
+          jsonEncode({
+            'sessionId': 42,
+            'calls': [
+              {'id': 'c1', 'customHeaders': <Map<String, String>>[]},
+            ],
+            'storedAt': now,
+          }),
+        );
+
+        final marker = await ReconnectTokenStore.getActiveCallsRecoveryMarker(
+          now: now,
+        );
+
+        expect(marker, isNull);
+        expect(await markerKeyPresent(), isFalse);
+      });
+
+      test(
+          'storedAt of wrong type throws inside fromJson, returns null '
+          'and deletes the entry', () async {
+        final now = DateTime.now().millisecondsSinceEpoch;
+        await seedMalformed(
+          jsonEncode({
+            'sessionId': 's',
+            'calls': [
+              {'id': 'c1', 'customHeaders': <Map<String, String>>[]},
+            ],
+            'storedAt': 'not-an-int',
+          }),
+        );
+
+        final marker = await ReconnectTokenStore.getActiveCallsRecoveryMarker(
+          now: now,
+        );
+
+        expect(marker, isNull);
+        expect(await markerKeyPresent(), isFalse);
+      });
+
+      test(
+          'calls element not a Map throws inside fromJson, returns null '
+          'and deletes the entry', () async {
+        final now = DateTime.now().millisecondsSinceEpoch;
+        await seedMalformed(
+          jsonEncode({
+            'sessionId': 's',
+            'calls': [42],
+            'storedAt': now,
+          }),
+        );
+
+        final marker = await ReconnectTokenStore.getActiveCallsRecoveryMarker(
+          now: now,
+        );
+
+        expect(marker, isNull);
+        expect(await markerKeyPresent(), isFalse);
       });
     });
   });

--- a/packages/telnyx_webrtc/test/services/reconnect_token_store_test.dart
+++ b/packages/telnyx_webrtc/test/services/reconnect_token_store_test.dart
@@ -1,6 +1,46 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_webrtc/model/call_state.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_event.dart';
+import 'package:telnyx_webrtc/model/push_notification.dart';
 import 'package:telnyx_webrtc/services/reconnect_token_store.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/tx_socket.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+
+/// Minimal fake socket that records connect calls and lets tests emit
+/// inbound messages through the client's real `_onMessage` path.
+class _FakeTxSocket extends TxSocket {
+  _FakeTxSocket() : super('wss://example.test');
+
+  int connectCount = 0;
+
+  @override
+  void connect() {
+    connectCount++;
+  }
+
+  @override
+  void close() {}
+
+  @override
+  void send(dynamic data) {}
+
+  void emitMessage(dynamic data) => onMessage(data);
+}
+
+CredentialConfig _credentialConfig() => CredentialConfig(
+      sipUser: 'user',
+      sipPassword: 'pass',
+      sipCallerIDName: 'name',
+      sipCallerIDNumber: 'number',
+      logLevel: LogLevel.none,
+      debug: false,
+    );
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -398,90 +438,309 @@ void main() {
     });
   });
 
-  group('VSDK-418: Session recovery integration', () {
-    // These tests describe the expected behavior of the session recovery
-    // flow integrated into TelnyxClient. They serve as TDD tests.
+  group('VSDK-418: Session recovery integration (TelnyxClient)', () {
+    late TelnyxClient client;
+    late _FakeTxSocket socket;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      socket = _FakeTxSocket();
+      client = TelnyxClient(connectivityChanges: () => const Stream.empty())
+        ..txSocket = socket;
+    });
+
+    tearDown(() {
+      client.dispose();
+    });
 
     test('Connect with stored reconnect session ID adds voice_sdk_id to URL',
-        () {
+        () async {
+      await ReconnectTokenStore.setReconnectSessionId('sess-123');
+
+      client.connectWithCredential(_credentialConfig());
+      await pumpEventQueue();
+
+      expect(client.txSocket.hostAddress, contains('voice_sdk_id=sess-123'));
+    });
+
+    test('Connect without stored session ID does not add voice_sdk_id',
+        () async {
+      client.connectWithCredential(_credentialConfig());
+      await pumpEventQueue();
+
+      expect(client.txSocket.hostAddress, isNot(contains('voice_sdk_id')));
+    });
+
+    test('Reconnect path reuses the stored voice_sdk_id', () async {
+      // The reconnect flow routes back through connectWithCredential, so a
+      // stored fresh session id is injected on reconnect too.
+      await ReconnectTokenStore.setReconnectSessionId('reconnect-sess');
+
+      client.connectWithCredential(_credentialConfig());
+      await pumpEventQueue();
+      expect(socket.connectCount, greaterThanOrEqualTo(1));
       expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires TelnyxClient integration',
+        client.txSocket.hostAddress,
+        contains('voice_sdk_id=reconnect-sess'),
       );
     });
 
-    test('Connect without stored session ID does not add voice_sdk_id', () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires TelnyxClient integration',
+    test('Successful REGED persists server voice_sdk_id + session id',
+        () async {
+      client.connectWithCredential(_credentialConfig());
+      await pumpEventQueue();
+
+      // A method message carrying voice_sdk_id populates the server id.
+      socket.emitMessage(
+        '{"jsonrpc":"2.0","id":"a","method":"telnyx_rtc.clientReady",'
+        '"voice_sdk_id":"server-vsid","params":{}}',
       );
+      await pumpEventQueue();
+      expect(client.voiceSdkId, 'server-vsid');
+
+      // A REGED result triggers persistence.
+      socket.emitMessage(
+        '{"jsonrpc":"2.0","id":"b","result":{"params":{"state":"REGED"}}}',
+      );
+      await pumpEventQueue();
+
+      expect(await ReconnectTokenStore.getReconnectSessionId(), client.sessid);
+      expect(await ReconnectTokenStore.getReconnectToken(), 'server-vsid');
     });
 
-    test('Successful login stores voice_sdk_id and session ID', () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires TelnyxClient integration',
+    test(
+        'Push-driven REGED persists the server voice_sdk_id (captured before '
+        'push metadata is cleared)', () async {
+      // Drive the genuine push path: handlePushNotification sets
+      // _isCallFromPush = true and wires the (fake) socket.
+      final pushMeta = PushMetaData(
+        callerName: 'caller',
+        callerNumber: '+100',
+        voiceSdkId: 'push-vsid',
       );
+      client.handlePushNotification(pushMeta, _credentialConfig(), null);
+      await pumpEventQueue();
+
+      // The server's clientReady message carries a *fresh* voice_sdk_id that
+      // overwrites the push metadata.
+      socket.emitMessage(
+        '{"jsonrpc":"2.0","id":"a","method":"telnyx_rtc.clientReady",'
+        '"voice_sdk_id":"server-vsid","params":{}}',
+      );
+      await pumpEventQueue();
+      expect(client.voiceSdkId, 'server-vsid');
+
+      // REGED (with _isCallFromPush == true) clears the push metadata as part
+      // of the attach flow. The reconnect token must still capture the server
+      // voice_sdk_id that was live at registration time.
+      socket.emitMessage(
+        '{"jsonrpc":"2.0","id":"b","result":{"params":{"state":"REGED"}}}',
+      );
+      await pumpEventQueue();
+
+      expect(await ReconnectTokenStore.getReconnectToken(), 'server-vsid');
+      expect(await ReconnectTokenStore.getReconnectSessionId(), client.sessid);
     });
 
-    test('Reconnect uses stored voice_sdk_id', () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires TelnyxClient integration',
+    test(
+        'Cold-start connect auto-loads the recovery marker and reattaches '
+        'after REGED (no manual readRecoveryMarkerAtStartup call)', () async {
+      // A marker persisted by a prior app session.
+      await ReconnectTokenStore.setActiveCallsRecoveryMarker(
+        [StoredActiveCall(id: 'call-1', customHeaders: const [])],
+        'sess',
       );
+      // The backend re-established the call for this id after login.
+      final call = client.call..callId = 'call-1';
+      client.calls['call-1'] = call;
+
+      // Real connect path only — the app never calls the startup hook.
+      client.connectWithCredential(_credentialConfig());
+      await pumpEventQueue();
+
+      // Registration completes.
+      socket.emitMessage(
+        '{"jsonrpc":"2.0","id":"b","result":{"params":{"state":"REGED"}}}',
+      );
+      await pumpEventQueue();
+
+      expect(
+        call.recoveredCallId,
+        'call-1',
+        reason: 'the marker must be auto-loaded on connect so reattach fires',
+      );
+      expect(await ReconnectTokenStore.getActiveCallsRecoveryMarker(), isNull);
     });
 
-    test('Disconnect clears all stored data', () {
+    test(
+        'Rapid disconnect→reconnect: a stale in-flight clearAll must not erase '
+        'the new session\'s recovery data', () async {
+      // Establish a first session and persist its recovery data.
+      client.connectWithCredential(_credentialConfig());
+      await pumpEventQueue();
+      socket
+        ..emitMessage(
+          '{"jsonrpc":"2.0","id":"a","method":"telnyx_rtc.clientReady",'
+          '"voice_sdk_id":"vsid-A","params":{}}',
+        )
+        ..emitMessage(
+          '{"jsonrpc":"2.0","id":"b","result":{"params":{"state":"REGED"}}}',
+        );
+      await pumpEventQueue();
+      expect(await ReconnectTokenStore.getReconnectToken(), 'vsid-A');
+
+      // Hold the disconnect's clearAll open with a gate so it will resume only
+      // *after* the reconnect has persisted fresh data — reproducing the race.
+      final gate = Completer<void>();
+      // Rapid disconnect → reconnect (synchronous, no pump between).
+      client
+        ..recoveryClearGate = gate.future
+        ..disconnect()
+        ..connectWithCredential(_credentialConfig());
+      await pumpEventQueue();
+
+      // New session registers and persists fresh recovery data.
+      socket
+        ..emitMessage(
+          '{"jsonrpc":"2.0","id":"c","method":"telnyx_rtc.clientReady",'
+          '"voice_sdk_id":"vsid-B","params":{}}',
+        )
+        ..emitMessage(
+          '{"jsonrpc":"2.0","id":"d","result":{"params":{"state":"REGED"}}}',
+        );
+      await pumpEventQueue();
+      expect(await ReconnectTokenStore.getReconnectToken(), 'vsid-B');
+
+      // Let the stale disconnect's clearAll resume — it must be superseded.
+      gate.complete();
+      await pumpEventQueue();
+
       expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires TelnyxClient integration',
+        await ReconnectTokenStore.getReconnectToken(),
+        'vsid-B',
+        reason: 'the stale clearAll must not wipe the reconnected session data',
       );
+      expect(await ReconnectTokenStore.getReconnectSessionId(), client.sessid);
     });
 
-    test('App startup with recovery marker attempts reattach', () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires TelnyxClient integration',
-      );
+    test(
+        'Bare connect() reapplies the stored structured/monitor config '
+        '(clears explicit-disconnect suppression)', () async {
+      // ignore: deprecated_member_use_from_same_package
+      client.connectWithCredential(_credentialConfig());
+      await pumpEventQueue();
+
+      // Explicit disconnect suppresses active-call marker persistence.
+      client.disconnect();
+      await pumpEventQueue();
+
+      // Reconnect through the bare stored-config connect().
+      // ignore: deprecated_member_use_from_same_package
+      client.connect();
+      await pumpEventQueue();
+
+      // A newly-active call must persist a marker again — proving the
+      // suppression flag was reset by reapplying the config.
+      final call = client.call
+        ..callId = 'call-x'
+        ..customHeaders = {'X-H': 'v'};
+      client.calls['call-x'] = call;
+      call.callHandler.changeState(CallState.active);
+      client.onCallStateChangedToActive('call-x');
+      await pumpEventQueue();
+
+      final marker = await ReconnectTokenStore.getActiveCallsRecoveryMarker();
+      expect(marker?.calls.single.id, 'call-x');
     });
 
-    test('SESSION_NOT_REATTACHED error emitted when server does not reattach',
-        () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires TelnyxClient integration',
+    test('Explicit disconnect clears all persisted recovery data', () async {
+      await ReconnectTokenStore.setReconnectToken('tok');
+      await ReconnectTokenStore.setReconnectSessionId('sess');
+      await ReconnectTokenStore.setActiveCallsRecoveryMarker(
+        [StoredActiveCall(id: 'c1', customHeaders: const [])],
+        'sess',
       );
+
+      client.disconnect();
+      await pumpEventQueue();
+
+      expect(await ReconnectTokenStore.getReconnectToken(), isNull);
+      expect(await ReconnectTokenStore.getReconnectSessionId(), isNull);
+      expect(await ReconnectTokenStore.getActiveCallsRecoveryMarker(), isNull);
     });
 
-    test('recoveredCallId is set on recovered calls', () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires TelnyxClient integration',
+    test('App startup reads a fresh recovery marker', () async {
+      await ReconnectTokenStore.setActiveCallsRecoveryMarker(
+        [StoredActiveCall(id: 'call-1', customHeaders: const [])],
+        'sess',
       );
+
+      final marker = await client.readRecoveryMarkerAtStartup();
+
+      expect(marker, isNotNull);
+      expect(client.pendingReattach?.calls.single.id, 'call-1');
     });
 
-    test('Active calls marker updated when call state changes', () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires TelnyxClient integration',
+    test('Failed reattachment emits SESSION_NOT_REATTACHED (48501) and clears',
+        () async {
+      final errors = <Object>[];
+      client
+        ..applyStructuredConfigForTest(_credentialConfig())
+        ..onTelnyxError = errors.add;
+      await ReconnectTokenStore.setActiveCallsRecoveryMarker(
+        [StoredActiveCall(id: 'gone-call', customHeaders: const [])],
+        'sess',
       );
+
+      await client.readRecoveryMarkerAtStartup();
+      await client.attemptPendingReattachForTest();
+
+      expect(errors, hasLength(1));
+      final event = errors.single as TelnyxErrorEvent;
+      expect(event.error.code, TelnyxErrorCodes.sessionNotReattached);
+      expect(event.callId, 'gone-call');
+      expect(await ReconnectTokenStore.getActiveCallsRecoveryMarker(), isNull);
     });
 
-    test('Active calls marker cleared when all calls end', () {
-      expect(
-        true,
-        isTrue,
-        reason: 'Implementation test — requires TelnyxClient integration',
+    test('recoveredCallId is set on a correlated restored call', () async {
+      final call = client.call..callId = 'call-1';
+      client.calls['call-1'] = call;
+      await ReconnectTokenStore.setActiveCallsRecoveryMarker(
+        [StoredActiveCall(id: 'call-1', customHeaders: const [])],
+        'sess',
       );
+
+      await client.readRecoveryMarkerAtStartup();
+      await client.attemptPendingReattachForTest();
+
+      expect(call.recoveredCallId, 'call-1');
+    });
+
+    test('Active-calls marker updated when a call becomes active', () async {
+      final call = client.call
+        ..callId = 'call-1'
+        ..customHeaders = {'X-Header': 'v'};
+      client.calls['call-1'] = call;
+      call.callHandler.changeState(CallState.active);
+
+      client.onCallStateChangedToActive('call-1');
+      await pumpEventQueue();
+
+      final marker = await ReconnectTokenStore.getActiveCallsRecoveryMarker();
+      expect(marker, isNotNull);
+      expect(marker!.calls.single.id, 'call-1');
+    });
+
+    test('Active-calls marker cleared when the last call ends', () async {
+      await ReconnectTokenStore.setActiveCallsRecoveryMarker(
+        [StoredActiveCall(id: 'old', customHeaders: const [])],
+        'sess',
+      );
+      // No active calls in the client.
+      client.onCallStateChangedToActive('call-1');
+      await pumpEventQueue();
+
+      expect(await ReconnectTokenStore.getActiveCallsRecoveryMarker(), isNull);
     });
   });
 }

--- a/packages/telnyx_webrtc/test/services/signaling_health_monitor_test.dart
+++ b/packages/telnyx_webrtc/test/services/signaling_health_monitor_test.dart
@@ -299,23 +299,87 @@ void main() {
       });
     });
 
-    group('probe mechanism', () {
-      test('after start with no socket activity for > 20s, probe is sent',
-          () async {
+    group('periodic recovery decisions', () {
+      testWidgets(
+          'recovered socket activity resolves deferred recovery with one ICE restart',
+          (tester) async {
+        final now = DateTime.utc(2026);
+        monitor = SignalingHealthMonitor(session, now: () => now);
         when(session.isConnected).thenReturn(true);
         when(session.hasActiveCall()).thenReturn(true);
-        monitor.start();
+        when(session.triggerIceRestart(any)).thenReturn(
+          const TriggerIceRestartResult(started: true),
+        );
+        monitor
+          ..start()
+          ..onPeerFailure('call-1', PeerFailureEvidence.iceFailed);
 
-        // Wait beyond the probe threshold (20s silence → probe)
-        // Since check interval is 3s, we need to wait at least 21s
-        // Instead of waiting real time, we test the isProbeInFlight state
-        // after the monitor has been running with no activity
-        // This is a timing-dependent test — in practice the check interval
-        // fires every 3s. We wait a short time and verify no probe yet
-        // (since 20s hasn't elapsed).
-        await Future.delayed(const Duration(milliseconds: 100));
+        expect(monitor.isProbeInFlight, isTrue);
+        verify(session.sendProbe()).called(1);
 
-        // After only 100ms, no probe should be in flight
+        monitor.onSocketActivity();
+        expect(monitor.isProbeInFlight, isFalse);
+        await tester.pump(const Duration(seconds: 3));
+
+        verify(session.triggerIceRestart('call-1')).called(1);
+        verifyNever(session.socketDisconnect());
+        await tester.pump(const Duration(seconds: 6));
+        verifyNever(session.triggerIceRestart('call-1'));
+        monitor.stop();
+      });
+
+      testWidgets('probe timeout escalates to exactly one socket reconnect',
+          (tester) async {
+        var now = DateTime.utc(2026);
+        monitor = SignalingHealthMonitor(session, now: () => now);
+        when(session.isConnected).thenReturn(true);
+        when(session.hasActiveCall()).thenReturn(true);
+        monitor
+          ..start()
+          ..onPeerFailure('call-2', PeerFailureEvidence.connectionFailed);
+
+        now = now.add(const Duration(seconds: 9));
+        await tester.pump(const Duration(seconds: 9));
+
+        verify(session.socketDisconnect()).called(1);
+        verifyNever(session.triggerIceRestart(any));
+        await tester.pump(const Duration(seconds: 6));
+        verifyNever(session.socketDisconnect());
+        monitor.stop();
+      });
+
+      testWidgets('idle signaling sends one probe after healthy window expires',
+          (tester) async {
+        var now = DateTime.utc(2026);
+        monitor = SignalingHealthMonitor(session, now: () => now);
+        when(session.isConnected).thenReturn(true);
+        when(session.hasActiveCall()).thenReturn(true);
+        monitor
+          ..start()
+          ..onSocketActivity();
+
+        now = now.add(const Duration(seconds: 18));
+        await tester.pump(const Duration(seconds: 18));
+        verifyNever(session.sendProbe());
+        now = now.add(const Duration(seconds: 3));
+        await tester.pump(const Duration(seconds: 3));
+
+        verify(session.sendProbe()).called(1);
+        expect(monitor.isProbeInFlight, isTrue);
+        await tester.pump(const Duration(seconds: 6));
+        verifyNever(session.sendProbe());
+        monitor.stop();
+      });
+
+      test('socket activity clears a probe already in flight', () {
+        when(session.isConnected).thenReturn(true);
+        when(session.hasActiveCall()).thenReturn(true);
+        monitor
+          ..start()
+          ..onPeerFailure('call-3', PeerFailureEvidence.iceFailed);
+
+        expect(monitor.isProbeInFlight, isTrue);
+        monitor.onSocketActivity();
         expect(monitor.isProbeInFlight, isFalse);
       });
     });

--- a/packages/telnyx_webrtc/test/telnyx_config_test.dart
+++ b/packages/telnyx_webrtc/test/telnyx_config_test.dart
@@ -273,4 +273,36 @@ void main() {
       expect(config.forceRelayCandidate, isTrue);
     });
   });
+
+  group('VSDK-415/416 configuration defaults', () {
+    test('TokenConfig enables structured errors and monitoring by default', () {
+      final config = TokenConfig(
+        sipToken: 'token',
+        sipCallerIDName: 'name',
+        sipCallerIDNumber: 'number',
+        debug: false,
+        logLevel: LogLevel.none,
+      );
+
+      expect(config.enableStructuredErrors, isTrue);
+      expect(config.enableSignalingHealthMonitor, isTrue);
+      expect(config.mediaPermissionsRecovery, isNull);
+    });
+
+    test('CredentialConfig enables structured errors and monitoring by default',
+        () {
+      final config = CredentialConfig(
+        sipUser: 'user',
+        sipPassword: 'password',
+        sipCallerIDName: 'name',
+        sipCallerIDNumber: 'number',
+        debug: false,
+        logLevel: LogLevel.none,
+      );
+
+      expect(config.enableStructuredErrors, isTrue);
+      expect(config.enableSignalingHealthMonitor, isTrue);
+      expect(config.mediaPermissionsRecovery, isNull);
+    });
+  });
 }

--- a/packages/telnyx_webrtc/test/telnyx_config_test.dart
+++ b/packages/telnyx_webrtc/test/telnyx_config_test.dart
@@ -6,8 +6,6 @@ import 'package:telnyx_webrtc/utils/logging/custom_logger.dart';
 
 // Mock custom logger for testing
 class MockCustomLogger implements CustomLogger {
-  LogLevel _logLevel = LogLevel.none;
-
   @override
   void log(LogLevel level, String message) {
     // Mock implementation
@@ -15,7 +13,7 @@ class MockCustomLogger implements CustomLogger {
 
   @override
   void setLogLevel(LogLevel level) {
-    _logLevel = level;
+    // Mock implementation — no-op
   }
 }
 

--- a/packages/telnyx_webrtc/test/vsdk415_ice_restart_failed_test.dart
+++ b/packages/telnyx_webrtc/test/vsdk415_ice_restart_failed_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_webrtc/model/call_state.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_event.dart';
+import 'package:telnyx_webrtc/services/signaling_health_monitor.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/tx_socket.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+
+class _FakeTxSocket extends TxSocket {
+  _FakeTxSocket() : super('wss://example.test');
+  @override
+  void connect() {}
+  @override
+  void close() {}
+  @override
+  void send(dynamic data) {}
+}
+
+CredentialConfig _config() => CredentialConfig(
+      sipUser: 'user',
+      sipPassword: 'pass',
+      sipCallerIDName: 'name',
+      sipCallerIDNumber: 'number',
+      logLevel: LogLevel.none,
+      debug: false,
+      autoReconnect: true,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+      'ICE restart that cannot be started emits iceRestartFailed (47001) '
+      'as a structured error', () {
+    SharedPreferences.setMockInitialValues({});
+    final socket = _FakeTxSocket();
+    final errors = <Object>[];
+    final client = TelnyxClient(connectivityChanges: () => const Stream.empty())
+      ..txSocket = socket
+      ..applyStructuredConfigForTest(_config())
+      ..onTelnyxError = errors.add;
+
+    // A call with no peer connection → restartIce() returns false (cannot
+    // start), which is a genuine ICE-restart failure.
+    final call = client.call..callId = 'call-1';
+    client.calls['call-1'] = call;
+    call.callHandler.changeState(CallState.active);
+    client.onCallStateChangedToActive('call-1');
+    // Mark signaling healthy so the monitor attempts an ICE restart.
+    client.healthMonitor!.onSocketActivity();
+
+    client.healthMonitor!
+        .onPeerFailure('call-1', PeerFailureEvidence.iceFailed);
+
+    final codes =
+        errors.whereType<TelnyxErrorEvent>().map((e) => e.error.code).toList();
+    expect(codes, contains(TelnyxErrorCodes.iceRestartFailed));
+
+    client.dispose();
+  });
+}

--- a/packages/telnyx_webrtc/test/vsdk415_structured_errors_test.dart
+++ b/packages/telnyx_webrtc/test/vsdk415_structured_errors_test.dart
@@ -1,0 +1,268 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_webrtc/model/errors/sdk_errors.dart';
+import 'package:telnyx_webrtc/model/errors/sdk_warnings.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_event.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_warning_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_warning_event.dart';
+import 'package:telnyx_webrtc/model/sdk_error_codes.dart';
+import 'package:telnyx_webrtc/model/sdk_warning_codes.dart';
+import 'package:telnyx_webrtc/model/telnyx_socket_error.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/tx_socket.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+
+class _FakeTxSocket extends TxSocket {
+  _FakeTxSocket() : super('wss://example.test');
+  @override
+  void connect() {}
+  @override
+  void close() {}
+  @override
+  void send(dynamic data) {}
+  void emitMessage(dynamic data) => onMessage(data);
+}
+
+CredentialConfig _config({bool enableStructuredErrors = true}) =>
+    CredentialConfig(
+      sipUser: 'user',
+      sipPassword: 'pass',
+      sipCallerIDName: 'name',
+      sipCallerIDNumber: 'number',
+      logLevel: LogLevel.none,
+      debug: false,
+      enableStructuredErrors: enableStructuredErrors,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late TelnyxClient client;
+  late _FakeTxSocket socket;
+  late List<Object> structuredErrors;
+  late List<TelnyxWarningEvent> warnings;
+  late List<TelnyxSocketError> legacyErrors;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    socket = _FakeTxSocket();
+    structuredErrors = <Object>[];
+    warnings = <TelnyxWarningEvent>[];
+    legacyErrors = <TelnyxSocketError>[];
+    client = TelnyxClient(connectivityChanges: () => const Stream.empty())
+      ..txSocket = socket
+      ..onTelnyxError = structuredErrors.add
+      ..onTelnyxWarning = warnings.add
+      ..onSocketErrorReceived = legacyErrors.add;
+  });
+
+  tearDown(() => client.dispose());
+
+  group('VSDK-415: callback surface + config', () {
+    test('onTelnyxError/onTelnyxWarning are optional (default null)', () {
+      final fresh =
+          TelnyxClient(connectivityChanges: () => const Stream.empty());
+      expect(fresh.onTelnyxError, isNull);
+      expect(fresh.onTelnyxWarning, isNull);
+      fresh.dispose();
+    });
+
+    test('Config exposes enableStructuredErrors defaulting to true', () {
+      expect(_config().enableStructuredErrors, isTrue);
+      expect(
+        _config(enableStructuredErrors: false).enableStructuredErrors,
+        isFalse,
+      );
+    });
+  });
+
+  group('VSDK-415: emit helpers', () {
+    test('emitStructuredErrorCode fires onTelnyxError with a structured event',
+        () {
+      client
+        ..applyStructuredConfigForTest(_config())
+        ..emitStructuredErrorCode(
+          TelnyxErrorCodes.loginFailed,
+          callId: 'call-9',
+        );
+
+      expect(structuredErrors, hasLength(1));
+      final event = structuredErrors.single as TelnyxErrorEvent;
+      expect(event.error.code, TelnyxErrorCodes.loginFailed);
+      expect(event.callId, 'call-9');
+      expect(event.recoverable, isFalse);
+    });
+
+    test('emitWarningCode fires onTelnyxWarning', () {
+      client
+        ..applyStructuredConfigForTest(_config())
+        ..emitWarningCode(
+          TelnyxWarningCodes.signalingRecoveryRequired,
+          reason: 'unhealthy',
+          source: 'health_monitor',
+        );
+
+      expect(warnings, hasLength(1));
+      expect(
+        warnings.single.warning.code,
+        TelnyxWarningCodes.signalingRecoveryRequired,
+      );
+      expect(warnings.single.source, 'health_monitor');
+    });
+
+    test('feature flag disabled suppresses structured error + warning', () {
+      client
+        ..applyStructuredConfigForTest(
+          _config(enableStructuredErrors: false),
+        )
+        ..emitStructuredErrorCode(TelnyxErrorCodes.loginFailed)
+        ..emitWarningCode(TelnyxWarningCodes.highRtt);
+
+      expect(structuredErrors, isEmpty);
+      expect(warnings, isEmpty);
+    });
+
+    test('a throwing app callback does not break the SDK', () {
+      client
+        ..applyStructuredConfigForTest(_config())
+        ..onTelnyxError = (_) => throw StateError('boom');
+
+      expect(
+        () => client.emitStructuredErrorCode(TelnyxErrorCodes.loginFailed),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('VSDK-415: runtime error emission (real socket path)', () {
+    test('server error message emits structured error AND legacy callback',
+        () async {
+      client.connectWithCredential(_config());
+      await pumpEventQueue();
+
+      socket.emitMessage(
+        '{"jsonrpc":"2.0","id":"1",'
+        '"error":{"code":-32001,"message":"Credential registration error"}}',
+      );
+      await pumpEventQueue();
+
+      // Legacy behavior preserved.
+      expect(legacyErrors, hasLength(1));
+      expect(legacyErrors.single.errorCode, -32001);
+      // Structured error fired alongside.
+      expect(structuredErrors, hasLength(1));
+      final event = structuredErrors.single as TelnyxErrorEvent;
+      expect(event.error.code, TelnyxErrorCodes.invalidCredentials);
+    });
+
+    test('token error maps to authenticationRequired', () async {
+      client.connectWithCredential(_config());
+      await pumpEventQueue();
+
+      socket.emitMessage(
+        '{"jsonrpc":"2.0","id":"1",'
+        '"error":{"code":-32000,"message":"Token registration error"}}',
+      );
+      await pumpEventQueue();
+
+      expect(legacyErrors, hasLength(1));
+      final event = structuredErrors.single as TelnyxErrorEvent;
+      expect(event.error.code, TelnyxErrorCodes.authenticationRequired);
+    });
+
+    test(
+        'unknown server error maps to unexpectedError (not loginFailed) and '
+        'preserves the raw server context', () async {
+      client.connectWithCredential(_config());
+      await pumpEventQueue();
+
+      socket.emitMessage(
+        '{"jsonrpc":"2.0","id":"1",'
+        '"error":{"code":-32099,"message":"Some unexpected server failure"}}',
+      );
+      await pumpEventQueue();
+
+      expect(legacyErrors.single.errorCode, -32099);
+      final event = structuredErrors.single as TelnyxErrorEvent;
+      expect(
+        event.error.code,
+        TelnyxErrorCodes.unexpectedError,
+        reason: 'a non-auth/non-gateway error must not masquerade as a login '
+            'failure',
+      );
+      expect(
+        event.error.originalError.toString(),
+        contains('Some unexpected server failure'),
+        reason: 'the raw server message must be preserved',
+      );
+    });
+
+    test('disabled flag: legacy fires, structured does not', () async {
+      client.connectWithCredential(_config(enableStructuredErrors: false));
+      await pumpEventQueue();
+
+      socket.emitMessage(
+        '{"jsonrpc":"2.0","id":"1",'
+        '"error":{"code":-32001,"message":"Credential registration error"}}',
+      );
+      await pumpEventQueue();
+
+      expect(legacyErrors, hasLength(1));
+      expect(structuredErrors, isEmpty);
+    });
+  });
+
+  group('VSDK-415: registry reconciliation', () {
+    test('public TelnyxErrorCodes match internal SdkErrorCode values', () {
+      expect(
+        TelnyxErrorCodes.sdpCreateOfferFailed,
+        SdkErrorCode.sdpCreateOfferFailed,
+      );
+      expect(
+        TelnyxErrorCodes.invalidCredentials,
+        SdkErrorCode.invalidCredentials,
+      );
+      expect(
+        TelnyxErrorCodes.sessionNotReattached,
+        SdkErrorCode.sessionNotReattached,
+      );
+      expect(TelnyxErrorCodes.unexpectedError, SdkErrorCode.unexpectedError);
+    });
+
+    test('public TelnyxWarningCodes match internal SdkWarningCode values', () {
+      expect(
+        TelnyxWarningCodes.signalingRecoveryRequired,
+        SdkWarningCode.signalingRecoveryRequired,
+      );
+      expect(
+        TelnyxWarningCodes.mediaRecoveryRequired,
+        SdkWarningCode.mediaRecoveryRequired,
+      );
+      expect(
+        TelnyxWarningCodes.peerConnectionFailed,
+        SdkWarningCode.peerConnectionFailed,
+      );
+    });
+
+    test('every public error/warning code resolves in its registry', () {
+      final error = TelnyxError(
+        code: TelnyxErrorCodes.gatewayFailed,
+        name: 'x',
+        message: 'x',
+        description: 'x',
+        causes: const [],
+        solutions: const [],
+        fatal: true,
+      );
+      expect(error.code, 45004);
+      expect(sdkErrors.containsKey(TelnyxErrorCodes.gatewayFailed), isTrue);
+      expect(
+        sdkWarnings.containsKey(TelnyxWarningCodes.mediaRecoveryRequired),
+        isTrue,
+      );
+    });
+  });
+}

--- a/packages/telnyx_webrtc/test/vsdk416_health_session_test.dart
+++ b/packages/telnyx_webrtc/test/vsdk416_health_session_test.dart
@@ -23,14 +23,18 @@ class _FakeTxSocket extends TxSocket {
   void emitOpen() => onOpen();
 }
 
-CredentialConfig _config({bool healthMonitor = true}) => CredentialConfig(
+CredentialConfig _config({
+  bool healthMonitor = true,
+  bool? autoReconnect = true,
+}) =>
+    CredentialConfig(
       sipUser: 'user',
       sipPassword: 'pass',
       sipCallerIDName: 'name',
       sipCallerIDNumber: 'number',
       logLevel: LogLevel.none,
       debug: false,
-      autoReconnect: true,
+      autoReconnect: autoReconnect,
       enableSignalingHealthMonitor: healthMonitor,
     );
 
@@ -80,6 +84,62 @@ void main() {
       client.calls['call-1']!.callHandler.changeState(CallState.done);
       client.onCallStateChangedToActive('call-1');
       expect(client.healthMonitor!.isRunning, isFalse);
+    });
+
+    test('disconnect stops a running monitor', () {
+      client.applyStructuredConfigForTest(_config());
+      addActiveCall('call-1');
+      client.onCallStateChangedToActive('call-1');
+      expect(client.healthMonitor!.isRunning, isTrue);
+
+      client.disconnect();
+
+      expect(client.healthMonitor!.isRunning, isFalse);
+    });
+
+    test('connect config immediately replaces a stale autoReconnect policy',
+        () {
+      client.applyStructuredConfigForTest(_config(autoReconnect: false));
+      expect(client.autoReconnectLoginForTest, isFalse);
+
+      client.applyStructuredConfigForTest(_config());
+      expect(client.autoReconnectLoginForTest, isTrue);
+
+      client.applyStructuredConfigForTest(_config(autoReconnect: null));
+      expect(client.autoReconnectLoginForTest, isTrue);
+    });
+
+    testWidgets(
+        'config reapplication clears deferred recovery without a duplicate ICE restart',
+        (tester) async {
+      client.applyStructuredConfigForTest(_config());
+      addActiveCall('call-1');
+      client.onCallStateChangedToActive('call-1');
+      final monitor = client.healthMonitor!;
+
+      // Kept separate from onSocketActivity so the pre-reset probe state is
+      // asserted before configuration clears it.
+      // ignore: cascade_invocations
+      monitor.onPeerFailure('call-1', PeerFailureEvidence.iceFailed);
+      expect(monitor.isProbeInFlight, isTrue);
+
+      client.applyStructuredConfigForTest(_config());
+      expect(monitor.isRunning, isTrue);
+      expect(monitor.isProbeInFlight, isFalse);
+
+      monitor.onSocketActivity();
+      warnings.clear();
+      await tester.pump(const Duration(seconds: 3));
+
+      expect(
+        warnings.where(
+          (event) =>
+              event.warning.code == TelnyxWarningCodes.mediaRecoveryRequired,
+        ),
+        isEmpty,
+        reason: 'the prior session must not trigger a deferred ICE restart',
+      );
+      monitor.stop();
     });
   });
 

--- a/packages/telnyx_webrtc/test/vsdk416_health_session_test.dart
+++ b/packages/telnyx_webrtc/test/vsdk416_health_session_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:telnyx_webrtc/call.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_webrtc/model/call_state.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_warning_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_warning_event.dart';
+import 'package:telnyx_webrtc/services/signaling_health_monitor.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/tx_socket.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+
+class _FakeTxSocket extends TxSocket {
+  _FakeTxSocket() : super('wss://example.test');
+  int connectCount = 0;
+  @override
+  void connect() => connectCount++;
+  @override
+  void close() {}
+  @override
+  void send(dynamic data) {}
+  void emitMessage(dynamic data) => onMessage(data);
+  void emitOpen() => onOpen();
+}
+
+CredentialConfig _config({bool healthMonitor = true}) => CredentialConfig(
+      sipUser: 'user',
+      sipPassword: 'pass',
+      sipCallerIDName: 'name',
+      sipCallerIDNumber: 'number',
+      logLevel: LogLevel.none,
+      debug: false,
+      autoReconnect: true,
+      enableSignalingHealthMonitor: healthMonitor,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late TelnyxClient client;
+  late _FakeTxSocket socket;
+  late List<TelnyxWarningEvent> warnings;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    socket = _FakeTxSocket();
+    warnings = <TelnyxWarningEvent>[];
+    client = TelnyxClient(connectivityChanges: () => const Stream.empty())
+      ..txSocket = socket
+      ..onTelnyxWarning = warnings.add;
+  });
+
+  tearDown(() => client.dispose());
+
+  Call addActiveCall(String id) {
+    final call = client.call..callId = id;
+    client.calls[id] = call;
+    call.callHandler.changeState(CallState.active);
+    return call;
+  }
+
+  group('VSDK-416: monitor ownership', () {
+    test('monitor is instantiated only when enabled', () {
+      client.applyStructuredConfigForTest(_config(healthMonitor: false));
+      expect(client.healthMonitor, isNull);
+
+      client.applyStructuredConfigForTest(_config());
+      expect(client.healthMonitor, isNotNull);
+    });
+
+    test('monitor starts when a call is active and stops when none remain',
+        () async {
+      client.applyStructuredConfigForTest(_config());
+
+      addActiveCall('call-1');
+      client.onCallStateChangedToActive('call-1');
+      expect(client.healthMonitor!.isRunning, isTrue);
+
+      // Move the call out of an active state → monitor stops.
+      client.calls['call-1']!.callHandler.changeState(CallState.done);
+      client.onCallStateChangedToActive('call-1');
+      expect(client.healthMonitor!.isRunning, isFalse);
+    });
+  });
+
+  group('VSDK-416: single recovery authority', () {
+    test(
+        'critical request timeout (connected + active) triggers signaling '
+        'recovery only', () async {
+      client.connectWithCredential(_config());
+      await pumpEventQueue();
+      socket.emitOpen(); // marks the client connected
+      addActiveCall('call-1');
+      client.onCallStateChangedToActive('call-1');
+      expect(client.healthMonitor!.isRunning, isTrue);
+
+      client.healthMonitor!.onRequestTimeout('req-1', 5000, 'telnyx_rtc.bye');
+
+      final codes = warnings.map((w) => w.warning.code).toList();
+      expect(codes, contains(TelnyxWarningCodes.signalingRecoveryRequired));
+      expect(
+        codes,
+        isNot(contains(TelnyxWarningCodes.mediaRecoveryRequired)),
+        reason: 'unhealthy signaling must never also restart ICE',
+      );
+    });
+
+    test('non-critical request timeout triggers no recovery', () async {
+      client.connectWithCredential(_config());
+      await pumpEventQueue();
+      socket.emitOpen();
+      addActiveCall('call-1');
+      client.onCallStateChangedToActive('call-1');
+
+      final connectBefore = socket.connectCount;
+      client.healthMonitor!.onRequestTimeout('req-1', 5000, 'telnyx_rtc.info');
+
+      expect(warnings, isEmpty);
+      expect(socket.connectCount, connectBefore);
+    });
+  });
+
+  group('VSDK-416: inbound activity feeds the monitor', () {
+    test(
+        'an inbound socket message marks signaling healthy so a peer failure '
+        'chooses ICE restart (media recovery)', () async {
+      client.connectWithCredential(_config());
+      await pumpEventQueue();
+      socket.emitOpen();
+      addActiveCall('call-1');
+      client.onCallStateChangedToActive('call-1');
+
+      // Any inbound message routes through _onMessage → onSocketActivity().
+      socket
+          .emitMessage('{"jsonrpc":"2.0","id":"x","method":"telnyx_rtc.ping"}');
+      await pumpEventQueue();
+
+      warnings.clear();
+      client.healthMonitor!
+          .onPeerFailure('call-1', PeerFailureEvidence.iceFailed);
+
+      final codes = warnings.map((w) => w.warning.code).toList();
+      expect(
+        codes,
+        contains(TelnyxWarningCodes.mediaRecoveryRequired),
+        reason: 'healthy signaling + peer failure => ICE restart',
+      );
+    });
+  });
+}

--- a/packages/telnyx_webrtc/test/vsdk416_peer_failure_test.dart
+++ b/packages/telnyx_webrtc/test/vsdk416_peer_failure_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:telnyx_webrtc/call.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_webrtc/model/call_state.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_warning_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_warning_event.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/tx_socket.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+
+class _FakeTxSocket extends TxSocket {
+  _FakeTxSocket() : super('wss://example.test');
+  @override
+  void connect() {}
+  @override
+  void close() {}
+  @override
+  void send(dynamic data) {}
+}
+
+/// A [Call] that counts ICE-restart requests so tests can assert the recovery
+/// authority triggers *exactly one* renegotiation.
+class _SpyCall extends Call {
+  _SpyCall(TxSocket socket, TelnyxClient client)
+      : super(
+          socket,
+          client,
+          'sess',
+          '',
+          '',
+          CallHandler((_) {}, null),
+          () {},
+          false,
+        ) {
+    callHandler.call = this;
+  }
+
+  int restartCount = 0;
+
+  @override
+  bool restartIce() {
+    restartCount++;
+    return true;
+  }
+}
+
+CredentialConfig _config({bool healthMonitor = true}) => CredentialConfig(
+      sipUser: 'user',
+      sipPassword: 'pass',
+      sipCallerIDName: 'name',
+      sipCallerIDNumber: 'number',
+      logLevel: LogLevel.none,
+      debug: false,
+      autoReconnect: true,
+      enableSignalingHealthMonitor: healthMonitor,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late TelnyxClient client;
+  late _FakeTxSocket socket;
+  late List<TelnyxWarningEvent> warnings;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    socket = _FakeTxSocket();
+    warnings = <TelnyxWarningEvent>[];
+    client = TelnyxClient(connectivityChanges: () => const Stream.empty())
+      ..txSocket = socket
+      ..onTelnyxWarning = warnings.add;
+  });
+
+  tearDown(() => client.dispose());
+
+  _SpyCall addActiveSpyCall(String id) {
+    final call = _SpyCall(socket, client)..callId = id;
+    client.calls[id] = call;
+    call.callHandler.changeState(CallState.active);
+    return call;
+  }
+
+  group('VSDK-416: peer ICE failure is a single recovery authority', () {
+    test(
+        'monitor enabled + healthy signaling → exactly one ICE restart '
+        '(no duplicate direct renegotiation)', () {
+      client.applyStructuredConfigForTest(_config());
+      final call = addActiveSpyCall('call-1');
+      client.onCallStateChangedToActive('call-1');
+      // Mark signaling healthy so the monitor chooses an ICE restart.
+      client.healthMonitor!.onSocketActivity();
+
+      client.handlePeerIceConnectionFailed('call-1', afterDisconnect: true);
+
+      expect(
+        call.restartCount,
+        1,
+        reason: 'the monitor is the sole authority — the peer must not also '
+            'renegotiate directly',
+      );
+      expect(
+        warnings.map((w) => w.warning.code),
+        contains(TelnyxWarningCodes.peerConnectionFailed),
+      );
+    });
+
+    test(
+        'monitor disabled + failure after disconnect → exactly one direct '
+        'ICE restart (legacy self-heal preserved)', () {
+      client.applyStructuredConfigForTest(_config(healthMonitor: false));
+      final call = addActiveSpyCall('call-1');
+
+      client.handlePeerIceConnectionFailed('call-1', afterDisconnect: true);
+
+      expect(call.restartCount, 1);
+    });
+
+    test('monitor disabled + failure without prior disconnect → no ICE restart',
+        () {
+      client.applyStructuredConfigForTest(_config(healthMonitor: false));
+      final call = addActiveSpyCall('call-1');
+
+      client.handlePeerIceConnectionFailed('call-1', afterDisconnect: false);
+
+      expect(call.restartCount, 0);
+    });
+  });
+
+  group('VSDK-416: peer connection failure routing', () {
+    test('emits peerConnectionFailed warning and routes to the monitor', () {
+      client.applyStructuredConfigForTest(_config());
+      addActiveSpyCall('call-1');
+      client
+        ..onCallStateChangedToActive('call-1')
+        ..handlePeerConnectionFailed('call-1');
+
+      expect(
+        warnings.map((w) => w.warning.code),
+        contains(TelnyxWarningCodes.peerConnectionFailed),
+      );
+    });
+  });
+}

--- a/packages/telnyx_webrtc/test/vsdk416_signaling_probe_test.dart
+++ b/packages/telnyx_webrtc/test/vsdk416_signaling_probe_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:telnyx_webrtc/config/telnyx_config.dart';
+import 'package:telnyx_webrtc/model/call_state.dart';
+import 'package:telnyx_webrtc/services/signaling_health_monitor.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/tx_socket.dart';
+import 'package:telnyx_webrtc/utils/logging/log_level.dart';
+
+/// Records every payload sent on the socket so tests can assert the real
+/// production send path is exercised.
+class _RecordingTxSocket extends TxSocket {
+  _RecordingTxSocket() : super('wss://example.test');
+  final List<String> sent = <String>[];
+  @override
+  void connect() {}
+  @override
+  void close() {}
+  @override
+  void send(dynamic data) => sent.add(data.toString());
+}
+
+CredentialConfig _config() => CredentialConfig(
+      sipUser: 'user',
+      sipPassword: 'pass',
+      sipCallerIDName: 'name',
+      sipCallerIDNumber: 'number',
+      logLevel: LogLevel.none,
+      debug: false,
+      autoReconnect: true,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late TelnyxClient client;
+  late _RecordingTxSocket socket;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    socket = _RecordingTxSocket();
+    client = TelnyxClient(connectivityChanges: () => const Stream.empty())
+      ..txSocket = socket;
+  });
+
+  tearDown(() => client.dispose());
+
+  test(
+      'unknown signaling + peer failure sends a real telnyx_rtc.ping probe '
+      'through the production socket adapter', () {
+    client.applyStructuredConfigForTest(_config());
+    final call = client.call..callId = 'call-1';
+    client.calls['call-1'] = call;
+    call.callHandler.changeState(CallState.active);
+    client.onCallStateChangedToActive('call-1');
+    expect(client.healthMonitor!.isRunning, isTrue);
+
+    // No inbound socket activity → signaling health is unknown, so a peer
+    // failure must defer with a probe rather than restarting ICE blindly.
+    client.healthMonitor!
+        .onPeerFailure('call-1', PeerFailureEvidence.iceFailed);
+
+    expect(client.healthMonitor!.isProbeInFlight, isTrue);
+    expect(
+      socket.sent,
+      contains(
+        predicate<String>(
+          (s) => s.contains('"method":"telnyx_rtc.ping"'),
+          'a telnyx_rtc.ping probe',
+        ),
+      ),
+      reason: 'the probe must actually be sent on the socket, not just flagged',
+    );
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,9 @@ dependencies:
   logger: ^2.5.0
   intl: ^0.19.0
   image_picker: ^1.0.4
+  # Marionette enables AI-agent (MCP) driving of the debug build only; the
+  # MarionetteBinding is initialized solely under kDebugMode in main().
+  marionette_flutter: ^0.6.0
 
 dev_dependencies:
   flutter_test:

--- a/test/media_recovery_helper_test.dart
+++ b/test/media_recovery_helper_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:telnyx_flutter_webrtc/utils/media_recovery_helper.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_event.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_factory.dart';
+
+TelnyxMediaRecoveryErrorEvent _event({
+  required void Function() onResume,
+  required void Function() onReject,
+}) => TelnyxMediaRecoveryErrorEvent(
+  error: createTelnyxError(TelnyxErrorCodes.mediaMicrophonePermissionDenied),
+  sessionId: 'sess',
+  callId: 'call-1',
+  retryDeadline: 0,
+  resume: () async => onResume(),
+  reject: () async => onReject(),
+);
+
+void main() {
+  group('VSDK-417 demo media recovery decision', () {
+    test('permission granted → resume() called, reject() not', () async {
+      var resumed = false, rejected = false;
+      final event = _event(
+        onResume: () => resumed = true,
+        onReject: () => rejected = true,
+      );
+
+      await resolveMediaRecovery(event, requestMicPermission: () async => true);
+
+      expect(resumed, isTrue);
+      expect(rejected, isFalse);
+    });
+
+    test('permission denied → reject() called, resume() not', () async {
+      var resumed = false, rejected = false;
+      final event = _event(
+        onResume: () => resumed = true,
+        onReject: () => rejected = true,
+      );
+
+      await resolveMediaRecovery(
+        event,
+        requestMicPermission: () async => false,
+      );
+
+      expect(resumed, isFalse);
+      expect(rejected, isTrue);
+    });
+
+    test('requester throws → fail-safe reject() called', () async {
+      var resumed = false, rejected = false;
+      final event = _event(
+        onResume: () => resumed = true,
+        onReject: () => rejected = true,
+      );
+
+      await resolveMediaRecovery(
+        event,
+        requestMicPermission: () async => throw StateError('boom'),
+      );
+
+      expect(resumed, isFalse);
+      expect(rejected, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
VSDK-415, VSDK-416, VSDK-417, VSDK-418

## Why

The diagnostics and recovery primitives added to the WebRTC package were not yet connected to the live client, signaling, media, and peer-connection lifecycles. As a result, applications could not consume structured runtime errors, signaling recovery was not centrally coordinated, media-permission retries were unreachable from inbound answering, and reconnect state was not restored by normal connection flows.

## What changed

- Emit structured errors and warnings from live socket, media, and peer paths while preserving the existing callbacks.
- Coordinate signaling probes, ICE restart, and socket reconnect through one health-monitor authority.
- Add opt-in inbound microphone-permission recovery with explicit `resume()` / `reject()` handling.
- Persist and restore a narrow reconnect projection with generation/epoch fencing for rapid disconnect/reconnect races.
- Add independently configurable rollback controls for structured errors and signaling monitoring.
- Wire the demo application's recovery flow and debug-only Marionette binding.
- Replace placeholder integration assertions with production-path and deterministic race tests.

## Behavior

### Defaults

- `enableStructuredErrors: true`
- `enableSignalingHealthMonitor: true`
- `mediaPermissionsRecovery: null` (disabled unless explicitly configured)

All public API additions are optional/defaulted. Existing callbacks continue to fire alongside structured callbacks.

### Persistence boundary

Recovery storage is limited to reconnect/session identifiers and active-call projections. It does not persist credentials, access tokens, SDP, ICE/TURN data, media, streams, or peer objects.

## Validation

- SDK tests: **611 passed, 8 skipped, 0 failed**
- Demo tests: **3 passed, 0 failed**
- Touched SDK and demo analysis: **no issues found**
- Full SDK analysis: **745 existing findings**, improved from the **770** baseline
- SDK formatting: **162 files checked, no changes required**
- `git diff --check`: passed
- Independent specification/architecture review: **PASS**
- Independent security/privacy/code-quality review: **PASS**
- iPhone 17 simulator debug build and launch: passed
- Flutter Marionette MCP:
  - inspected the rendered widget tree and screenshots
  - dismissed and reopened the Existing Profiles sheet
  - verified the tree changed from 6 to 14 interactive elements and returned to 6
  - observed no Flutter error screen or exception overlay

Marionette's `get_logs` command returned a server-side tooling error, so runtime error validation used the Flutter process output plus widget-tree and screenshot inspection.

## Not covered

- No authenticated connection or billable call was placed during simulator validation.
