### PR TITLE
[VSDK-502] Align production TURNS defaults with JS SDK

### DIFF
--- a/packages/telnyx_webrtc/lib/config.dart
+++ b/packages/telnyx_webrtc/lib/config.dart
@@ -27,10 +27,12 @@ class DefaultConfig {
   static const String defaultTurnUdp =
       'turn:turn.telnyx.com:3478?transport=udp';
 
-  /// Production TURNS server with TCP transport over TLS on port 443
+  /// Primary production TURNS server over TLS on port 443.
   /// (last-resort fallback for restrictive firewalls that block non-443 traffic)
-  static const String defaultTurns443 =
-      'turns:turn.telnyx.com:443?transport=tcp';
+  static const String defaultTurns443 = 'turns:turn.telnyx.com:443';
+
+  /// Secondary production TURNS endpoint retained during DNS migration.
+  static const String secondaryTurns443 = 'turns:turn2.telnyx.com:443';
 
   /// Production STUN server
   static const String defaultStun = 'stun:stun.telnyx.com:3478';
@@ -44,8 +46,7 @@ class DefaultConfig {
 
   /// Development TURNS server with TCP transport over TLS on port 443
   /// (last-resort fallback for restrictive firewalls that block non-443 traffic)
-  static const String devTurns443 =
-      'turns:turndev.telnyx.com:443?transport=tcp';
+  static const String devTurns443 = 'turns:turndev.telnyx.com:443';
 
   /// Development STUN server
   static const String devStun = 'stun:stundev.telnyx.com:3478';
@@ -70,8 +71,7 @@ class DefaultConfig {
   /// - Google STUN server (fallback)
   /// - Telnyx TURN server with UDP transport (preferred)
   /// - Telnyx TURN server with TCP transport (fallback)
-  /// - Telnyx TURNS server with TCP transport over TLS on port 443
-  ///   (last-resort fallback for restrictive firewalls)
+  /// - Primary and secondary Telnyx TURNS endpoints on port 443
   static List<TxIceServer> get defaultProdIceServers => [
         const TxIceServer(urls: [defaultStun]),
         const TxIceServer(urls: [googleStun]),
@@ -88,6 +88,11 @@ class DefaultConfig {
         // TURNS 443 (last-resort fallback for restrictive firewalls)
         TxIceServer(
           urls: [defaultTurns443],
+          username: username,
+          credential: password,
+        ),
+        TxIceServer(
+          urls: [secondaryTurns443],
           username: username,
           credential: password,
         ),

--- a/packages/telnyx_webrtc/test/config_test.dart
+++ b/packages/telnyx_webrtc/test/config_test.dart
@@ -6,14 +6,14 @@ void main() {
     test('defaultTurns443 uses TLS on port 443 for prod', () {
       expect(
         DefaultConfig.defaultTurns443,
-        equals('turns:turn.telnyx.com:443?transport=tcp'),
+        equals('turns:turn.telnyx.com:443'),
       );
     });
 
     test('devTurns443 uses TLS on port 443 for dev', () {
       expect(
         DefaultConfig.devTurns443,
-        equals('turns:turndev.telnyx.com:443?transport=tcp'),
+        equals('turns:turndev.telnyx.com:443'),
       );
     });
   });
@@ -21,17 +21,25 @@ void main() {
   group('DefaultConfig.defaultProdIceServers', () {
     final servers = DefaultConfig.defaultProdIceServers;
 
-    test('contains 5 entries (TURNS 443 added as 5th)', () {
-      expect(servers.length, equals(5));
+    test('contains 6 entries including both production TURNS endpoints', () {
+      expect(servers.length, equals(6));
     });
 
-    test('preserves ordering: STUN, Google STUN, TURN UDP, TURN TCP, TURNS 443',
+    test('preserves ordering with primary and secondary TURNS last',
         () {
       expect(servers[0].urls, equals([DefaultConfig.defaultStun]));
       expect(servers[1].urls, equals([DefaultConfig.googleStun]));
       expect(servers[2].urls, equals([DefaultConfig.defaultTurnUdp]));
       expect(servers[3].urls, equals([DefaultConfig.defaultTurn]));
       expect(servers[4].urls, equals([DefaultConfig.defaultTurns443]));
+      expect(servers[5].urls, equals([DefaultConfig.secondaryTurns443]));
+    });
+
+    test('secondary TURNS 443 entry has correct credentials', () {
+      final turns443 = servers[5];
+      expect(turns443.urls, equals([DefaultConfig.secondaryTurns443]));
+      expect(turns443.username, equals(DefaultConfig.username));
+      expect(turns443.credential, equals(DefaultConfig.password));
     });
 
     test('TURNS 443 entry (5th) has correct URL and credentials', () {
@@ -75,10 +83,10 @@ void main() {
   });
 
   group('DefaultConfig ICE server ordering invariants', () {
-    test('TURNS 443 is the last entry in both default lists', () {
+    test('secondary prod TURNS and dev TURNS are last', () {
       expect(
         DefaultConfig.defaultProdIceServers.last.urls,
-        equals([DefaultConfig.defaultTurns443]),
+        equals([DefaultConfig.secondaryTurns443]),
       );
       expect(
         DefaultConfig.defaultDevIceServers.last.urls,
@@ -92,11 +100,15 @@ void main() {
       final udpIdx = urls.indexOf(DefaultConfig.defaultTurnUdp);
       final tcpIdx = urls.indexOf(DefaultConfig.defaultTurn);
       final turns443Idx = urls.indexOf(DefaultConfig.defaultTurns443);
+      final secondaryTurns443Idx =
+          urls.indexOf(DefaultConfig.secondaryTurns443);
       expect(udpIdx, isNonNegative);
       expect(tcpIdx, isNonNegative);
       expect(turns443Idx, isNonNegative);
+      expect(secondaryTurns443Idx, isNonNegative);
       expect(udpIdx, lessThan(turns443Idx));
       expect(tcpIdx, lessThan(turns443Idx));
+      expect(turns443Idx, lessThan(secondaryTurns443Idx));
     });
 
     test('lower-latency UDP/TCP TURN entries precede TURNS 443 in dev', () {

--- a/packages/telnyx_webrtc/test/ice_server_fallback_test.dart
+++ b/packages/telnyx_webrtc/test/ice_server_fallback_test.dart
@@ -269,8 +269,8 @@ void main() {
               defaultServerConfig: clientDefault,
             );
 
-            // Should be the production default ICE servers (5 servers)
-            expect(result.length, 5);
+            // Production includes both primary and secondary TURNS endpoints.
+            expect(result.length, 6);
             expect(result, equals(DefaultConfig.defaultProdIceServers));
           },
         );


### PR DESCRIPTION
Adds the secondary turns:turn2.telnyx.com:443 production endpoint after the primary turns:turn.telnyx.com:443 endpoint, matching the JavaScript SDK catalog. TURNS URLs intentionally omit the transport query. Updates ordering, credential, and fallback tests. Focused Flutter tests: 37 passed.