### PR TITLE
[VSUP-184] - Fall back to default ICE servers when server-provided config has empty URLs

### DIFF
--- a/packages/telnyx_webrtc/lib/model/tx_ice_server.dart
+++ b/packages/telnyx_webrtc/lib/model/tx_ice_server.dart
@@ -71,7 +71,12 @@ class TxIceServer {
     if (urlsValue is String) {
       urls = [urlsValue];
     } else if (urlsValue is List) {
-      urls = urlsValue.cast<String>();
+      urls = urlsValue.whereType<String>().toList();
+      if (urls.length != urlsValue.length) {
+        GlobalLogger().w(
+          'TxIceServer :: Ignored non-string values in ICE server urls list.',
+        );
+      }
     } else {
       GlobalLogger().w(
         'TxIceServer :: Invalid urls value type in ICE server config: ${urlsValue?.runtimeType}. Expected String or List<String>.',

--- a/packages/telnyx_webrtc/lib/src/ice_server_resolver.dart
+++ b/packages/telnyx_webrtc/lib/src/ice_server_resolver.dart
@@ -1,0 +1,63 @@
+import 'package:telnyx_webrtc/config.dart';
+import 'package:telnyx_webrtc/model/tx_ice_server.dart';
+import 'package:telnyx_webrtc/model/tx_server_configuration.dart';
+import 'package:telnyx_webrtc/utils/logging/global_logger.dart';
+
+List<TxIceServer> resolveEffectiveIceServers({
+  List<TxIceServer>? configIceServers,
+  TxServerConfiguration? serverConfig,
+  required TxServerConfiguration defaultServerConfig,
+}) {
+  final custom = _sanitize(configIceServers, 'Config');
+  if (custom.isNotEmpty) return custom;
+
+  final server = _sanitize(
+    serverConfig?.webRTCIceServers,
+    'serverConfiguration',
+  );
+  if (server.isNotEmpty) return server;
+
+  final clientDefaults = _sanitize(
+    defaultServerConfig.webRTCIceServers,
+    'default serverConfiguration',
+  );
+  if (clientDefaults.isNotEmpty) return clientDefaults;
+
+  GlobalLogger().w(
+    'TelnyxClient :: Default serverConfiguration has no valid ICE URLs; using SDK defaults',
+  );
+  return defaultServerConfig.environment == WebRTCEnvironment.development
+      ? DefaultConfig.defaultDevIceServers
+      : DefaultConfig.defaultProdIceServers;
+}
+
+List<TxIceServer> _sanitize(List<TxIceServer>? servers, String source) {
+  if (servers == null || servers.isEmpty) return const [];
+
+  final sanitized = <TxIceServer>[];
+  var removedUrls = 0;
+  for (final server in servers) {
+    final urls = server.urls.where((url) => url.trim().isNotEmpty).toList();
+    removedUrls += server.urls.length - urls.length;
+    if (urls.isNotEmpty) {
+      sanitized.add(TxIceServer(
+        urls: urls,
+        username: server.username,
+        credential: server.credential,
+      ));
+    }
+  }
+
+  final removedServers = servers.length - sanitized.length;
+  if (removedServers > 0 || removedUrls > 0) {
+    GlobalLogger().w(
+      'TelnyxClient :: Filtered $removedServers invalid ICE server(s) and $removedUrls empty URL(s) from $source',
+    );
+  }
+  if (sanitized.isNotEmpty) {
+    GlobalLogger().i(
+      'TelnyxClient :: Using ICE servers from $source (${sanitized.length} servers)',
+    );
+  }
+  return sanitized;
+}

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -1025,14 +1025,37 @@ class TelnyxClient {
   /// 1. Custom ICE servers from Config (iceServers property)
   /// 2. ICE servers from serverConfiguration (webRTCIceServers property)
   /// 3. Default ICE servers from serverConfiguration
-  List<TxIceServer> _getEffectiveIceServers() {
+  List<TxIceServer> getEffectiveIceServers() {
     final config = _storedCredentialConfig ?? _storedTokenConfig;
+    return resolveEffectiveIceServers(
+      configIceServers: config?.iceServers,
+      serverConfig: config?.serverConfiguration,
+      defaultServerConfig: _serverConfiguration,
+    );
+  }
 
+  /// Resolves the effective ICE servers from the given priority layers.
+  ///
+  /// Extracted as a static method so tests can exercise the exact same logic
+  /// without instantiating a [TelnyxClient] (which requires socket/network
+  /// dependencies).
+  @visibleForTesting
+  static List<TxIceServer> resolveEffectiveIceServers({
+    List<TxIceServer>? configIceServers,
+    TxServerConfiguration? serverConfig,
+    required TxServerConfiguration defaultServerConfig,
+  }) {
     // First priority: custom ICE servers from Config
-    final configIceServers = config?.iceServers;
     if (configIceServers != null && configIceServers.isNotEmpty) {
-      final valid = configIceServers.where((s) => s.urls.isNotEmpty).toList();
+      final valid = configIceServers
+          .where((s) => s.urls.any((u) => u.isNotEmpty))
+          .toList();
       if (valid.isNotEmpty) {
+        if (valid.length < configIceServers.length) {
+          GlobalLogger().w(
+            'TelnyxClient :: Filtered ${configIceServers.length - valid.length} empty-URL ICE server(s) from Config',
+          );
+        }
         GlobalLogger().i(
           'TelnyxClient :: Using custom ICE servers from Config (${valid.length} servers)',
         );
@@ -1044,12 +1067,16 @@ class TelnyxClient {
     }
 
     // Second priority: ICE servers from serverConfiguration in Config
-    final serverConfig = config?.serverConfiguration;
     if (serverConfig != null) {
       final valid = serverConfig.webRTCIceServers
-          .where((s) => s.urls.isNotEmpty)
+          .where((s) => s.urls.any((u) => u.isNotEmpty))
           .toList();
       if (valid.isNotEmpty) {
+        if (valid.length < serverConfig.webRTCIceServers.length) {
+          GlobalLogger().w(
+            'TelnyxClient :: Filtered ${serverConfig.webRTCIceServers.length - valid.length} empty-URL ICE server(s) from serverConfiguration',
+          );
+        }
         GlobalLogger().i(
           'TelnyxClient :: Using ICE servers from serverConfiguration (${valid.length} servers)',
         );
@@ -1060,11 +1087,11 @@ class TelnyxClient {
       );
     }
 
-    // Third priority: ICE servers from _serverConfiguration (client-level default)
+    // Third priority: ICE servers from default serverConfiguration (client-level default)
     GlobalLogger().i(
-      'TelnyxClient :: Using ICE servers from default serverConfiguration (${_serverConfiguration.webRTCIceServers.length} servers)',
+      'TelnyxClient :: Using ICE servers from default serverConfiguration (${defaultServerConfig.webRTCIceServers.length} servers)',
     );
-    return _serverConfiguration.webRTCIceServers;
+    return defaultServerConfig.webRTCIceServers;
   }
 
   /// Returns whether or not the client is connected to the socket connection
@@ -2557,7 +2584,7 @@ class TelnyxClient {
       useTrickleIce,
       audioConstraints,
       mutedMicOnStart,
-      _getEffectiveIceServers(),
+      getEffectiveIceServers(),
     );
     // Apply call report config from stored config
     final callReportConfig = _storedCredentialConfig ?? _storedTokenConfig;
@@ -2663,7 +2690,7 @@ class TelnyxClient {
       useTrickleIce,
       audioConstraints,
       mutedMicOnStart,
-      _getEffectiveIceServers(),
+      getEffectiveIceServers(),
     );
     // Apply call report config from stored config
     final answerCallReportConfig =

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -6,6 +6,7 @@ import 'package:telnyx_webrtc/model/call_termination_reason.dart';
 import 'package:telnyx_webrtc/model/connection_status.dart';
 import 'package:telnyx_webrtc/model/network_reason.dart';
 import 'package:telnyx_webrtc/model/tx_ice_server.dart';
+import 'package:telnyx_webrtc/src/ice_server_resolver.dart' as ice_resolver;
 import 'package:telnyx_webrtc/model/verto/receive/update_media_response.dart';
 import 'package:telnyx_webrtc/model/verto/send/attach_call_message.dart';
 import 'package:telnyx_webrtc/peer/peer.dart'
@@ -1025,73 +1026,13 @@ class TelnyxClient {
   /// 1. Custom ICE servers from Config (iceServers property)
   /// 2. ICE servers from serverConfiguration (webRTCIceServers property)
   /// 3. Default ICE servers from serverConfiguration
-  List<TxIceServer> getEffectiveIceServers() {
+  List<TxIceServer> _getEffectiveIceServers() {
     final config = _storedCredentialConfig ?? _storedTokenConfig;
-    return resolveEffectiveIceServers(
+    return ice_resolver.resolveEffectiveIceServers(
       configIceServers: config?.iceServers,
       serverConfig: config?.serverConfiguration,
       defaultServerConfig: _serverConfiguration,
     );
-  }
-
-  /// Resolves the effective ICE servers from the given priority layers.
-  ///
-  /// Extracted as a static method so tests can exercise the exact same logic
-  /// without instantiating a [TelnyxClient] (which requires socket/network
-  /// dependencies).
-  @visibleForTesting
-  static List<TxIceServer> resolveEffectiveIceServers({
-    List<TxIceServer>? configIceServers,
-    TxServerConfiguration? serverConfig,
-    required TxServerConfiguration defaultServerConfig,
-  }) {
-    // First priority: custom ICE servers from Config
-    if (configIceServers != null && configIceServers.isNotEmpty) {
-      final valid = configIceServers
-          .where((s) => s.urls.any((u) => u.isNotEmpty))
-          .toList();
-      if (valid.isNotEmpty) {
-        if (valid.length < configIceServers.length) {
-          GlobalLogger().w(
-            'TelnyxClient :: Filtered ${configIceServers.length - valid.length} empty-URL ICE server(s) from Config',
-          );
-        }
-        GlobalLogger().i(
-          'TelnyxClient :: Using custom ICE servers from Config (${valid.length} servers)',
-        );
-        return valid;
-      }
-      GlobalLogger().w(
-        'TelnyxClient :: Custom ICE servers from Config all have empty URLs, falling back',
-      );
-    }
-
-    // Second priority: ICE servers from serverConfiguration in Config
-    if (serverConfig != null) {
-      final valid = serverConfig.webRTCIceServers
-          .where((s) => s.urls.any((u) => u.isNotEmpty))
-          .toList();
-      if (valid.isNotEmpty) {
-        if (valid.length < serverConfig.webRTCIceServers.length) {
-          GlobalLogger().w(
-            'TelnyxClient :: Filtered ${serverConfig.webRTCIceServers.length - valid.length} empty-URL ICE server(s) from serverConfiguration',
-          );
-        }
-        GlobalLogger().i(
-          'TelnyxClient :: Using ICE servers from serverConfiguration (${valid.length} servers)',
-        );
-        return valid;
-      }
-      GlobalLogger().w(
-        'TelnyxClient :: serverConfiguration ICE servers all have empty URLs, falling back to defaults',
-      );
-    }
-
-    // Third priority: ICE servers from default serverConfiguration (client-level default)
-    GlobalLogger().i(
-      'TelnyxClient :: Using ICE servers from default serverConfiguration (${defaultServerConfig.webRTCIceServers.length} servers)',
-    );
-    return defaultServerConfig.webRTCIceServers;
   }
 
   /// Returns whether or not the client is connected to the socket connection
@@ -2584,7 +2525,7 @@ class TelnyxClient {
       useTrickleIce,
       audioConstraints,
       mutedMicOnStart,
-      getEffectiveIceServers(),
+      _getEffectiveIceServers(),
     );
     // Apply call report config from stored config
     final callReportConfig = _storedCredentialConfig ?? _storedTokenConfig;
@@ -2690,7 +2631,7 @@ class TelnyxClient {
       useTrickleIce,
       audioConstraints,
       mutedMicOnStart,
-      getEffectiveIceServers(),
+      _getEffectiveIceServers(),
     );
     // Apply call report config from stored config
     final answerCallReportConfig =

--- a/packages/telnyx_webrtc/lib/telnyx_client.dart
+++ b/packages/telnyx_webrtc/lib/telnyx_client.dart
@@ -1031,19 +1031,33 @@ class TelnyxClient {
     // First priority: custom ICE servers from Config
     final configIceServers = config?.iceServers;
     if (configIceServers != null && configIceServers.isNotEmpty) {
-      GlobalLogger().i(
-        'TelnyxClient :: Using custom ICE servers from Config (${configIceServers.length} servers)',
+      final valid = configIceServers.where((s) => s.urls.isNotEmpty).toList();
+      if (valid.isNotEmpty) {
+        GlobalLogger().i(
+          'TelnyxClient :: Using custom ICE servers from Config (${valid.length} servers)',
+        );
+        return valid;
+      }
+      GlobalLogger().w(
+        'TelnyxClient :: Custom ICE servers from Config all have empty URLs, falling back',
       );
-      return configIceServers;
     }
 
     // Second priority: ICE servers from serverConfiguration in Config
     final serverConfig = config?.serverConfiguration;
     if (serverConfig != null) {
-      GlobalLogger().i(
-        'TelnyxClient :: Using ICE servers from serverConfiguration (${serverConfig.webRTCIceServers.length} servers)',
+      final valid = serverConfig.webRTCIceServers
+          .where((s) => s.urls.isNotEmpty)
+          .toList();
+      if (valid.isNotEmpty) {
+        GlobalLogger().i(
+          'TelnyxClient :: Using ICE servers from serverConfiguration (${valid.length} servers)',
+        );
+        return valid;
+      }
+      GlobalLogger().w(
+        'TelnyxClient :: serverConfiguration ICE servers all have empty URLs, falling back to defaults',
       );
-      return serverConfig.webRTCIceServers;
     }
 
     // Third priority: ICE servers from _serverConfiguration (client-level default)

--- a/packages/telnyx_webrtc/test/ice_server_fallback_test.dart
+++ b/packages/telnyx_webrtc/test/ice_server_fallback_test.dart
@@ -2,15 +2,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:telnyx_webrtc/config.dart';
 import 'package:telnyx_webrtc/model/tx_ice_server.dart';
 import 'package:telnyx_webrtc/model/tx_server_configuration.dart';
+import 'package:telnyx_webrtc/telnyx_client.dart';
 
-/// Tests for the ICE server empty-URL fallback behaviour in _getEffectiveIceServers().
+/// Tests for the ICE server empty-URL fallback behaviour in
+/// [TelnyxClient.resolveEffectiveIceServers].
 ///
-/// These tests verify that:
-/// 1. TxIceServer with empty urls are filtered out from custom iceServers
-/// 2. When all custom iceServers have empty URLs, falls back to serverConfiguration
-/// 3. When serverConfiguration.webRTCIceServers also has empty URLs, falls back
-///    to client-level defaults
-/// 4. Normal (non-empty) ICE servers pass through unchanged
+/// These tests exercise the *actual* static method used by the SDK (not a
+/// re-implementation) so they catch real regressions.
 void main() {
   group('ICE server empty-URL fallback', () {
     group('TxIceServer.fromJson empty-URL handling', () {
@@ -28,160 +26,127 @@ void main() {
         final server = TxIceServer.fromJson({'urls': 42});
         expect(server.urls, isEmpty);
       });
+
+      test('empty-string urls field produces urls: [""]', () {
+        final server = TxIceServer.fromJson({'urls': ''});
+        expect(server.urls, ['']);
+      });
+
+      test('list with empty string produces urls: [""]', () {
+        final server = TxIceServer.fromJson({
+          'urls': [''],
+        });
+        expect(server.urls, ['']);
+      });
     });
 
-    group('filtering of empty-URL ICE servers', () {
-      test('empty-URL servers are filtered out, valid ones remain', () {
+    group('resolveEffectiveIceServers — filtering of empty-URL ICE servers',
+        () {
+      test('empty-list servers are filtered out, valid ones remain', () {
         const servers = [
           TxIceServer(urls: ['stun:stun.example.com:3478']),
           TxIceServer(urls: []),
           TxIceServer(urls: ['turn:turn.example.com:3478?transport=tcp']),
         ];
 
-        final valid = servers.where((s) => s.urls.isNotEmpty).toList();
+        final result = TelnyxClient.resolveEffectiveIceServers(
+          configIceServers: servers,
+          defaultServerConfig: TxServerConfiguration.production(),
+        );
 
-        expect(valid.length, 2);
-        expect(valid[0].urls, ['stun:stun.example.com:3478']);
-        expect(valid[1].urls, ['turn:turn.example.com:3478?transport=tcp']);
+        expect(result.length, 2);
+        expect(result[0].urls, ['stun:stun.example.com:3478']);
+        expect(result[1].urls, ['turn:turn.example.com:3478?transport=tcp']);
       });
 
-      test('all-empty list filters to empty', () {
+      test('all-empty list filters to empty, falls back to defaults', () {
         const servers = [
           TxIceServer(urls: []),
           TxIceServer(urls: []),
         ];
 
-        final valid = servers.where((s) => s.urls.isNotEmpty).toList();
-
-        expect(valid, isEmpty);
-      });
-    });
-
-    group(
-        'fallback chain: custom iceServers -> serverConfiguration -> defaults',
-        () {
-      // Simulate the _getEffectiveIceServers logic in isolation.
-      // We extract the logic into a testable function that mirrors the
-      // priority order in telnyx_client.dart.
-      List<TxIceServer> resolveEffectiveIceServers({
-        List<TxIceServer>? configIceServers,
-        TxServerConfiguration? configServerConfig,
-        required TxServerConfiguration clientDefault,
-      }) {
-        // First priority: custom ICE servers from Config
-        if (configIceServers != null && configIceServers.isNotEmpty) {
-          final valid =
-              configIceServers.where((s) => s.urls.isNotEmpty).toList();
-          if (valid.isNotEmpty) return valid;
-        }
-
-        // Second priority: ICE servers from serverConfiguration in Config
-        if (configServerConfig != null) {
-          final valid = configServerConfig.webRTCIceServers
-              .where((s) => s.urls.isNotEmpty)
-              .toList();
-          if (valid.isNotEmpty) return valid;
-        }
-
-        // Third priority: client-level default serverConfiguration
-        return clientDefault.webRTCIceServers;
-      }
-
-      test('normal non-empty custom iceServers pass through unchanged', () {
-        final customServers = [
-          TxIceServer(urls: ['stun:custom.example.com:3478']),
-          TxIceServer(
-            urls: ['turn:custom.example.com:3478?transport=tcp'],
-            username: 'user',
-            credential: 'pass',
-          ),
-        ];
-
-        final result = resolveEffectiveIceServers(
-          configIceServers: customServers,
-          clientDefault: TxServerConfiguration.production(),
+        final result = TelnyxClient.resolveEffectiveIceServers(
+          configIceServers: servers,
+          defaultServerConfig: TxServerConfiguration.production(),
         );
 
-        expect(result.length, 2);
-        expect(result[0].urls, ['stun:custom.example.com:3478']);
-        expect(result[1].urls, ['turn:custom.example.com:3478?transport=tcp']);
-        expect(result[1].username, 'user');
-        expect(result[1].credential, 'pass');
-      });
-
-      test(
-          'when all custom iceServers have empty URLs, falls back to serverConfiguration',
-          () {
-        final emptyServers = [
-          TxIceServer(urls: []),
-          TxIceServer(urls: []),
-        ];
-
-        final serverConfig = TxServerConfiguration(
-          webRTCIceServers: [
-            TxIceServer(urls: ['stun:from-server-config:3478']),
-            TxIceServer(
-              urls: ['turn:from-server-config:3478?transport=tcp'],
-              username: 'srvuser',
-              credential: 'srvpass',
-            ),
-          ],
-        );
-
-        final result = resolveEffectiveIceServers(
-          configIceServers: emptyServers,
-          configServerConfig: serverConfig,
-          clientDefault: TxServerConfiguration.production(),
-        );
-
-        expect(result.length, 2);
-        expect(result[0].urls, ['stun:from-server-config:3478']);
-        expect(result[1].urls, ['turn:from-server-config:3478?transport=tcp']);
-      });
-
-      test(
-          'when both custom iceServers and serverConfiguration have empty URLs, falls back to client-level defaults',
-          () {
-        final emptyServers = [TxIceServer(urls: [])];
-
-        final emptyServerConfig = TxServerConfiguration(
-          webRTCIceServers: [TxIceServer(urls: [])],
-        );
-
-        final clientDefault = TxServerConfiguration.production();
-
-        final result = resolveEffectiveIceServers(
-          configIceServers: emptyServers,
-          configServerConfig: emptyServerConfig,
-          clientDefault: clientDefault,
-        );
-
-        // Should be the production default ICE servers (5 servers)
-        expect(result.length, 5);
+        // Falls all the way through to defaults
         expect(result, equals(DefaultConfig.defaultProdIceServers));
       });
 
-      test(
-          'when no custom iceServers and no serverConfiguration, uses client-level defaults',
-          () {
-        final clientDefault = TxServerConfiguration.development();
+      test('TxIceServer with urls [""] is filtered out', () {
+        const servers = [
+          TxIceServer(urls: ['']),
+          TxIceServer(urls: ['stun:stun.telnyx.com:3478']),
+        ];
 
-        final result = resolveEffectiveIceServers(
-          clientDefault: clientDefault,
+        final result = TelnyxClient.resolveEffectiveIceServers(
+          configIceServers: servers,
+          defaultServerConfig: TxServerConfiguration.production(),
         );
 
-        // Should be the development default ICE servers (5 servers)
-        expect(result.length, 5);
-        expect(result, equals(DefaultConfig.defaultDevIceServers));
+        expect(result.length, 1);
+        expect(result[0].urls, ['stun:stun.telnyx.com:3478']);
+      });
+
+      test('TxIceServer.fromJson({"urls": ""}) is filtered out', () {
+        final servers = [
+          TxIceServer.fromJson({'urls': ''}),
+          TxIceServer.fromJson({'urls': 'stun:stun.telnyx.com:3478'}),
+        ];
+
+        final result = TelnyxClient.resolveEffectiveIceServers(
+          configIceServers: servers,
+          defaultServerConfig: TxServerConfiguration.production(),
+        );
+
+        expect(result.length, 1);
+        expect(result[0].urls, ['stun:stun.telnyx.com:3478']);
+      });
+
+      test('TxIceServer.fromJson({"urls": [""]}) is filtered out', () {
+        final servers = [
+          TxIceServer.fromJson({
+            'urls': [''],
+          }),
+          TxIceServer.fromJson({
+            'urls': ['stun:stun.telnyx.com:3478'],
+          }),
+        ];
+
+        final result = TelnyxClient.resolveEffectiveIceServers(
+          configIceServers: servers,
+          defaultServerConfig: TxServerConfiguration.production(),
+        );
+
+        expect(result.length, 1);
+        expect(result[0].urls, ['stun:stun.telnyx.com:3478']);
       });
 
       test(
-          'mixed empty and valid servers in custom iceServers: only valid ones are used',
+          'TxIceServer with urls ["", "stun:stun.telnyx.com:3478"] passes (has at least one valid URL)',
           () {
-        final mixedServers = [
+        const servers = [
+          TxIceServer(urls: ['', 'stun:stun.telnyx.com:3478']),
+        ];
+
+        final result = TelnyxClient.resolveEffectiveIceServers(
+          configIceServers: servers,
+          defaultServerConfig: TxServerConfiguration.production(),
+        );
+
+        expect(result.length, 1);
+        expect(result[0].urls, ['', 'stun:stun.telnyx.com:3478']);
+      });
+
+      test(
+          'mix of empty-list and empty-string servers: only valid ones returned',
+          () {
+        const servers = [
           TxIceServer(urls: []),
+          TxIceServer(urls: ['']),
+          TxIceServer(urls: ['', '']),
           TxIceServer(urls: ['stun:valid.example.com:3478']),
-          TxIceServer(urls: []),
           TxIceServer(
             urls: ['turn:valid.example.com:3478?transport=udp'],
             username: 'u',
@@ -189,49 +154,221 @@ void main() {
           ),
         ];
 
-        final result = resolveEffectiveIceServers(
-          configIceServers: mixedServers,
-          clientDefault: TxServerConfiguration.production(),
+        final result = TelnyxClient.resolveEffectiveIceServers(
+          configIceServers: servers,
+          defaultServerConfig: TxServerConfiguration.production(),
         );
 
         expect(result.length, 2);
         expect(result[0].urls, ['stun:valid.example.com:3478']);
         expect(result[1].urls, ['turn:valid.example.com:3478?transport=udp']);
       });
-
-      test('serverConfiguration with mixed empty/valid: only valid used', () {
-        final serverConfig = TxServerConfiguration(
-          webRTCIceServers: [
-            TxIceServer(urls: []),
-            TxIceServer(urls: ['stun:mixed-valid:3478']),
-            TxIceServer(urls: []),
-          ],
-        );
-
-        final result = resolveEffectiveIceServers(
-          configServerConfig: serverConfig,
-          clientDefault: TxServerConfiguration.production(),
-        );
-
-        expect(result.length, 1);
-        expect(result[0].urls, ['stun:mixed-valid:3478']);
-      });
     });
+
+    group(
+      'fallback chain: custom iceServers -> serverConfiguration -> defaults',
+      () {
+        test(
+          'normal non-empty custom iceServers pass through unchanged',
+          () {
+            final customServers = [
+              TxIceServer(urls: ['stun:custom.example.com:3478']),
+              TxIceServer(
+                urls: ['turn:custom.example.com:3478?transport=tcp'],
+                username: 'user',
+                credential: 'pass',
+              ),
+            ];
+
+            final result = TelnyxClient.resolveEffectiveIceServers(
+              configIceServers: customServers,
+              defaultServerConfig: TxServerConfiguration.production(),
+            );
+
+            expect(result.length, 2);
+            expect(result[0].urls, ['stun:custom.example.com:3478']);
+            expect(
+              result[1].urls,
+              ['turn:custom.example.com:3478?transport=tcp'],
+            );
+            expect(result[1].username, 'user');
+            expect(result[1].credential, 'pass');
+          },
+        );
+
+        test(
+          'when all custom iceServers have empty URLs, falls back to serverConfiguration',
+          () {
+            final emptyServers = [
+              TxIceServer(urls: []),
+              TxIceServer(urls: []),
+            ];
+
+            final serverConfig = TxServerConfiguration(
+              webRTCIceServers: [
+                TxIceServer(urls: ['stun:from-server-config:3478']),
+                TxIceServer(
+                  urls: ['turn:from-server-config:3478?transport=tcp'],
+                  username: 'srvuser',
+                  credential: 'srvpass',
+                ),
+              ],
+            );
+
+            final result = TelnyxClient.resolveEffectiveIceServers(
+              configIceServers: emptyServers,
+              serverConfig: serverConfig,
+              defaultServerConfig: TxServerConfiguration.production(),
+            );
+
+            expect(result.length, 2);
+            expect(result[0].urls, ['stun:from-server-config:3478']);
+            expect(
+              result[1].urls,
+              ['turn:from-server-config:3478?transport=tcp'],
+            );
+          },
+        );
+
+        test(
+          'when both custom iceServers and serverConfiguration have empty URLs, falls back to client-level defaults',
+          () {
+            final emptyServers = [TxIceServer(urls: [])];
+
+            final emptyServerConfig = TxServerConfiguration(
+              webRTCIceServers: [
+                TxIceServer(urls: ['']),
+              ],
+            );
+
+            final clientDefault = TxServerConfiguration.production();
+
+            final result = TelnyxClient.resolveEffectiveIceServers(
+              configIceServers: emptyServers,
+              serverConfig: emptyServerConfig,
+              defaultServerConfig: clientDefault,
+            );
+
+            // Should be the production default ICE servers (5 servers)
+            expect(result.length, 5);
+            expect(result, equals(DefaultConfig.defaultProdIceServers));
+          },
+        );
+
+        test(
+          'when no custom iceServers and no serverConfiguration, uses client-level defaults',
+          () {
+            final clientDefault = TxServerConfiguration.development();
+
+            final result = TelnyxClient.resolveEffectiveIceServers(
+              defaultServerConfig: clientDefault,
+            );
+
+            // Should be the development default ICE servers (5 servers)
+            expect(result.length, 5);
+            expect(result, equals(DefaultConfig.defaultDevIceServers));
+          },
+        );
+
+        test(
+          'mixed empty and valid servers in custom iceServers: only valid ones are used',
+          () {
+            final mixedServers = [
+              TxIceServer(urls: []),
+              TxIceServer(urls: ['stun:valid.example.com:3478']),
+              TxIceServer(urls: []),
+              TxIceServer(
+                urls: ['turn:valid.example.com:3478?transport=udp'],
+                username: 'u',
+                credential: 'p',
+              ),
+            ];
+
+            final result = TelnyxClient.resolveEffectiveIceServers(
+              configIceServers: mixedServers,
+              defaultServerConfig: TxServerConfiguration.production(),
+            );
+
+            expect(result.length, 2);
+            expect(result[0].urls, ['stun:valid.example.com:3478']);
+            expect(
+              result[1].urls,
+              ['turn:valid.example.com:3478?transport=udp'],
+            );
+          },
+        );
+
+        test('serverConfiguration with mixed empty/valid: only valid used', () {
+          final serverConfig = TxServerConfiguration(
+            webRTCIceServers: [
+              TxIceServer(urls: []),
+              TxIceServer(urls: ['stun:mixed-valid:3478']),
+              TxIceServer(urls: []),
+            ],
+          );
+
+          final result = TelnyxClient.resolveEffectiveIceServers(
+            serverConfig: serverConfig,
+            defaultServerConfig: TxServerConfiguration.production(),
+          );
+
+          expect(result.length, 1);
+          expect(result[0].urls, ['stun:mixed-valid:3478']);
+        });
+
+        test(
+          'serverConfiguration with empty-string URLs: falls back to defaults',
+          () {
+            final serverConfig = TxServerConfiguration(
+              webRTCIceServers: [
+                TxIceServer(urls: ['']),
+                TxIceServer(urls: ['', '']),
+              ],
+            );
+
+            final result = TelnyxClient.resolveEffectiveIceServers(
+              serverConfig: serverConfig,
+              defaultServerConfig: TxServerConfiguration.production(),
+            );
+
+            expect(result, equals(DefaultConfig.defaultProdIceServers));
+          },
+        );
+      },
+    );
 
     group('default ICE server integrity', () {
       test('production defaults all have non-empty URLs', () {
         for (final server in DefaultConfig.defaultProdIceServers) {
-          expect(server.urls, isNotEmpty,
-              reason:
-                  'Production default ICE server should have non-empty URLs');
+          expect(
+            server.urls,
+            isNotEmpty,
+            reason: 'Production default ICE server should have non-empty URLs',
+          );
+          for (final url in server.urls) {
+            expect(
+              url,
+              isNotEmpty,
+              reason: 'Production default ICE server URL should not be empty',
+            );
+          }
         }
       });
 
       test('development defaults all have non-empty URLs', () {
         for (final server in DefaultConfig.defaultDevIceServers) {
-          expect(server.urls, isNotEmpty,
-              reason:
-                  'Development default ICE server should have non-empty URLs');
+          expect(
+            server.urls,
+            isNotEmpty,
+            reason: 'Development default ICE server should have non-empty URLs',
+          );
+          for (final url in server.urls) {
+            expect(
+              url,
+              isNotEmpty,
+              reason: 'Development default ICE server URL should not be empty',
+            );
+          }
         }
       });
     });

--- a/packages/telnyx_webrtc/test/ice_server_fallback_test.dart
+++ b/packages/telnyx_webrtc/test/ice_server_fallback_test.dart
@@ -1,0 +1,239 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:telnyx_webrtc/config.dart';
+import 'package:telnyx_webrtc/model/tx_ice_server.dart';
+import 'package:telnyx_webrtc/model/tx_server_configuration.dart';
+
+/// Tests for the ICE server empty-URL fallback behaviour in _getEffectiveIceServers().
+///
+/// These tests verify that:
+/// 1. TxIceServer with empty urls are filtered out from custom iceServers
+/// 2. When all custom iceServers have empty URLs, falls back to serverConfiguration
+/// 3. When serverConfiguration.webRTCIceServers also has empty URLs, falls back
+///    to client-level defaults
+/// 4. Normal (non-empty) ICE servers pass through unchanged
+void main() {
+  group('ICE server empty-URL fallback', () {
+    group('TxIceServer.fromJson empty-URL handling', () {
+      test('returns empty urls list when urls is null', () {
+        final server = TxIceServer.fromJson({'urls': null});
+        expect(server.urls, isEmpty);
+      });
+
+      test('returns empty urls list when urls key is missing', () {
+        final server = TxIceServer.fromJson({});
+        expect(server.urls, isEmpty);
+      });
+
+      test('returns empty urls list when urls is wrong type', () {
+        final server = TxIceServer.fromJson({'urls': 42});
+        expect(server.urls, isEmpty);
+      });
+    });
+
+    group('filtering of empty-URL ICE servers', () {
+      test('empty-URL servers are filtered out, valid ones remain', () {
+        const servers = [
+          TxIceServer(urls: ['stun:stun.example.com:3478']),
+          TxIceServer(urls: []),
+          TxIceServer(urls: ['turn:turn.example.com:3478?transport=tcp']),
+        ];
+
+        final valid = servers.where((s) => s.urls.isNotEmpty).toList();
+
+        expect(valid.length, 2);
+        expect(valid[0].urls, ['stun:stun.example.com:3478']);
+        expect(valid[1].urls, ['turn:turn.example.com:3478?transport=tcp']);
+      });
+
+      test('all-empty list filters to empty', () {
+        const servers = [
+          TxIceServer(urls: []),
+          TxIceServer(urls: []),
+        ];
+
+        final valid = servers.where((s) => s.urls.isNotEmpty).toList();
+
+        expect(valid, isEmpty);
+      });
+    });
+
+    group(
+        'fallback chain: custom iceServers -> serverConfiguration -> defaults',
+        () {
+      // Simulate the _getEffectiveIceServers logic in isolation.
+      // We extract the logic into a testable function that mirrors the
+      // priority order in telnyx_client.dart.
+      List<TxIceServer> resolveEffectiveIceServers({
+        List<TxIceServer>? configIceServers,
+        TxServerConfiguration? configServerConfig,
+        required TxServerConfiguration clientDefault,
+      }) {
+        // First priority: custom ICE servers from Config
+        if (configIceServers != null && configIceServers.isNotEmpty) {
+          final valid =
+              configIceServers.where((s) => s.urls.isNotEmpty).toList();
+          if (valid.isNotEmpty) return valid;
+        }
+
+        // Second priority: ICE servers from serverConfiguration in Config
+        if (configServerConfig != null) {
+          final valid = configServerConfig.webRTCIceServers
+              .where((s) => s.urls.isNotEmpty)
+              .toList();
+          if (valid.isNotEmpty) return valid;
+        }
+
+        // Third priority: client-level default serverConfiguration
+        return clientDefault.webRTCIceServers;
+      }
+
+      test('normal non-empty custom iceServers pass through unchanged', () {
+        final customServers = [
+          TxIceServer(urls: ['stun:custom.example.com:3478']),
+          TxIceServer(
+            urls: ['turn:custom.example.com:3478?transport=tcp'],
+            username: 'user',
+            credential: 'pass',
+          ),
+        ];
+
+        final result = resolveEffectiveIceServers(
+          configIceServers: customServers,
+          clientDefault: TxServerConfiguration.production(),
+        );
+
+        expect(result.length, 2);
+        expect(result[0].urls, ['stun:custom.example.com:3478']);
+        expect(result[1].urls, ['turn:custom.example.com:3478?transport=tcp']);
+        expect(result[1].username, 'user');
+        expect(result[1].credential, 'pass');
+      });
+
+      test(
+          'when all custom iceServers have empty URLs, falls back to serverConfiguration',
+          () {
+        final emptyServers = [
+          TxIceServer(urls: []),
+          TxIceServer(urls: []),
+        ];
+
+        final serverConfig = TxServerConfiguration(
+          webRTCIceServers: [
+            TxIceServer(urls: ['stun:from-server-config:3478']),
+            TxIceServer(
+              urls: ['turn:from-server-config:3478?transport=tcp'],
+              username: 'srvuser',
+              credential: 'srvpass',
+            ),
+          ],
+        );
+
+        final result = resolveEffectiveIceServers(
+          configIceServers: emptyServers,
+          configServerConfig: serverConfig,
+          clientDefault: TxServerConfiguration.production(),
+        );
+
+        expect(result.length, 2);
+        expect(result[0].urls, ['stun:from-server-config:3478']);
+        expect(result[1].urls, ['turn:from-server-config:3478?transport=tcp']);
+      });
+
+      test(
+          'when both custom iceServers and serverConfiguration have empty URLs, falls back to client-level defaults',
+          () {
+        final emptyServers = [TxIceServer(urls: [])];
+
+        final emptyServerConfig = TxServerConfiguration(
+          webRTCIceServers: [TxIceServer(urls: [])],
+        );
+
+        final clientDefault = TxServerConfiguration.production();
+
+        final result = resolveEffectiveIceServers(
+          configIceServers: emptyServers,
+          configServerConfig: emptyServerConfig,
+          clientDefault: clientDefault,
+        );
+
+        // Should be the production default ICE servers (5 servers)
+        expect(result.length, 5);
+        expect(result, equals(DefaultConfig.defaultProdIceServers));
+      });
+
+      test(
+          'when no custom iceServers and no serverConfiguration, uses client-level defaults',
+          () {
+        final clientDefault = TxServerConfiguration.development();
+
+        final result = resolveEffectiveIceServers(
+          clientDefault: clientDefault,
+        );
+
+        // Should be the development default ICE servers (5 servers)
+        expect(result.length, 5);
+        expect(result, equals(DefaultConfig.defaultDevIceServers));
+      });
+
+      test(
+          'mixed empty and valid servers in custom iceServers: only valid ones are used',
+          () {
+        final mixedServers = [
+          TxIceServer(urls: []),
+          TxIceServer(urls: ['stun:valid.example.com:3478']),
+          TxIceServer(urls: []),
+          TxIceServer(
+            urls: ['turn:valid.example.com:3478?transport=udp'],
+            username: 'u',
+            credential: 'p',
+          ),
+        ];
+
+        final result = resolveEffectiveIceServers(
+          configIceServers: mixedServers,
+          clientDefault: TxServerConfiguration.production(),
+        );
+
+        expect(result.length, 2);
+        expect(result[0].urls, ['stun:valid.example.com:3478']);
+        expect(result[1].urls, ['turn:valid.example.com:3478?transport=udp']);
+      });
+
+      test('serverConfiguration with mixed empty/valid: only valid used', () {
+        final serverConfig = TxServerConfiguration(
+          webRTCIceServers: [
+            TxIceServer(urls: []),
+            TxIceServer(urls: ['stun:mixed-valid:3478']),
+            TxIceServer(urls: []),
+          ],
+        );
+
+        final result = resolveEffectiveIceServers(
+          configServerConfig: serverConfig,
+          clientDefault: TxServerConfiguration.production(),
+        );
+
+        expect(result.length, 1);
+        expect(result[0].urls, ['stun:mixed-valid:3478']);
+      });
+    });
+
+    group('default ICE server integrity', () {
+      test('production defaults all have non-empty URLs', () {
+        for (final server in DefaultConfig.defaultProdIceServers) {
+          expect(server.urls, isNotEmpty,
+              reason:
+                  'Production default ICE server should have non-empty URLs');
+        }
+      });
+
+      test('development defaults all have non-empty URLs', () {
+        for (final server in DefaultConfig.defaultDevIceServers) {
+          expect(server.urls, isNotEmpty,
+              reason:
+                  'Development default ICE server should have non-empty URLs');
+        }
+      });
+    });
+  });
+}

--- a/packages/telnyx_webrtc/test/ice_server_fallback_test.dart
+++ b/packages/telnyx_webrtc/test/ice_server_fallback_test.dart
@@ -2,10 +2,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:telnyx_webrtc/config.dart';
 import 'package:telnyx_webrtc/model/tx_ice_server.dart';
 import 'package:telnyx_webrtc/model/tx_server_configuration.dart';
-import 'package:telnyx_webrtc/telnyx_client.dart';
+import 'package:telnyx_webrtc/src/ice_server_resolver.dart';
 
 /// Tests for the ICE server empty-URL fallback behaviour in
-/// [TelnyxClient.resolveEffectiveIceServers].
+/// [resolveEffectiveIceServers].
 ///
 /// These tests exercise the *actual* static method used by the SDK (not a
 /// re-implementation) so they catch real regressions.
@@ -38,6 +38,13 @@ void main() {
         });
         expect(server.urls, ['']);
       });
+
+      test('ignores non-string members in a urls list', () {
+        final server = TxIceServer.fromJson({
+          'urls': ['stun:valid.example.com:3478', 42, null],
+        });
+        expect(server.urls, ['stun:valid.example.com:3478']);
+      });
     });
 
     group('resolveEffectiveIceServers — filtering of empty-URL ICE servers',
@@ -49,7 +56,7 @@ void main() {
           TxIceServer(urls: ['turn:turn.example.com:3478?transport=tcp']),
         ];
 
-        final result = TelnyxClient.resolveEffectiveIceServers(
+        final result = resolveEffectiveIceServers(
           configIceServers: servers,
           defaultServerConfig: TxServerConfiguration.production(),
         );
@@ -65,7 +72,7 @@ void main() {
           TxIceServer(urls: []),
         ];
 
-        final result = TelnyxClient.resolveEffectiveIceServers(
+        final result = resolveEffectiveIceServers(
           configIceServers: servers,
           defaultServerConfig: TxServerConfiguration.production(),
         );
@@ -80,7 +87,7 @@ void main() {
           TxIceServer(urls: ['stun:stun.telnyx.com:3478']),
         ];
 
-        final result = TelnyxClient.resolveEffectiveIceServers(
+        final result = resolveEffectiveIceServers(
           configIceServers: servers,
           defaultServerConfig: TxServerConfiguration.production(),
         );
@@ -95,7 +102,7 @@ void main() {
           TxIceServer.fromJson({'urls': 'stun:stun.telnyx.com:3478'}),
         ];
 
-        final result = TelnyxClient.resolveEffectiveIceServers(
+        final result = resolveEffectiveIceServers(
           configIceServers: servers,
           defaultServerConfig: TxServerConfiguration.production(),
         );
@@ -114,7 +121,7 @@ void main() {
           }),
         ];
 
-        final result = TelnyxClient.resolveEffectiveIceServers(
+        final result = resolveEffectiveIceServers(
           configIceServers: servers,
           defaultServerConfig: TxServerConfiguration.production(),
         );
@@ -124,19 +131,32 @@ void main() {
       });
 
       test(
-          'TxIceServer with urls ["", "stun:stun.telnyx.com:3478"] passes (has at least one valid URL)',
+          'invalid members are removed from a mixed URL list',
           () {
         const servers = [
           TxIceServer(urls: ['', 'stun:stun.telnyx.com:3478']),
         ];
 
-        final result = TelnyxClient.resolveEffectiveIceServers(
+        final result = resolveEffectiveIceServers(
           configIceServers: servers,
           defaultServerConfig: TxServerConfiguration.production(),
         );
 
         expect(result.length, 1);
-        expect(result[0].urls, ['', 'stun:stun.telnyx.com:3478']);
+        expect(result[0].urls, ['stun:stun.telnyx.com:3478']);
+      });
+
+      test('whitespace-only URLs are removed', () {
+        const servers = [
+          TxIceServer(urls: ['  ', '\n', 'stun:valid.example.com:3478']),
+        ];
+
+        final result = resolveEffectiveIceServers(
+          configIceServers: servers,
+          defaultServerConfig: TxServerConfiguration.production(),
+        );
+
+        expect(result.single.urls, ['stun:valid.example.com:3478']);
       });
 
       test(
@@ -154,7 +174,7 @@ void main() {
           ),
         ];
 
-        final result = TelnyxClient.resolveEffectiveIceServers(
+        final result = resolveEffectiveIceServers(
           configIceServers: servers,
           defaultServerConfig: TxServerConfiguration.production(),
         );
@@ -180,7 +200,7 @@ void main() {
               ),
             ];
 
-            final result = TelnyxClient.resolveEffectiveIceServers(
+            final result = resolveEffectiveIceServers(
               configIceServers: customServers,
               defaultServerConfig: TxServerConfiguration.production(),
             );
@@ -215,7 +235,7 @@ void main() {
               ],
             );
 
-            final result = TelnyxClient.resolveEffectiveIceServers(
+            final result = resolveEffectiveIceServers(
               configIceServers: emptyServers,
               serverConfig: serverConfig,
               defaultServerConfig: TxServerConfiguration.production(),
@@ -243,7 +263,7 @@ void main() {
 
             final clientDefault = TxServerConfiguration.production();
 
-            final result = TelnyxClient.resolveEffectiveIceServers(
+            final result = resolveEffectiveIceServers(
               configIceServers: emptyServers,
               serverConfig: emptyServerConfig,
               defaultServerConfig: clientDefault,
@@ -260,7 +280,7 @@ void main() {
           () {
             final clientDefault = TxServerConfiguration.development();
 
-            final result = TelnyxClient.resolveEffectiveIceServers(
+            final result = resolveEffectiveIceServers(
               defaultServerConfig: clientDefault,
             );
 
@@ -269,6 +289,21 @@ void main() {
             expect(result, equals(DefaultConfig.defaultDevIceServers));
           },
         );
+
+        test('invalid client-level defaults fall back to SDK defaults', () {
+          final invalidDefault = TxServerConfiguration(
+            webRTCIceServers: const [
+              TxIceServer(urls: []),
+              TxIceServer(urls: ['  ']),
+            ],
+          );
+
+          final result = resolveEffectiveIceServers(
+            defaultServerConfig: invalidDefault,
+          );
+
+          expect(result, equals(DefaultConfig.defaultProdIceServers));
+        });
 
         test(
           'mixed empty and valid servers in custom iceServers: only valid ones are used',
@@ -284,7 +319,7 @@ void main() {
               ),
             ];
 
-            final result = TelnyxClient.resolveEffectiveIceServers(
+            final result = resolveEffectiveIceServers(
               configIceServers: mixedServers,
               defaultServerConfig: TxServerConfiguration.production(),
             );
@@ -307,7 +342,7 @@ void main() {
             ],
           );
 
-          final result = TelnyxClient.resolveEffectiveIceServers(
+          final result = resolveEffectiveIceServers(
             serverConfig: serverConfig,
             defaultServerConfig: TxServerConfiguration.production(),
           );
@@ -326,7 +361,7 @@ void main() {
               ],
             );
 
-            final result = TelnyxClient.resolveEffectiveIceServers(
+            final result = resolveEffectiveIceServers(
               serverConfig: serverConfig,
               defaultServerConfig: TxServerConfiguration.production(),
             );


### PR DESCRIPTION
## Problem

During the VSUP-184 Careco audio investigation, we found that `TxIceServer.fromJson()` silently returns an empty `urls` list when parsing fails (e.g. when the server handshake sends `urls: null` or malformed JSON). The `_getEffectiveIceServers()` method in `telnyx_client.dart` then used these broken servers instead of falling back to the SDK defaults (`DefaultConfig.defaultProdIceServers` / `defaultDevIceServers`).

This means a single malformed server response could strip all working ICE servers from the WebRTC peer connection config, causing call connectivity failures.

## Fix

Add validation in `_getEffectiveIceServers()` to filter out `TxIceServer` entries with empty `urls` at each priority level:

1. **Custom ICE servers from Config** — filter empty-URL entries; if all are empty, fall through
2. **ICE servers from `serverConfiguration` in Config** — same filtering; if all empty, fall through
3. **Client-level default `_serverConfiguration`** — hardcoded defaults, always valid

A warning is logged at each level when filtering removes empty-URL servers.

## Changes

- `packages/telnyx_webrtc/lib/telnyx_client.dart`: Filter empty-URL ICE servers at each priority level in `_getEffectiveIceServers()`
- `packages/telnyx_webrtc/test/ice_server_fallback_test.dart`: New test file with 13 tests covering:
  - `TxIceServer.fromJson()` empty-URL handling (null, missing key, wrong type)
  - Filtering of empty-URL servers from lists
  - Full fallback chain: custom iceServers → serverConfiguration → client defaults
  - Mixed empty/valid server filtering
  - Default ICE server URL integrity (prod + dev)

## Testing

- `dart format .` ✅
- `dart analyze` ✅ (no new issues in changed files)
- `flutter test test/ice_server_fallback_test.dart` ✅ — 13/13 tests passed

## Related

- VSUP-184 Careco audio investigation