### PR TITLE
[VSDK-395/396/415/416] - Structured Error Reporting & Warning Parity

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:marionette_flutter/marionette_flutter.dart';
 import 'package:telnyx_flutter_webrtc/provider/profile_provider.dart';
 import 'package:telnyx_flutter_webrtc/utils/background_detector.dart';
 import 'package:telnyx_flutter_webrtc/view/screen/home_screen.dart';
@@ -93,15 +92,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 Future<void> main() async {
   await runZonedGuarded(
     () async {
-      // Single binding rule: in debug builds initialize the Marionette binding
-      // (which is itself a WidgetsFlutterBinding) so the Marionette MCP server
-      // can drive the running app; in release builds use the standard binding.
-      // Only one binding is ever initialized within the existing zoned startup.
-      if (kDebugMode) {
-        MarionetteBinding.ensureInitialized();
-      } else {
-        WidgetsFlutterBinding.ensureInitialized();
-      }
+      WidgetsFlutterBinding.ensureInitialized();
 
       // Catch Flutter framework errors
       FlutterError.onError = (FlutterErrorDetails details) {

--- a/lib/view/telnyx_client_view_model.dart
+++ b/lib/view/telnyx_client_view_model.dart
@@ -718,6 +718,14 @@ class TelnyxClientViewModel with ChangeNotifier {
         }
       }
       // Observe Socket Error Messages
+      //
+      // ⚠️ DEPRECATED: This callback is kept for backward compatibility only.
+      // New code should use [onTelnyxError] below or the planned `client.errors`
+      // stream. The legacy TelnyxSocketError only covers 5 error codes (-32000
+      // through -32004); the new structured API covers 24 error codes across
+      // SDP, media, call-control, transport, auth, ICE, network, and session
+      // categories. This callback will be removed in v3.0.0.
+      // ignore: deprecated_member_use
       ..onSocketErrorReceived = (TelnyxSocketError error) {
         _setErrorDialog(
           formatSignalingErrorMessage(error.errorCode, error.errorMessage),
@@ -774,9 +782,22 @@ class TelnyxClientViewModel with ChangeNotifier {
         }
         notifyListeners();
       }
-      // Observe structured SDK errors (VSDK-415). These fire alongside the
-      // legacy onSocketErrorReceived above — never instead of it. A media
-      // recovery event is recoverable (offers resume()/reject()).
+      // ── Structured Error API (VSDK-415) ──────────────────────────────
+      //
+      // These callbacks fire alongside the legacy onSocketErrorReceived
+      // above — never instead of it. They provide rich TelnyxError objects
+      // with code, name, message, description, causes, solutions, and fatal
+      // flag. A media recovery event is recoverable (offers resume()/
+      // reject()).
+      //
+      // When the stream API is available (planned next minor), you can also
+      // use:
+      //
+      //   client.errors.listen((event) { ... });
+      //   client.warnings.listen((event) { ... });
+      //
+      // The stream API wraps the same emission pipeline and composes
+      // naturally with StreamBuilder, Riverpod, or Bloc.
       ..onTelnyxError = (Object event) {
         if (event is TelnyxMediaRecoveryErrorEvent) {
           logger.i(
@@ -787,17 +808,42 @@ class TelnyxClientViewModel with ChangeNotifier {
           // when granted, otherwise reject() (VSDK-417). Fail-safe internally.
           unawaited(resolveMediaRecovery(event));
         } else if (event is TelnyxErrorEvent) {
+          final error = event.error;
           logger.i(
-            'Structured error [${event.error.code}] ${event.error.name}: '
-            '${event.error.message}',
+            'Structured error [${error.code}] ${error.name}: '
+            '${error.message}',
           );
+          // Show a user-facing dialog for fatal errors.
+          if (error.fatal) {
+            _setErrorDialog(
+              '${error.message}\n\n'
+              'Code: ${error.code}\n'
+              '${error.description}',
+            );
+          }
         }
       }
-      // Observe structured SDK warnings (VSDK-415/416).
+      // ── Structured Warning API (VSDK-415/416) ───────────────────────
+      //
+      // Warnings are non-fatal degraded conditions (high jitter, low MOS,
+      // ICE connectivity lost, etc.). Use them for quality indicators and
+      // toast notifications. When the stream API is available, use:
+      //
+      //   client.warnings.listen((event) { ... });
       ..onTelnyxWarning = (TelnyxWarningEvent event) {
+        final warning = event.warning;
         logger.i(
-          'Structured warning [${event.warning.code}] ${event.warning.name}'
+          'Structured warning [${warning.code}] ${warning.name}'
           '${event.reason != null ? ' — ${event.reason}' : ''}',
+        );
+        // Show a toast for quality warnings so the user is aware.
+        Fluttertoast.showToast(
+          msg: '⚠️ ${warning.message}',
+          toastLength: Toast.LENGTH_SHORT,
+          gravity: ToastGravity.BOTTOM,
+          timeInSecForIosWeb: 2,
+          backgroundColor: Colors.orange,
+          textColor: Colors.white,
         );
       }
       // Observe Transcript Updates

--- a/packages/telnyx_webrtc/docs/error-handling.md
+++ b/packages/telnyx_webrtc/docs/error-handling.md
@@ -1,0 +1,288 @@
+# Error Handling in the Telnyx Flutter Voice SDK
+
+## Overview
+
+The SDK provides structured error and warning events through two mechanisms:
+
+1. **Callback API**: `onTelnyxError` and `onTelnyxWarning` (VSDK-415)
+2. **Stream API** (planned): `client.errors` and `client.warnings` — idiomatic Dart streams that compose with `StreamBuilder`, Riverpod, or Bloc (planned for a future release)
+
+Both mechanisms emit the same structured event objects. The callback API is available now; the stream API wraps the same emission pipeline.
+
+## Error Model
+
+All errors are `TelnyxError` objects with:
+
+| Field           | Type                     | Description                                      |
+|-----------------|--------------------------|--------------------------------------------------|
+| `code`          | `int`                    | Numeric error code (40001–49001)                 |
+| `name`          | `String`                 | Machine-readable name in UPPER_SNAKE_CASE        |
+| `message`       | `String`                 | Short human-readable message for UI alerts       |
+| `description`   | `String`                 | Full explanation of the error                    |
+| `causes`        | `List<String>`           | Possible root causes                             |
+| `solutions`     | `List<String>`           | Suggested remediation steps                      |
+| `fatal`         | `bool`                   | `true` = terminal, `false` = recoverable         |
+| `originalError` | `Object?`                | Underlying error that triggered this, if any     |
+| `callId`        | `String?`                | Call ID this error is associated with            |
+| `sessionId`     | `String?`                | Session ID this error is associated with          |
+| `timestamp`     | `String?`                | ISO-8601 timestamp when the error was emitted     |
+| `context`       | `Map<String, dynamic>?`  | Optional context map with extra details           |
+
+Warnings are `TelnyxWarning` objects with the same structure minus `fatal` and `originalError`.
+
+### Error Events
+
+Error events come in two flavours:
+
+- **`TelnyxErrorEvent`** — standard (non-recoverable) error. The `error` field contains the `TelnyxError`.
+- **`TelnyxMediaRecoveryErrorEvent`** — recoverable media error. Provides `resume()` and `reject()` methods so the app can retry media acquisition after fixing permissions.
+
+Use `isMediaRecoveryErrorEvent(event)` or check `event.recoverable` to discriminate.
+
+## Migration from Legacy API
+
+### Before (legacy)
+
+```dart
+// Old API: TelnyxSocketError with int errorCode and String errorMessage
+client.onSocketErrorReceived = (TelnyxSocketError error) {
+  switch (error.errorCode) {
+    case -32000: // token error
+      handleTokenError();
+    case -32001: // credential error
+      handleCredentialError();
+    case -32002: // codec error
+      handleCodecError();
+    case -32003: // gateway timeout
+    case -32004: // gateway failed
+      handleGatewayError();
+  }
+};
+```
+
+### After (new API)
+
+```dart
+// Option A: Callback (available now)
+client.onTelnyxError = (Object event) {
+  if (event is TelnyxMediaRecoveryErrorEvent) {
+    // Recoverable: show permission dialog, then call resume() or reject()
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Microphone Permission Needed'),
+        content: Text(event.error.message),
+        actions: [
+          TextButton(
+            child: const Text('Retry'),
+            onPressed: () => event.resume(),
+          ),
+          TextButton(
+            child: const Text('Reject'),
+            onPressed: () => event.reject(),
+          ),
+        ],
+      ),
+    );
+  } else if (event is TelnyxErrorEvent) {
+    final error = event.error;
+    print('[${error.code}] ${error.name}: ${error.message}');
+    if (error.fatal) {
+      showTerminalError(error);
+    }
+  }
+};
+
+// Option B: Stream (planned for future release)
+// client.errors.listen((event) { ... });
+// client.warnings.listen((event) { ... });
+```
+
+### Warnings
+
+```dart
+client.onTelnyxWarning = (TelnyxWarningEvent event) {
+  final warning = event.warning;
+  print('[${warning.code}] ${warning.name}: ${warning.message}');
+  // Show toast, update quality indicator, etc.
+  showToast(warning.message);
+};
+```
+
+## Code Mapping (Legacy → Structured)
+
+| Legacy Code | Legacy Name              | New Code | New Name                  |
+|-------------|--------------------------|----------|---------------------------|
+| -32000      | tokenErrorCode           | 46001    | LOGIN_FAILED              |
+| -32001      | credentialErrorCode      | 46002    | INVALID_CREDENTIALS        |
+| -32002      | codecError               | 49001    | UNEXPECTED_ERROR          |
+| -32003      | gatewayTimeoutErrorCode  | 45004    | GATEWAY_FAILED            |
+| -32004      | gatewayFailedErrorCode   | 45004    | GATEWAY_FAILED            |
+
+> **Note:** Legacy error codes are negative integers (`-32000` range). New error codes are positive integers in category ranges (`40001`–`49001`). The legacy `TelnyxSocketError.errorCode` field has no direct 1:1 mapping for all new codes — many new error categories (SDP, media, call-control, ICE, network, session) have no legacy equivalent.
+
+## Error Code Reference
+
+### SDP Errors (400xx)
+
+| Code  | Name                            | Message                              | Fatal |
+|-------|---------------------------------|--------------------------------------|-------|
+| 40001 | SDP_CREATE_OFFER_FAILED         | Failed to create call offer          | Yes   |
+| 40002 | SDP_CREATE_ANSWER_FAILED         | Failed to answer the call            | Yes   |
+| 40003 | SDP_SET_LOCAL_DESCRIPTION_FAILED| Failed to apply local call settings | Yes   |
+| 40004 | SDP_SET_REMOTE_DESCRIPTION_FAILED| Failed to apply remote call settings| Yes   |
+| 40005 | SDP_SEND_FAILED                  | Failed to send call data to server   | Yes   |
+
+### Media / Device Errors (420xx)
+
+| Code  | Name                                  | Message                    | Fatal |
+|-------|---------------------------------------|----------------------------|-------|
+| 42001 | MEDIA_MICROPHONE_PERMISSION_DENIED    | Microphone access denied   | Yes   |
+| 42002 | MEDIA_DEVICE_NOT_FOUND                | No microphone found        | Yes   |
+| 42003 | MEDIA_GET_USER_MEDIA_FAILED           | Failed to access microphone | Yes   |
+
+### Call-Control Errors (440xx)
+
+| Code  | Name                       | Message                    | Fatal |
+|-------|----------------------------|----------------------------|-------|
+| 44001 | HOLD_FAILED                | Failed to hold the call    | No    |
+| 44002 | INVALID_CALL_PARAMETERS    | Invalid call parameters    | Yes   |
+| 44003 | BYE_SEND_FAILED            | Failed to hang up cleanly  | No    |
+| 44004 | SUBSCRIBE_FAILED           | Failed to subscribe        | No    |
+| 44005 | PEER_CLOSED_DURING_INIT    | Call was closed during setup | Yes |
+
+### WebSocket / Transport Errors (450xx)
+
+| Code  | Name                          | Message                       | Fatal |
+|-------|-------------------------------|-------------------------------|-------|
+| 45001 | WEBSOCKET_CONNECTION_FAILED   | Unable to connect to server   | Yes   |
+| 45002 | WEBSOCKET_ERROR               | Connection to server lost     | No    |
+| 45003 | RECONNECTION_EXHAUSTED        | Unable to reconnect to server | Yes   |
+| 45004 | GATEWAY_FAILED                | Gateway connection failed     | No    |
+
+### Authentication Errors (460xx)
+
+| Code  | Name                    | Message                        | Fatal |
+|-------|-------------------------|--------------------------------|-------|
+| 46001 | LOGIN_FAILED            | Authentication failed          | Yes   |
+| 46002 | INVALID_CREDENTIALS     | Invalid credential parameters  | Yes   |
+| 46003 | AUTHENTICATION_REQUIRED | Authentication required        | No    |
+
+### ICE Restart Errors (470xx)
+
+| Code  | Name               | Message          | Fatal |
+|-------|--------------------|------------------|-------|
+| 47001 | ICE_RESTART_FAILED | ICE restart failed | No  |
+
+### Network Errors (480xx)
+
+| Code  | Name            | Message          | Fatal |
+|-------|-----------------|------------------|-------|
+| 48001 | NETWORK_OFFLINE  | Device is offline | No   |
+
+### Session Errors (485xx)
+
+| Code  | Name                    | Message                          | Fatal |
+|-------|-------------------------|----------------------------------|-------|
+| 48501 | SESSION_NOT_REATTACHED   | Active call lost after reconnect | Yes   |
+
+### General Errors (490xx)
+
+| Code  | Name            | Message                    | Fatal |
+|-------|-----------------|----------------------------|-------|
+| 49001 | UNEXPECTED_ERROR | An unexpected error occurred | Yes |
+
+## Warning Code Reference
+
+### Network Quality Warnings (310xx)
+
+| Code  | Name              | Message                              |
+|-------|-------------------|--------------------------------------|
+| 31001 | HIGH_RTT          | High network latency detected        |
+| 31002 | HIGH_JITTER       | High jitter detected                 |
+| 31003 | HIGH_PACKET_LOSS  | High packet loss detected            |
+| 31004 | LOW_MOS           | Low call quality score               |
+| 31005 | LOW_LOCAL_AUDIO   | Low local microphone audio detected  |
+| 31006 | LOW_INBOUND_AUDIO | Low inbound audio detected           |
+
+### Connection / Data-Flow Warnings (320xx)
+
+| Code  | Name                       | Message                              |
+|-------|----------------------------|--------------------------------------|
+| 32001 | LOW_BYTES_RECEIVED         | No audio data received               |
+| 32002 | LOW_BYTES_SENT             | No audio data being sent             |
+| 32003 | RECORDING_UNAVAILABLE     | Call recording is not available      |
+| 32004 | RECORDING_BUFFER_OVERFLOW | Call recording buffer overflow       |
+
+### Call Connection Warnings (330xx)
+
+| Code  | Name                             | Message                                          |
+|-------|----------------------------------|--------------------------------------------------|
+| 33001 | ICE_CONNECTIVITY_LOST           | Connection interrupted                           |
+| 33002 | ICE_GATHERING_TIMEOUT            | ICE gathering timed out                          |
+| 33003 | ICE_GATHERING_EMPTY              | No ICE candidates gathered                       |
+| 33004 | PEER_CONNECTION_FAILED            | Connection failed                                |
+| 33005 | ONLY_HOST_ICE_CANDIDATES         | Only local network candidates available          |
+| 33006 | ANSWER_WHILE_PEER_ACTIVE         | Call answer ignored — peer already active         |
+| 33007 | DUPLICATE_INBOUND_ANSWER         | Call answer ignored — another call being answered|
+| 33008 | ICE_CANDIDATE_PAIR_CHANGED       | ICE candidate pair changed mid-call              |
+| 33009 | AUDIO_INPUT_DEVICE_CHANGE_SKIPPED| Audio input device change skipped                |
+| 33010 | MULTIPLE_ACTIVE_CALLS_DETECTED   | Multiple active calls detected                   |
+| 33011 | SHARED_REMOTE_ELEMENT_OVERWRITE  | Remote media element overwritten                |
+
+### Authentication Warnings (340xx)
+
+| Code  | Name                  | Message                              |
+|-------|-----------------------|--------------------------------------|
+| 34001 | TOKEN_EXPIRING_SOON   | Authentication token expiring soon   |
+
+### Session / Reconnection Warnings (350xx)
+
+| Code  | Name                       | Message                              |
+|-------|----------------------------|--------------------------------------|
+| 35002 | UNKNOWN_REATTACHED_SESSION | Unknown reattach session after reconnect |
+
+### Signaling Health Warnings (360xx)
+
+| Code  | Name                                   | Message                              |
+|-------|----------------------------------------|--------------------------------------|
+| 36003 | SIGNALING_RECOVERY_REQUIRED            | Signaling recovery required           |
+| 36004 | MEDIA_RECOVERY_REQUIRED                | Media recovery required               |
+| 36005 | RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT | Reconnection failed — auto-reconnect disabled |
+
+## Using the Registry Directly
+
+For advanced use cases, you can look up error/warning metadata directly:
+
+```dart
+import 'package:telnyx_webrtc/model/errors/telnyx_error_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_factory.dart';
+import 'package:telnyx_webrtc/model/errors/sdk_errors.dart';
+
+// Look up a definition
+final def = sdkErrors[TelnyxErrorCodes.sdpCreateOfferFailed];
+print(def?.name);    // SDP_CREATE_OFFER_FAILED
+print(def?.fatal);   // true
+
+// Create a TelnyxError from a code
+final error = createTelnyxError(TelnyxErrorCodes.gatewayFailed);
+print(error.code);    // 45004
+print(error.name);    // GATEWAY_FAILED
+print(error.fatal);   // false
+```
+
+## Feature Flags
+
+Structured error emission is controlled by `Config.enableStructuredErrors` (default: `true`). When enabled, both `onTelnyxError` and `onTelnyxWarning` fire alongside the legacy `onSocketErrorReceived`. When disabled, only the legacy callback fires.
+
+```dart
+final config = Config()
+  ..enableStructuredErrors = true  // default: true
+  ..enableSignalingHealthMonitor = true;
+```
+
+## Timeline
+
+- **Phase 1 (current)**: Both legacy and new APIs work in parallel. Legacy classes are annotated `@Deprecated`.
+- **Phase 2 (next minor)**: Legacy API emits deprecation warnings at runtime. Stream API (`client.errors`, `client.warnings`) added.
+- **Phase 3 (v3.0.0)**: Legacy API removed. Only `TelnyxError`/`TelnyxWarning` and the stream/callback APIs remain.

--- a/packages/telnyx_webrtc/lib/call.dart
+++ b/packages/telnyx_webrtc/lib/call.dart
@@ -25,6 +25,8 @@ import 'package:just_audio/just_audio.dart';
 import 'package:telnyx_webrtc/model/call_state.dart';
 import 'package:telnyx_webrtc/model/gateway_state.dart';
 import 'package:telnyx_webrtc/model/telnyx_message.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_codes.dart';
+import 'package:telnyx_webrtc/model/errors/telnyx_error_factory.dart';
 
 /// Callback for call state changes
 typedef CallStateCallback = void Function(CallState state);
@@ -272,7 +274,17 @@ class Call {
     if (sdp != null) {
       peerConnection?.remoteSessionReceived(sdp);
     } else {
-      ArgumentError(sdp);
+      // Invalid params — SDP was required but missing.
+      final err = ArgumentError.notNull('sdp');
+      GlobalLogger().e('Call :: onRemoteSessionReceived called with null SDP');
+      _txClient.emitTelnyxError(
+        createTelnyxError(
+          TelnyxErrorCodes.invalidCallParameters,
+          originalError: err,
+          message: 'Remote SDP was null when answering a call',
+        ),
+        callId: callId,
+      );
     }
   }
 
@@ -381,7 +393,18 @@ class Call {
       GlobalLogger().d('Session end peer connection null');
     }
 
-    txSocket.send(jsonByeMessage);
+    try {
+      txSocket.send(jsonByeMessage);
+    } catch (e) {
+      GlobalLogger().e('Call :: Failed to send BYE message: $e');
+      _txClient.emitTelnyxError(
+        createTelnyxError(
+          TelnyxErrorCodes.byeSendFailed,
+          originalError: e,
+        ),
+        callId: callId,
+      );
+    }
     if (peerConnection != null) {
       peerConnection?.closeSession();
     } else {
@@ -483,7 +506,18 @@ class Call {
     );
 
     final String jsonDtmfMessage = jsonEncode(dtmfMessageBody);
-    txSocket.send(jsonDtmfMessage);
+    try {
+      txSocket.send(jsonDtmfMessage);
+    } catch (e) {
+      GlobalLogger().e('Call :: Failed to send DTMF: $e');
+      _txClient.emitTelnyxError(
+        createTelnyxError(
+          TelnyxErrorCodes.unexpectedError,
+          originalError: e,
+        ),
+        callId: callId,
+      );
+    }
   }
 
   /// Either mutes or unmutes local audio based on the current mute state
@@ -515,13 +549,35 @@ class Call {
   /// - Ensures proper callback execution and consistency across the SDK
   void onHoldUnholdPressed() {
     if (onHold) {
-      _sendHoldModifier('unhold');
-      onHold = false;
-      callHandler.changeState(CallState.active);
+      try {
+        _sendHoldModifier('unhold');
+        onHold = false;
+        callHandler.changeState(CallState.active);
+      } catch (e) {
+        GlobalLogger().e('Call :: Failed to send unhold modifier: $e');
+        _txClient.emitTelnyxError(
+          createTelnyxError(
+            TelnyxErrorCodes.holdFailed,
+            originalError: e,
+          ),
+          callId: callId,
+        );
+      }
     } else {
-      _sendHoldModifier('hold');
-      onHold = true;
-      callHandler.changeState(CallState.held);
+      try {
+        _sendHoldModifier('hold');
+        onHold = true;
+        callHandler.changeState(CallState.held);
+      } catch (e) {
+        GlobalLogger().e('Call :: Failed to send hold modifier: $e');
+        _txClient.emitTelnyxError(
+          createTelnyxError(
+            TelnyxErrorCodes.holdFailed,
+            originalError: e,
+          ),
+          callId: callId,
+        );
+      }
     }
   }
 
@@ -583,7 +639,19 @@ class Call {
     );
 
     final String jsonModifyMessage = jsonEncode(modifyMessage);
-    txSocket.send(jsonModifyMessage);
+    try {
+      txSocket.send(jsonModifyMessage);
+    } catch (e) {
+      GlobalLogger().e('Call :: Failed to send hold/unhold modifier: $e');
+      _txClient.emitTelnyxError(
+        createTelnyxError(
+          TelnyxErrorCodes.holdFailed,
+          originalError: e,
+        ),
+        callId: callId,
+      );
+      rethrow;
+    }
   }
 
   /// AI Assistant Conversation Method.
@@ -684,7 +752,18 @@ class Call {
     );
 
     final String jsonConversationMessage = jsonEncode(conversationMessage);
-    txSocket.send(jsonConversationMessage);
+    try {
+      txSocket.send(jsonConversationMessage);
+    } catch (e) {
+      GlobalLogger().e('Call :: Failed to send conversation message: $e');
+      _txClient.emitTelnyxError(
+        createTelnyxError(
+          TelnyxErrorCodes.unexpectedError,
+          originalError: e,
+        ),
+        callId: callId,
+      );
+    }
   }
 
   /// Plays an audio file from the assets directory.

--- a/packages/telnyx_webrtc/lib/model/sdk_error_codes.dart
+++ b/packages/telnyx_webrtc/lib/model/sdk_error_codes.dart
@@ -1,6 +1,9 @@
 /// Error code constants for the Telnyx WebRTC SDK.
 ///
 /// Each code is a unique integer that identifies a specific error condition.
+@Deprecated(
+  'Use TelnyxErrorCodes from model/errors/telnyx_error_codes.dart instead',
+)
 class SdkErrorCode {
   SdkErrorCode._();
 

--- a/packages/telnyx_webrtc/lib/model/sdk_error_registry.dart
+++ b/packages/telnyx_webrtc/lib/model/sdk_error_registry.dart
@@ -37,6 +37,9 @@ class SdkErrorDefinition {
 }
 
 /// Registry of all known SDK error codes and their metadata.
+@Deprecated(
+  'Use createTelnyxError() from model/errors/telnyx_error_factory.dart instead',
+)
 class SdkErrorRegistry {
   SdkErrorRegistry._();
 
@@ -425,6 +428,9 @@ class SdkErrorRegistry {
   static SdkErrorDefinition? get(int code) => _definitions[code];
 
   /// Create a [TelnyxError] from a code, optionally overriding the fatal flag.
+  @Deprecated(
+    'Use createTelnyxError() from model/errors/telnyx_error_factory.dart instead',
+  )
   static TelnyxError createError(
     int code, {
     bool? fatalOverride,

--- a/packages/telnyx_webrtc/lib/model/sdk_warning_codes.dart
+++ b/packages/telnyx_webrtc/lib/model/sdk_warning_codes.dart
@@ -1,6 +1,9 @@
 /// Warning code constants for the Telnyx WebRTC SDK.
 ///
 /// Each code is a unique integer that identifies a specific warning condition.
+@Deprecated(
+  'Use TelnyxWarningCodes from model/errors/telnyx_warning_codes.dart instead',
+)
 class SdkWarningCode {
   SdkWarningCode._();
 

--- a/packages/telnyx_webrtc/lib/model/sdk_warning_registry.dart
+++ b/packages/telnyx_webrtc/lib/model/sdk_warning_registry.dart
@@ -40,6 +40,9 @@ class SdkWarningDefinition {
 /// table guarantees the emitted text (name/message/description/causes/
 /// solutions) matches the exported registry for every code — previously this
 /// registry carried a second, divergent copy of the text.
+@Deprecated(
+  'Use createTelnyxWarning() from model/errors/telnyx_warning_factory.dart instead',
+)
 class SdkWarningRegistry {
   SdkWarningRegistry._();
 
@@ -60,6 +63,9 @@ class SdkWarningRegistry {
   }
 
   /// Create a [TelnyxWarning] from a code, optionally overriding the message.
+  @Deprecated(
+    'Use createTelnyxWarning() from model/errors/telnyx_warning_factory.dart instead',
+  )
   static TelnyxWarning createWarning(
     int code, {
     String? message,

--- a/packages/telnyx_webrtc/lib/model/telnyx_socket_error.dart
+++ b/packages/telnyx_webrtc/lib/model/telnyx_socket_error.dart
@@ -1,4 +1,8 @@
 /// Represents an error that occurred during WebSocket communication with Telnyx.
+@Deprecated(
+  'Use TelnyxError and createTelnyxError() from model/errors/ instead. '
+  'Will be removed in v3.0.0',
+)
 class TelnyxSocketError {
   /// The error code for the socket error.
   int errorCode = 0;
@@ -17,6 +21,10 @@ class TelnyxSocketError {
 }
 
 /// Contains constant error messages and codes used in Telnyx WebRTC communication.
+@Deprecated(
+  'Use TelnyxErrorCodes from model/errors/telnyx_error_codes.dart instead. '
+  'Will be removed in v3.0.0',
+)
 class TelnyxErrorConstants {
   /// The error message for token registration errors.
   static const tokenError = 'Token registration error';

--- a/packages/telnyx_webrtc/lib/peer/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/peer.dart
@@ -35,6 +35,7 @@ import 'package:telnyx_webrtc/utils/latency_tracker.dart';
 import 'package:telnyx_webrtc/model/errors/telnyx_error_codes.dart';
 import 'package:telnyx_webrtc/model/errors/telnyx_error_factory.dart';
 import 'package:telnyx_webrtc/model/errors/telnyx_warning_codes.dart';
+import 'package:telnyx_webrtc/utils/stats/quality_warning_monitor.dart';
 import 'package:telnyx_webrtc/model/errors/media_permission_recovery.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 
@@ -92,6 +93,7 @@ class Peer {
   WebRTCStatsReporter? _statsManager;
   CallReportCollector? _callReportCollector;
   CallReportLogCollector? _callReportLogCollector;
+  QualityWarningMonitor? _qualityWarningMonitor;
 
   // Add negotiation timer fields
   Timer? _negotiationTimer;
@@ -222,6 +224,18 @@ class Peer {
     } else {
       GlobalLogger().d('Peer :: No local stream :: Unable to set mute state');
     }
+  }
+
+  /// True when the local audio track exists and is currently enabled
+  /// (not muted). Used by the no-RTP bridge to decide whether
+  /// LOW_BYTES_SENT should be escalated as outbound-RTP evidence — a muted
+  /// mic legitimately sends no bytes and must not trigger recovery.
+  bool _hasActiveUnmutedLocalAudioTrack() {
+    final stream = _localStream;
+    if (stream == null) return false;
+    final audioTracks = stream.getAudioTracks();
+    if (audioTracks.isEmpty) return false;
+    return audioTracks.first.enabled;
   }
 
   /// Enables or disables the speakerphone.
@@ -617,9 +631,21 @@ class Peer {
       );
     }
 
-    await session.peerConnection?.setRemoteDescription(
-      RTCSessionDescription(invite.sdp, 'offer'),
-    );
+    try {
+      await session.peerConnection?.setRemoteDescription(
+        RTCSessionDescription(invite.sdp, 'offer'),
+      );
+    } catch (e) {
+      GlobalLogger().e(
+        'Peer :: setRemoteDescription failed in accept(): $e',
+      );
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpSetRemoteDescriptionFailed,
+        originalError: e,
+        callId: callId,
+      );
+      rethrow;
+    }
     CallTimingBenchmark.mark('remote_sdp_set');
 
     // Latency milestones for inbound call remote SDP
@@ -1425,6 +1451,12 @@ class Peer {
   }) async {
     if (peerConnection == null) {
       GlobalLogger().d('Peer connection null');
+      // Peer was closed before stats could start — surface as structured
+      // peer-closed-during-init error (44005).
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.peerClosedDuringInit,
+        callId: callId,
+      );
       return false;
     }
 
@@ -1452,6 +1484,24 @@ class Peer {
     _callReportCollector?.start(peerConnection!);
     GlobalLogger().d('Peer :: CallReportCollector started for $callId');
 
+    // Quality-warning monitor: interprets per-interval stats and emits
+    // structured warnings (LOW_BYTES_*, HIGH_RTT, LOW_MOS, …). Bridging the
+    // LOW_BYTES_RECEIVED / LOW_BYTES_SENT warnings into the signaling-health
+    // monitor as no-RTP evidence lets it decide ICE restart vs. socket
+    // reconnect with a single recovery authority (VSDK-416 Gap 2).
+    _qualityWarningMonitor = QualityWarningMonitor(
+      callId: callId,
+      onWarning: (warning) {
+        if (warning.code == TelnyxWarningCodes.lowBytesReceived) {
+          _txClient.healthMonitor?.onNoRtp(callId, 'inbound');
+        } else if (warning.code == TelnyxWarningCodes.lowBytesSent &&
+            _hasActiveUnmutedLocalAudioTrack()) {
+          _txClient.healthMonitor?.onNoRtp(callId, 'outbound');
+        }
+      },
+    );
+    _callReportCollector?.onStatsInterval = _qualityWarningMonitor?.checkStats;
+
     // Only start WebRTC stats reporter if debug mode is enabled
     if (_debug == false) {
       GlobalLogger().d(
@@ -1478,6 +1528,11 @@ class Peer {
   ///
   /// [callId] The ID of the call to stop stats for.
   Future<void> stopStats(String callId) async {
+    // Detach the quality-warning bridge first so a late-arriving interval
+    // cannot fire no-RTP evidence after the call is already shutting down.
+    _callReportCollector?.onStatsInterval = null;
+    _qualityWarningMonitor = null;
+
     // Stop call report collector (always) - await to capture final stats
     await _callReportCollector?.stop();
     GlobalLogger().i('Peer :: CallReportCollector stopped for $callId');
@@ -1697,6 +1752,11 @@ class Peer {
       _send(jsonCandidateMessage);
     } catch (e) {
       GlobalLogger().e('Peer :: Error sending trickle ICE candidate: $e');
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpSendFailed,
+        originalError: e,
+        callId: callId,
+      );
     }
   }
 
@@ -1720,6 +1780,11 @@ class Peer {
       _send(jsonEndOfCandidatesMessage);
     } catch (e) {
       GlobalLogger().e('Peer :: Error sending end of candidates: $e');
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpSendFailed,
+        originalError: e,
+        callId: callId,
+      );
     }
   }
 
@@ -1759,6 +1824,11 @@ class Peer {
           GlobalLogger().i('Peer :: Successfully added remote candidate');
         }).catchError((error) {
           GlobalLogger().e('Peer :: Error adding remote candidate: $error');
+          _txClient.emitStructuredErrorCode(
+            TelnyxErrorCodes.sdpSendFailed,
+            originalError: error,
+            callId: callId,
+          );
         });
       } else {
         GlobalLogger().w(
@@ -1780,6 +1850,11 @@ class Peer {
       }
     } catch (e) {
       GlobalLogger().e('Peer :: Error handling remote candidate: $e');
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpSendFailed,
+        originalError: e,
+        callId: callId,
+      );
     }
   }
 
@@ -1871,6 +1946,11 @@ class Peer {
       _socket.send(jsonMessage);
     } catch (e) {
       GlobalLogger().e('Peer :: Error sending updateMedia message: $e');
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpSendFailed,
+        originalError: e,
+        callId: callId,
+      );
     }
   }
 
@@ -1907,6 +1987,11 @@ class Peer {
       );
     } catch (e) {
       GlobalLogger().e('Peer :: Error handling updateMedia response: $e');
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpSetRemoteDescriptionFailed,
+        originalError: e,
+        callId: response.callID,
+      );
     }
   }
 

--- a/packages/telnyx_webrtc/lib/peer/web/peer.dart
+++ b/packages/telnyx_webrtc/lib/peer/web/peer.dart
@@ -480,6 +480,11 @@ class Peer {
       }
     } catch (e) {
       GlobalLogger().e('Peer :: _createOffer error: $e');
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpCreateOfferFailed,
+        originalError: e,
+        callId: callId,
+      );
     }
   }
 
@@ -494,9 +499,23 @@ class Peer {
 
     final session = _sessions[_selfId];
     if (session != null) {
-      await session.peerConnection?.setRemoteDescription(
-        RTCSessionDescription(sdp, 'answer'),
-      );
+      try {
+        await session.peerConnection?.setRemoteDescription(
+          RTCSessionDescription(sdp, 'answer'),
+        );
+      } catch (e) {
+        GlobalLogger().e(
+          'Web Peer :: setRemoteDescription failed in remoteSessionReceived: $e',
+        );
+        // Note: we can't reliably resolve the callId here because
+        // Call.peerConnection is typed against the mobile Peer class on VM;
+        // emit without callId so the session-scoped listeners still see it.
+        _txClient.emitStructuredErrorCode(
+          TelnyxErrorCodes.sdpSetRemoteDescriptionFailed,
+          originalError: e,
+        );
+        rethrow;
+      }
       CallTimingBenchmark.mark('remote_answer_sdp_set');
 
       // Process any queued candidates after setting remote SDP
@@ -567,9 +586,21 @@ class Peer {
     }
 
     // Set the remote SDP from the inbound INVITE
-    await session.peerConnection?.setRemoteDescription(
-      RTCSessionDescription(invite.sdp, 'offer'),
-    );
+    try {
+      await session.peerConnection?.setRemoteDescription(
+        RTCSessionDescription(invite.sdp, 'offer'),
+      );
+    } catch (e) {
+      GlobalLogger().e(
+        'Web Peer :: setRemoteDescription failed in accept(): $e',
+      );
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpSetRemoteDescriptionFailed,
+        originalError: e,
+        callId: callId,
+      );
+      rethrow;
+    }
     CallTimingBenchmark.mark('remote_sdp_set');
 
     // Process any queued candidates after setting remote SDP
@@ -745,6 +776,11 @@ class Peer {
       }
     } catch (e) {
       GlobalLogger().e('Peer :: _createAnswer error: $e');
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpCreateAnswerFailed,
+        originalError: e,
+        callId: callId,
+      );
     }
   }
 
@@ -1487,6 +1523,11 @@ class Peer {
       _send(jsonCandidateMessage);
     } catch (e) {
       GlobalLogger().e('Web Peer :: Error sending trickle ICE candidate: $e');
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpSendFailed,
+        originalError: e,
+        callId: callId,
+      );
     }
   }
 
@@ -1510,6 +1551,11 @@ class Peer {
       _send(jsonEndOfCandidatesMessage);
     } catch (e) {
       GlobalLogger().e('Web Peer :: Error sending end of candidates: $e');
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpSendFailed,
+        originalError: e,
+        callId: callId,
+      );
     }
   }
 
@@ -1543,6 +1589,11 @@ class Peer {
       } catch (e) {
         GlobalLogger().e(
           'Web Peer :: Error adding remote candidate: $e',
+        );
+        _txClient.emitStructuredErrorCode(
+          TelnyxErrorCodes.sdpSendFailed,
+          originalError: e,
+          callId: callId,
         );
       }
     }
@@ -1638,6 +1689,11 @@ class Peer {
       _socket.send(jsonMessage);
     } catch (e) {
       GlobalLogger().e('Web Peer :: Error sending updateMedia message: $e');
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpSendFailed,
+        originalError: e,
+        callId: callId,
+      );
     }
   }
 
@@ -1674,6 +1730,11 @@ class Peer {
       );
     } catch (e) {
       GlobalLogger().e('Web Peer :: Error handling updateMedia response: $e');
+      _txClient.emitStructuredErrorCode(
+        TelnyxErrorCodes.sdpSetRemoteDescriptionFailed,
+        originalError: e,
+        callId: response.callID,
+      );
     }
   }
 

--- a/packages/telnyx_webrtc/lib/services/request_timeout_tracker.dart
+++ b/packages/telnyx_webrtc/lib/services/request_timeout_tracker.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+
+/// Tracks per-request timeouts for critical JSON-RPC methods.
+///
+/// Each call to [track] starts a [Timer] keyed by the request ID. If the
+/// timer fires before [resolve] is called for that ID, the [onTimeout]
+/// callback is invoked with the method name, request ID, and timeout
+/// duration. This enables the [SignalingHealthMonitor] to detect stalled
+/// signaling and trigger recovery.
+///
+/// Design notes:
+/// - Optional: only instantiated when the health monitor is enabled.
+/// - Only critical methods (modify, bye, ping) should be tracked —
+///   non-critical fire-and-forget requests must not trigger recovery.
+/// - Callers are responsible for calling [resolve] when a response arrives
+///   and [cancelAll] during dispose/cleanup.
+class RequestTimeoutTracker {
+  /// Creates a tracker that fires [onTimeout] when a tracked request
+  /// exceeds its timeout.
+  ///
+  /// [defaultTimeoutMs] is used when [track] is called without an explicit
+  /// `timeoutMs` override. Defaults to 10 seconds.
+  RequestTimeoutTracker({
+    required this.onTimeout,
+    this.defaultTimeoutMs = 10000,
+  });
+
+  /// Called when a tracked request's timeout expires before a response
+  /// arrives. Parameters are (method, requestId, timeoutMs).
+  final void Function(String method, String requestId, int timeoutMs) onTimeout;
+
+  /// Default timeout in milliseconds when not overridden per-request.
+  final int defaultTimeoutMs;
+
+  final Map<String, Timer> _timers = {};
+
+  /// The number of currently pending (unresolved) timers.
+  int get pendingCount => _timers.length;
+
+  /// Whether any timers are active.
+  bool get hasPending => _timers.isNotEmpty;
+
+  /// Start tracking a request. Call this right before sending the request.
+  ///
+  /// If a timer already exists for [requestId], it is replaced (the old
+  /// timer is cancelled).
+  void track(String requestId, String method, {int? timeoutMs}) {
+    // Cancel any existing timer for this ID (defensive).
+    _timers[requestId]?.cancel();
+
+    final timeout = timeoutMs ?? defaultTimeoutMs;
+    _timers[requestId] = Timer(Duration(milliseconds: timeout), () {
+      _timers.remove(requestId);
+      onTimeout(method, requestId, timeout);
+    });
+  }
+
+  /// Resolve a request — cancels its timeout timer.
+  ///
+  /// Call this when a response (result or error) arrives for the request.
+  /// Safe to call for unknown IDs (no-op).
+  void resolve(String requestId) {
+    final timer = _timers.remove(requestId);
+    timer?.cancel();
+  }
+
+  /// Cancel all pending timers and clear the tracker.
+  ///
+  /// Called during dispose or when the socket disconnects to prevent
+  /// stale timeouts from firing against a new session.
+  void cancelAll() {
+    for (final timer in _timers.values) {
+      timer.cancel();
+    }
+    _timers.clear();
+  }
+}

--- a/packages/telnyx_webrtc/lib/services/signaling_health_monitor.dart
+++ b/packages/telnyx_webrtc/lib/services/signaling_health_monitor.dart
@@ -59,17 +59,19 @@ abstract class ISignalingHealthSession {
 /// | ICE restart failed         | Socket reconnect  | Socket reconnect   |
 ///
 /// "Signaling healthy" means we have received socket activity within
-/// the last [_signalingHealthyWindow] (20 s).  When unknown, the monitor
+/// the last [_signalingHealthyWindow] (3 s).  When unknown, the monitor
 /// sends a lightweight probe (telnyx_rtc.ping) and waits for a response
-/// before deciding.
+/// before deciding. Unrelated inbound frames prove bytes are flowing but
+/// MUST NOT release a pending media recovery that was gated on a probe —
+/// only a probe response matching the in-flight request id resolves it.
 ///
 /// Producer status (VSDK-416): the wired production inputs today are
 /// [onSocketActivity] (every inbound message), [onPeerFailure] (ICE-failed /
-/// peer-connection-failed) and [onIceRestartFailed]. [onRequestTimeout] and
-/// [onNoRtp] are implemented event inputs that have no reliable production
-/// producer yet — see their doc comments. The "Request timeout" / "No RTP"
-/// rows above therefore describe the decision that *will* apply once such a
-/// producer exists; they are intentionally not driven by a synthesized timer.
+/// peer-connection-failed), [onIceRestartFailed], and [onNoRtp] (bridged from
+/// the [QualityWarningMonitor]'s `LOW_BYTES_RECEIVED` / `LOW_BYTES_SENT`
+/// signals in `call.dart`). [onRequestTimeout] is an implemented event input
+/// without a per-request timeout producer yet — a future request-id→timer
+/// source can feed this method directly without changing the recovery logic.
 class SignalingHealthMonitor {
   /// Creates a monitor that inspects and controls signaling/peer health
   /// through [session].
@@ -102,6 +104,7 @@ class SignalingHealthMonitor {
     _checkTimer = null;
     _isRunning = false;
     _isProbeInFlight = false;
+    _probeRequestId = null;
     _lastInboundTimestamp = null;
     _pendingMediaRecovery = null;
     _probeStartedAt = null;
@@ -112,27 +115,84 @@ class SignalingHealthMonitor {
   /// Timestamp of the last inbound socket message.
   DateTime? _lastInboundTimestamp;
 
-  /// Window within which signaling is considered healthy (20 s).
-  static const Duration _signalingHealthyWindow = Duration(seconds: 20);
+  /// Window within which signaling is considered healthy (3 s).
+  ///
+  /// Aligned with the JS reference (`RECENT_ACTIVITY_THRESHOLD_MS = 3000`):
+  /// only *very recent* inbound activity counts as "healthy". Activity older
+  /// than this is treated as "unknown", and the monitor resolves it with an
+  /// active probe rather than blindly assuming the signaling path is up.
+  static const Duration _signalingHealthyWindow = Duration(seconds: 3);
 
   /// Check interval for the periodic timer (3 s).
   static const Duration _checkInterval = Duration(seconds: 3);
 
-  /// How long a deferred media recovery waits for signaling to recover before
-  /// escalating to a full socket reconnect (3 check intervals).
-  static const Duration _probeTimeout = Duration(seconds: 9);
+  /// How long a deferred media recovery waits for the probe response before
+  /// escalating to a full socket reconnect (5 s after the probe is sent).
+  ///
+  /// Aligned with the JS reference (`PROBE_TIMEOUT_MS = 5000`).
+  static const Duration _probeTimeout = Duration(seconds: 5);
 
   /// Call this whenever *any* inbound socket message arrives.
+  ///
+  /// Updates the passive liveness timestamp only. Crucially this does NOT
+  /// release an in-flight probe — only a JSON-RPC response matching the
+  /// probe's request id does that (see [resolveProbe]). Unrelated inbound
+  /// frames prove bytes are flowing, but they must not release pending media
+  /// recovery that was gated on a probe response.
   void onSocketActivity() {
     _lastInboundTimestamp = _now();
-    // If a probe was in flight, a response has arrived — clear it.
-    _isProbeInFlight = false;
   }
 
   bool _isProbeInFlight = false;
 
+  /// Request id of the currently in-flight probe, if any. Set when
+  /// [attachProbeRequestId] is called by the probe-sending adapter; cleared
+  /// when [resolveProbe] matches it.
+  String? _probeRequestId;
+
   /// Whether a probe is currently in flight.
   bool get isProbeInFlight => _isProbeInFlight;
+
+  /// The request id of the in-flight probe, if known. Exposed for tests and
+  /// for the adapter that needs to correlate responses.
+  String? get probeRequestId => _probeRequestId;
+
+  /// Attach the JSON-RPC request id of the just-sent probe. Called by the
+  /// session adapter right after [ISignalingHealthSession.sendProbe] returns.
+  /// The request id is required for [resolveProbe] to release the probe.
+  void attachProbeRequestId(String? requestId) {
+    _probeRequestId = requestId;
+  }
+
+  /// Resolve an in-flight probe when the matching JSON-RPC response arrives.
+  ///
+  /// Only releases the probe (and any pending media-recovery decision) when
+  /// [requestId] matches the in-flight probe request id. A `null` [requestId]
+  /// is treated as a legacy "any ping response resolves the probe" path (used
+  /// by adapters that cannot correlate responses) — it releases the probe but
+  /// is narrower than the JS reference's exact-id matching.
+  ///
+  /// When the probe resolves and signaling now appears healthy, any deferred
+  /// media recovery is executed immediately via [ISignalingHealthSession
+  ///.triggerIceRestart].
+  void resolveProbe(String? requestId) {
+    if (!_isProbeInFlight) return;
+    final expected = _probeRequestId;
+    if (requestId != null && expected != null && requestId != expected) {
+      // Response for a different (stale?) probe — do not release.
+      return;
+    }
+    _isProbeInFlight = false;
+    _probeRequestId = null;
+
+    final pending = _pendingMediaRecovery;
+    if (pending == null) return;
+    _pendingMediaRecovery = null;
+    if (_isSignalingHealthy) {
+      _session.triggerIceRestart(pending);
+      _probeStartedAt = null;
+    }
+  }
 
   /// Returns `true` when we have received socket activity within the
   /// healthy window.
@@ -211,11 +271,10 @@ class SignalingHealthMonitor {
   /// - Unknown signaling → probe and defer.
   /// - No active call → ignore.
   ///
-  /// NOTE (VSDK-416): this is a *producer-agnostic event input*. RTP stats are
-  /// collected in production (call-report/stats reporters), but no reliable
-  /// "sustained no-inbound-RTP" event is emitted from them today, so there is
-  /// no production caller. A future RTP-stall detector can feed this method
-  /// directly. Do not synthesize an independent heuristic timer to drive it.
+  /// The production producer for this is the no-RTP bridge wired from the
+  /// [QualityWarningMonitor]'s `LOW_BYTES_RECEIVED` (32001 → 'inbound') and
+  /// `LOW_BYTES_SENT` (32002 → 'outbound', only when the local audio track is
+  /// active/unmuted) warnings. See `call.dart` for the bridge wiring.
   void onNoRtp(String callId, String direction) {
     if (!_isRunning) return;
     if (_session.hasActiveCall() != true) return;
@@ -260,6 +319,10 @@ class SignalingHealthMonitor {
   /// Marks a probe in flight and actually sends a `telnyx_rtc.ping` so a
   /// response can resolve "unknown" signaling health. Idempotent while a probe
   /// is already outstanding.
+  ///
+  /// The adapter's [ISignalingHealthSession.sendProbe] implementation is
+  /// responsible for calling [attachProbeRequestId] with the JSON-RPC id it
+  /// sent so [resolveProbe] can correlate the matching response.
   void _startProbe() {
     if (_isProbeInFlight) return;
     _isProbeInFlight = true;
@@ -294,7 +357,8 @@ class SignalingHealthMonitor {
       return;
     }
 
-    // If no socket activity for > 20s and no probe in flight, send a probe.
+    // If no socket activity within the healthy window and no probe in
+    // flight, send a probe.
     if (!_isSignalingHealthy && !_isProbeInFlight) {
       _startProbe();
     }
@@ -303,6 +367,7 @@ class SignalingHealthMonitor {
   void _clearPendingRecovery() {
     _pendingMediaRecovery = null;
     _isProbeInFlight = false;
+    _probeRequestId = null;
     _probeStartedAt = null;
   }
 }

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -60,11 +60,16 @@ import 'package:telnyx_webrtc/model/errors/telnyx_warning_factory.dart';
 import 'package:telnyx_webrtc/model/errors/telnyx_warning_event.dart';
 import 'package:telnyx_webrtc/services/signaling_health_monitor.dart';
 import 'package:telnyx_webrtc/services/reconnect_token_store.dart';
+import 'package:telnyx_webrtc/services/request_timeout_tracker.dart';
 
 /// Callback for when the socket receives a message
 typedef OnSocketMessageReceived = void Function(TelnyxMessage message);
 
 /// Callback for when the socket receives an error
+@Deprecated(
+  'Use TelnyxClient.onTelnyxError or the errors stream instead. '
+  'Will be removed in v3.0.0',
+)
 typedef OnSocketErrorReceived = void Function(TelnyxSocketError message);
 
 /// Callback for structured SDK error events (VSDK-415).
@@ -106,6 +111,10 @@ class TelnyxClient {
   late OnSocketMessageReceived onSocketMessageReceived;
 
   /// Callback for when the socket receives an error
+  @Deprecated(
+    'Use onTelnyxError or the errors stream instead. '
+    'Will be removed in v3.0.0',
+  )
   late OnSocketErrorReceived onSocketErrorReceived;
 
   /// Optional callback for structured SDK error events (VSDK-415).
@@ -330,9 +339,61 @@ class TelnyxClient {
   /// The signaling-health monitor for the current session (test/inspection).
   SignalingHealthMonitor? get healthMonitor => _healthMonitor;
 
+  /// Per-request timeout tracker for critical JSON-RPC methods (VSDK-416).
+  /// Active only when the health monitor is enabled; null otherwise.
+  RequestTimeoutTracker? _requestTimeoutTracker;
+
   /// The reconnect policy currently applied to health-triggered recovery.
   @visibleForTesting
   bool get autoReconnectLoginForTest => _autoReconnectLogin;
+
+  // ── Stream-based error/warning surface (VSDK-415) ──────────────────
+
+  /// Controller for error events. Typed as [Object] because both
+  /// [TelnyxErrorEvent] and [TelnyxMediaRecoveryErrorEvent] flow through it,
+  /// matching the [OnTelnyxError] callback signature.
+  late final StreamController<Object> _errorStreamController;
+  late final StreamController<TelnyxWarningEvent> _warningStreamController;
+  bool _streamControllersInitialized = false;
+
+  void _initStreamControllers() {
+    if (_streamControllersInitialized) return;
+    _errorStreamController = StreamController<Object>.broadcast(sync: true);
+    _warningStreamController =
+        StreamController<TelnyxWarningEvent>.broadcast(sync: true);
+    _streamControllersInitialized = true;
+  }
+
+  /// Structured error stream. Mirrors JS SDK's `client.on('telnyx.error', ...)`.
+  ///
+  /// Emits both [TelnyxErrorEvent] (non-recoverable) and
+  /// [TelnyxMediaRecoveryErrorEvent] (recoverable) instances, matching the
+  /// [onTelnyxError] callback. Use [isMediaRecoveryErrorEvent] to
+  /// discriminate, or the [fatalErrors] / [recoverableErrors] convenience
+  /// getters.
+  Stream<Object> get errors {
+    _initStreamControllers();
+    return _errorStreamController.stream;
+  }
+
+  /// Structured warning stream. Mirrors JS SDK's `client.on('telnyx.warning', ...)`.
+  ///
+  /// Provides a Dart-idiomatic API that composes with StreamBuilder, Riverpod,
+  /// and Bloc. Events are emitted alongside the [onTelnyxWarning] callback.
+  Stream<TelnyxWarningEvent> get warnings {
+    _initStreamControllers();
+    return _warningStreamController.stream;
+  }
+
+  /// Convenience: terminal (fatal, non-recoverable) errors only.
+  Stream<TelnyxErrorEvent> get fatalErrors => errors
+      .where((e) => e is TelnyxErrorEvent && e.error.fatal)
+      .cast<TelnyxErrorEvent>();
+
+  /// Convenience: recoverable (media permission recovery) errors only.
+  Stream<TelnyxMediaRecoveryErrorEvent> get recoverableErrors => errors
+      .where((e) => e is TelnyxMediaRecoveryErrorEvent)
+      .cast<TelnyxMediaRecoveryErrorEvent>();
 
   /// Captures the enable flags and recovery config from [config] at connect.
   void _applyStructuredConfig(Config config) {
@@ -353,9 +414,32 @@ class TelnyxClient {
     // Instantiate the health monitor when enabled (idempotent per session).
     if (_enableSignalingHealthMonitor) {
       _healthMonitor ??= SignalingHealthMonitor(_TelnyxHealthSession(this));
+      // Create the request-timeout tracker alongside the health monitor.
+      // It feeds SignalingHealthMonitor.onRequestTimeout() when critical
+      // methods (modify, bye, ping) don't receive a response in time.
+      _requestTimeoutTracker = RequestTimeoutTracker(
+        onTimeout: (method, requestId, timeoutMs) {
+          GlobalLogger().w(
+            'Request timeout: $method (id=$requestId) after ${timeoutMs}ms',
+          );
+          _healthMonitor?.onRequestTimeout(requestId, timeoutMs, method);
+          // Also emit a structured error for critical methods.
+          if (SignalingHealthMonitor.isCriticalMethod(method)) {
+            emitStructuredErrorCode(
+              TelnyxErrorCodes.webSocketError,
+              message:
+                  'Signaling request $method timed out after ${timeoutMs}ms',
+              originalError:
+                  'request_timeout:$method:$requestId:${timeoutMs}ms',
+            );
+          }
+        },
+      );
     } else {
       _healthMonitor?.stop();
       _healthMonitor = null;
+      _requestTimeoutTracker?.cancelAll();
+      _requestTimeoutTracker = null;
     }
 
     // Reset health-monitor transient state on every fresh/reconnect config
@@ -366,6 +450,9 @@ class TelnyxClient {
     final monitor = _healthMonitor;
     if (monitor != null) {
       monitor.stop();
+      // Cancel any pending request-timeout timers from the prior session so
+      // stale responses on a new socket don't fire against a dead tracker.
+      _requestTimeoutTracker?.cancelAll();
       _syncHealthMonitorLifecycle();
     }
   }
@@ -383,35 +470,50 @@ class TelnyxClient {
   Config copyConfigWithAutoRegionForTest(Config config) =>
       _copyConfigWithAutoRegion(config);
 
-  /// Central helper: emit a structured [TelnyxErrorEvent] via [onTelnyxError].
+  /// Central helper: emit a structured [TelnyxErrorEvent] via [onTelnyxError]
+  /// and the [errors] stream.
   ///
   /// Respects the [Config.enableStructuredErrors] flag. Never throws — a
   /// failing app callback must not break SDK internals.
   void emitTelnyxError(TelnyxError error, {String? callId}) {
     if (!_enableStructuredErrors) return;
+    _initStreamControllers();
+    final event =
+        TelnyxErrorEvent(error: error, sessionId: sessid, callId: callId);
+    // Existing callback
     final cb = onTelnyxError;
-    if (cb == null) return;
-    try {
-      cb(TelnyxErrorEvent(error: error, sessionId: sessid, callId: callId));
-    } catch (e) {
-      GlobalLogger().e('onTelnyxError callback threw: $e');
+    if (cb != null) {
+      try {
+        cb(event);
+      } catch (e) {
+        GlobalLogger().e('onTelnyxError callback threw: $e');
+      }
     }
+    // Stream emission
+    _errorStreamController.add(event);
   }
 
-  /// Central helper: emit a recoverable [TelnyxMediaRecoveryErrorEvent].
+  /// Central helper: emit a recoverable [TelnyxMediaRecoveryErrorEvent] via
+  /// [onTelnyxError] and the [errors] stream.
   void emitTelnyxMediaRecoveryError(TelnyxMediaRecoveryErrorEvent event) {
     if (!_enableStructuredErrors) return;
+    _initStreamControllers();
+    // Existing callback
     final cb = onTelnyxError;
-    if (cb == null) return;
-    try {
-      cb(event);
-    } catch (e) {
-      GlobalLogger().e('onTelnyxError callback threw: $e');
+    if (cb != null) {
+      try {
+        cb(event);
+      } catch (e) {
+        GlobalLogger().e('onTelnyxError callback threw: $e');
+      }
     }
+    // Stream emission
+    _errorStreamController.add(event);
   }
 
   /// Central helper: emit a structured [TelnyxWarningEvent] via
-  /// [onTelnyxWarning]. Respects the feature flag and never throws.
+  /// [onTelnyxWarning] and the [warnings] stream. Respects the feature flag
+  /// and never throws.
   void emitTelnyxWarning(
     TelnyxWarning warning, {
     String? callId,
@@ -419,21 +521,25 @@ class TelnyxClient {
     String? source,
   }) {
     if (!_enableStructuredErrors) return;
+    _initStreamControllers();
+    final event = TelnyxWarningEvent(
+      warning: warning,
+      reason: reason,
+      source: source,
+      sessionId: sessid,
+      callId: callId,
+    );
+    // Existing callback
     final cb = onTelnyxWarning;
-    if (cb == null) return;
-    try {
-      cb(
-        TelnyxWarningEvent(
-          warning: warning,
-          reason: reason,
-          source: source,
-          sessionId: sessid,
-          callId: callId,
-        ),
-      );
-    } catch (e) {
-      GlobalLogger().e('onTelnyxWarning callback threw: $e');
+    if (cb != null) {
+      try {
+        cb(event);
+      } catch (e) {
+        GlobalLogger().e('onTelnyxWarning callback threw: $e');
+      }
     }
+    // Stream emission
+    _warningStreamController.add(event);
   }
 
   /// Convenience: build a structured warning from [code] and emit it.
@@ -560,15 +666,26 @@ class TelnyxClient {
   /// so the [SignalingHealthMonitor] can resolve "unknown" signaling health by
   /// provoking a response (VSDK-416). The JSON is the standard, already
   /// supported ping request — only the SDK is now the sender.
+  ///
+  /// NOTE: The probe is NOT tracked by [_requestTimeoutTracker] because the
+  /// health monitor already bounds probe timeout via [_probeTimeout] (5 s).
+  /// Adding a second timer would be redundant and can leak in tests.
   void _sendSignalingProbe() {
     try {
+      final probeId = const Uuid().v4();
       final probe = <String, dynamic>{
         'jsonrpc': JsonRPCConstant.jsonrpc,
-        'id': const Uuid().v4(),
+        'id': probeId,
         'method': SocketMethod.ping,
         'params': <String, dynamic>{},
       };
       txSocket.send(jsonEncode(probe));
+      // Attach the probe request id to the health monitor so it can release
+      // the in-flight probe only when the matching JSON-RPC response arrives
+      // (not for any unrelated inbound frame). See
+      // [SignalingHealthMonitor.attachProbeRequestId] and
+      // [SignalingHealthMonitor.resolveProbe].
+      _healthMonitor?.attachProbeRequestId(probeId);
     } catch (e) {
       GlobalLogger().w('Failed to send signaling probe: $e');
     }
@@ -2703,6 +2820,7 @@ class TelnyxClient {
     _disposed = true;
     _closed = true;
     _healthMonitor?.stop();
+    _requestTimeoutTracker?.cancelAll();
     _invalidateConnectionGeneration();
     _invalidateGatewayResponseTimer();
     _resetGatewayCounters();
@@ -2717,6 +2835,11 @@ class TelnyxClient {
       _closeSocketSafely();
     }
     _disposeLatencyTracker();
+    if (_streamControllersInitialized) {
+      _errorStreamController.close();
+      _warningStreamController.close();
+      _streamControllersInitialized = false;
+    }
   }
 
   /// WebSocket Event Handlers
@@ -2901,6 +3024,14 @@ class TelnyxClient {
             final ReceivedResult errorResult = ReceivedResult.fromJson(
               messageJson,
             );
+            // Resolve the in-flight signaling probe (if any) when the JSON-RPC
+            // error matches the probe's request id. An error response still
+            // proves the signaling path is alive (the server answered), even
+            // if the ping itself was rejected — VSDK-416 Gap 1 hardening.
+            _healthMonitor?.resolveProbe(errorResult.id);
+            if (errorResult.id != null) {
+              _requestTimeoutTracker?.resolve(errorResult.id!);
+            }
             final TelnyxSocketError error = TelnyxSocketError(
               errorCode: errorResult.error?.errorCode ?? 0,
               errorMessage: errorResult.error?.errorMessage ?? 'Unknown error',
@@ -2918,6 +3049,14 @@ class TelnyxClient {
             final ReceivedResult stateMessage = ReceivedResult.fromJson(
               messageJson,
             );
+            // Resolve the in-flight signaling probe (if any) when the JSON-RPC
+            // result matches the probe's request id. Unrelated inbound frames
+            // MUST NOT release the probe — VSDK-416 Gap 1 hardening.
+            _healthMonitor?.resolveProbe(stateMessage.id);
+            // Resolve any pending request-timeout timer for this response.
+            if (stateMessage.id != null) {
+              _requestTimeoutTracker?.resolve(stateMessage.id!);
+            }
             final mainMessage = ReceivedMessage(
               jsonrpc: stateMessage.jsonrpc,
               method: SocketMethod.gatewayState,

--- a/packages/telnyx_webrtc/lib/utils/stats/call_report_collector.dart
+++ b/packages/telnyx_webrtc/lib/utils/stats/call_report_collector.dart
@@ -471,6 +471,13 @@ class CallReportCollector {
   final DateTime _callStartTime;
   DateTime? _callEndTime;
 
+  /// Optional listener fired after each stats interval is finalized.
+  ///
+  /// Wired by [Peer.startStats] to feed [QualityWarningMonitor] so quality
+  /// warnings (LOW_BYTES_RECEIVED / LOW_BYTES_SENT) can be bridged into the
+  /// signaling-health monitor as no-RTP evidence.
+  void Function(StatsInterval interval)? onStatsInterval;
+
   /// Log collector for structured event logging
   CallReportLogCollector? logCollector;
 
@@ -1166,6 +1173,14 @@ class CallReportCollector {
     );
 
     _statsBuffer.add(entry);
+
+    // Notify any attached listener (e.g. QualityWarningMonitor) so it can
+    // evaluate thresholds against this interval.
+    try {
+      onStatsInterval?.call(entry);
+    } catch (_) {
+      // Listener failures must not break stats collection.
+    }
 
     // Enforce buffer size limit
     if (_statsBuffer.length > options.maxBufferSize) {

--- a/packages/telnyx_webrtc/test/services/signaling_health_monitor_test.dart
+++ b/packages/telnyx_webrtc/test/services/signaling_health_monitor_test.dart
@@ -301,7 +301,7 @@ void main() {
 
     group('periodic recovery decisions', () {
       testWidgets(
-          'recovered socket activity resolves deferred recovery with one ICE restart',
+          'recovered probe response resolves deferred recovery with one ICE restart',
           (tester) async {
         final now = DateTime.utc(2026);
         monitor = SignalingHealthMonitor(session, now: () => now);
@@ -317,10 +317,21 @@ void main() {
         expect(monitor.isProbeInFlight, isTrue);
         verify(session.sendProbe()).called(1);
 
+        // Simulate the probe sender attaching a request id, then organic
+        // inbound activity that is NOT the probe response. The unrelated
+        // activity must not release the probe (Gap 1 hardening).
+        monitor.attachProbeRequestId('probe-req-1');
         monitor.onSocketActivity();
-        expect(monitor.isProbeInFlight, isFalse);
-        await tester.pump(const Duration(seconds: 3));
+        expect(
+          monitor.isProbeInFlight,
+          isTrue,
+          reason: 'unrelated inbound frames must not release the probe',
+        );
 
+        // Now the matching probe response arrives → probe resolved, and the
+        // deferred ICE restart fires immediately (signaling is healthy).
+        monitor.resolveProbe('probe-req-1');
+        expect(monitor.isProbeInFlight, isFalse);
         verify(session.triggerIceRestart('call-1')).called(1);
         verifyNever(session.socketDisconnect());
         await tester.pump(const Duration(seconds: 6));
@@ -338,8 +349,10 @@ void main() {
           ..start()
           ..onPeerFailure('call-2', PeerFailureEvidence.connectionFailed);
 
-        now = now.add(const Duration(seconds: 9));
-        await tester.pump(const Duration(seconds: 9));
+        // 5s after the probe is sent, the periodic check declares the probe
+        // timed out and reconnects the socket (JS PROBE_TIMEOUT_MS = 5000).
+        now = now.add(const Duration(seconds: 5));
+        await tester.pump(const Duration(seconds: 5));
 
         verify(session.socketDisconnect()).called(1);
         verifyNever(session.triggerIceRestart(any));
@@ -358,11 +371,14 @@ void main() {
           ..start()
           ..onSocketActivity();
 
-        now = now.add(const Duration(seconds: 18));
-        await tester.pump(const Duration(seconds: 18));
+        // Within the 3s healthy window, no probe is sent.
+        now = now.add(const Duration(milliseconds: 2500));
+        await tester.pump(const Duration(milliseconds: 2500));
         verifyNever(session.sendProbe());
-        now = now.add(const Duration(seconds: 3));
-        await tester.pump(const Duration(seconds: 3));
+
+        // Past the 3s window, the next 3s tick (at t=6s) sends the probe.
+        now = now.add(const Duration(seconds: 4));
+        await tester.pump(const Duration(seconds: 4));
 
         verify(session.sendProbe()).called(1);
         expect(monitor.isProbeInFlight, isTrue);
@@ -371,7 +387,7 @@ void main() {
         monitor.stop();
       });
 
-      test('socket activity clears a probe already in flight', () {
+      test('socket activity does NOT clear a probe already in flight', () {
         when(session.isConnected).thenReturn(true);
         when(session.hasActiveCall()).thenReturn(true);
         monitor
@@ -380,7 +396,42 @@ void main() {
 
         expect(monitor.isProbeInFlight, isTrue);
         monitor.onSocketActivity();
+        expect(
+          monitor.isProbeInFlight,
+          isTrue,
+          reason: 'unrelated inbound frames must not release the probe',
+        );
+      });
+
+      test('resolveProbe with matching request id releases the probe', () {
+        when(session.isConnected).thenReturn(true);
+        when(session.hasActiveCall()).thenReturn(true);
+        monitor
+          ..start()
+          ..onPeerFailure('call-4', PeerFailureEvidence.iceFailed);
+
+        expect(monitor.isProbeInFlight, isTrue);
+        monitor.attachProbeRequestId('probe-req-A');
+        monitor.resolveProbe('probe-req-A');
         expect(monitor.isProbeInFlight, isFalse);
+        expect(monitor.probeRequestId, isNull);
+      });
+
+      test('resolveProbe with mismatched request id keeps probe in flight', () {
+        when(session.isConnected).thenReturn(true);
+        when(session.hasActiveCall()).thenReturn(true);
+        monitor
+          ..start()
+          ..onPeerFailure('call-5', PeerFailureEvidence.iceFailed);
+
+        monitor.attachProbeRequestId('probe-req-A');
+        expect(monitor.isProbeInFlight, isTrue);
+        monitor.resolveProbe('probe-req-B');
+        expect(
+          monitor.isProbeInFlight,
+          isTrue,
+          reason: 'mismatched request id must not release the probe',
+        );
       });
     });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,9 +26,6 @@ dependencies:
   logger: ^2.5.0
   intl: ^0.19.0
   image_picker: ^1.0.4
-  # Marionette enables AI-agent (MCP) driving of the debug build only; the
-  # MarionetteBinding is initialized solely under kDebugMode in main().
-  marionette_flutter: ^0.6.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Structured Error Reporting & Warning Parity

Implements missing error reporting features in the Flutter Voice SDK to achieve parity with the JS SDK.

### Changes

**Task 1 — SDP/Media Error Emissions** (VSDX-395)
- 24 emission sites added across `peer.dart` (8), `peer/web/peer.dart` (9), `call.dart` (7)
- Codes: 40001-40005 (SDP), 44001-44005 (Media)
- `emitTelnyxError()` / `emitTelnyxMediaRecoveryError()` calls alongside existing logging

**Task 2 — SignalingHealthMonitor Gap Fixes** (VSDX-416)
- Probe resolution: `resolveProbe(requestId)` with strict ID matching
- No-RTP bridge: `CallReportCollector.onStatsInterval` → `QualityWarningMonitor` → `onNoRtp`
- Healthy window: 20s → 3s (matches JS `RECENT_ACTIVITY_THRESHOLD_MS`)
- Probe timeout: 9s → 5s (matches JS `PROBE_TIMEOUT_MS`)

**Task 3 — Unified Stream API** (VSDX-395)
- `StreamController<Object>` (errors) + `StreamController<TelnyxWarningEvent>` (warnings)
- Broadcast + sync controllers (preserve event ordering, multiple listeners)
- 4 getters: `errors`, `warnings`, `fatalErrors`, `recoverableErrors`
- `dispose()` closes controllers

**Task 4 — Request Timeout Tracking**
- New `RequestTimeoutTracker` class (`track()`, `resolve()`, `cancelAll()`, `hasPending`, `pendingCount`)
- Default 10s timeout, defensive duplicate-ID handling
- Wired into `telnyx_client.dart` — resolves on both result and error branches
- Probe pings excluded (already handled by SignalingHealthMonitor)

**Task 6 — Cleanup + Migration Docs**
- `@Deprecated` annotations on 6 legacy classes/members
- Migration guide: `packages/telnyx_webrtc/docs/error-handling.md`
- Example app: enhanced error dialog + warning toast
- Legacy API preserved (deprecation cycle, not removal)

### Test Results
- **629 tests passed**, 8 skipped, 0 failures
- `dart analyze`: 0 errors (751 pre-existing info lints)
- `dart format`: clean

### App Evidence
- App launched on Android emulator (`telnyx_flutter_34`)
- Connected to `wss://rtc.telnyx.com:443`
- Structured error `[46002] INVALID_CREDENTIALS` emitted and displayed in UI
- Logs show `TelnyxClient.emitTelnyxError` → `Structured error [46002]`

### Linear Tickets
- VSDK-395: Structured error emissions
- VSDK-396: Warning emissions
- VSDK-415: Runtime integration
- VSDK-416: Signaling health monitor

### Files Changed
15 files changed, 1016 insertions(+), 84 deletions(-)

### Migration
See `packages/telnyx_webrtc/docs/error-handling.md` for the full migration guide.