### PR TITLE
test(android): expose stable profile form selectors

### DIFF
--- a/lib/view/widgets/login/bottom_sheet/add_profile_form.dart
+++ b/lib/view/widgets/login/bottom_sheet/add_profile_form.dart
@@ -13,6 +13,7 @@ class CustomFormField extends StatefulWidget {
   final String? Function(String?)? validator;
   final bool isPassword;
   final TextInputType? keyboardType;
+  final String? semanticsIdentifier;
 
   const CustomFormField({
     Key? key,
@@ -22,6 +23,7 @@ class CustomFormField extends StatefulWidget {
     this.validator,
     this.isPassword = false,
     this.keyboardType,
+    this.semanticsIdentifier,
   }) : super(key: key);
 
   @override
@@ -45,28 +47,31 @@ class _CustomFormFieldState extends State<CustomFormField> {
             ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
           ),
         ),
-        TextFormField(
-          controller: widget.controller,
-          keyboardType: widget.keyboardType,
-          obscureText: widget.isPassword && !_isPasswordVisible,
-          decoration: InputDecoration(
-            hintText: widget.hintText,
-            suffixIcon: widget.isPassword
-                ? IconButton(
-                    icon: Icon(
-                      _isPasswordVisible
-                          ? Icons.visibility
-                          : Icons.visibility_off,
-                    ),
-                    onPressed: () {
-                      setState(() {
-                        _isPasswordVisible = !_isPasswordVisible;
-                      });
-                    },
-                  )
-                : null,
+        Semantics(
+          identifier: widget.semanticsIdentifier,
+          child: TextFormField(
+            controller: widget.controller,
+            keyboardType: widget.keyboardType,
+            obscureText: widget.isPassword && !_isPasswordVisible,
+            decoration: InputDecoration(
+              hintText: widget.hintText,
+              suffixIcon: widget.isPassword
+                  ? IconButton(
+                      icon: Icon(
+                        _isPasswordVisible
+                            ? Icons.visibility
+                            : Icons.visibility_off,
+                      ),
+                      onPressed: () {
+                        setState(() {
+                          _isPasswordVisible = !_isPasswordVisible;
+                        });
+                      },
+                    )
+                  : null,
+            ),
+            validator: widget.validator,
           ),
-          validator: widget.validator,
         ),
       ],
     );
@@ -326,22 +331,19 @@ class _AddProfileFormState extends State<AddProfileForm> {
               ),
             ),
             const SizedBox(height: spacingS),
-            Semantics(
-              identifier: 'caller_number_field',
-              container: true,
-              child: CustomFormField(
-                key: const ValueKey('caller_number_field'),
-                title: 'Caller ID Number',
-                controller: _sipCallerIDNumberController,
-                hintText: 'Enter your caller ID number',
-                keyboardType: TextInputType.phone,
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Please enter a caller ID number';
-                  }
-                  return null;
-                },
-              ),
+            CustomFormField(
+              key: const ValueKey('caller_number_field'),
+              semanticsIdentifier: 'caller_number_field',
+              title: 'Caller ID Number',
+              controller: _sipCallerIDNumberController,
+              hintText: 'Enter your caller ID number',
+              keyboardType: TextInputType.phone,
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Please enter a caller ID number';
+                }
+                return null;
+              },
             ),
             const SizedBox(height: spacingS),
             // Region Selection
@@ -353,8 +355,8 @@ class _AddProfileFormState extends State<AddProfileForm> {
                   child: Text(
                     'Region',
                     style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                          fontWeight: FontWeight.w500,
-                        ),
+                      fontWeight: FontWeight.w500,
+                    ),
                   ),
                 ),
                 DropdownButtonFormField<Region>(
@@ -423,12 +425,9 @@ class _AddProfileFormState extends State<AddProfileForm> {
                       ),
                       Text(
                         'Forces TURN relay for all connections, preventing local network access prompts',
-                        style: Theme.of(
-                          context,
-                        )
-                            .textTheme
-                            .bodySmall
-                            ?.copyWith(color: Colors.grey[600]),
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Colors.grey[600],
+                        ),
                       ),
                     ],
                   ),

--- a/lib/view/widgets/login/bottom_sheet/add_profile_form.dart
+++ b/lib/view/widgets/login/bottom_sheet/add_profile_form.dart
@@ -35,6 +35,28 @@ class _CustomFormFieldState extends State<CustomFormField> {
 
   @override
   Widget build(BuildContext context) {
+    final formField = TextFormField(
+      controller: widget.controller,
+      keyboardType: widget.keyboardType,
+      obscureText: widget.isPassword && !_isPasswordVisible,
+      decoration: InputDecoration(
+        hintText: widget.hintText,
+        suffixIcon: widget.isPassword
+            ? IconButton(
+                icon: Icon(
+                  _isPasswordVisible ? Icons.visibility : Icons.visibility_off,
+                ),
+                onPressed: () {
+                  setState(() {
+                    _isPasswordVisible = !_isPasswordVisible;
+                  });
+                },
+              )
+            : null,
+      ),
+      validator: widget.validator,
+    );
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -47,32 +69,14 @@ class _CustomFormFieldState extends State<CustomFormField> {
             ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
           ),
         ),
-        Semantics(
-          identifier: widget.semanticsIdentifier,
-          child: TextFormField(
-            controller: widget.controller,
-            keyboardType: widget.keyboardType,
-            obscureText: widget.isPassword && !_isPasswordVisible,
-            decoration: InputDecoration(
-              hintText: widget.hintText,
-              suffixIcon: widget.isPassword
-                  ? IconButton(
-                      icon: Icon(
-                        _isPasswordVisible
-                            ? Icons.visibility
-                            : Icons.visibility_off,
-                      ),
-                      onPressed: () {
-                        setState(() {
-                          _isPasswordVisible = !_isPasswordVisible;
-                        });
-                      },
-                    )
-                  : null,
-            ),
-            validator: widget.validator,
+        if (widget.semanticsIdentifier == null)
+          formField
+        else
+          Semantics(
+            identifier: widget.semanticsIdentifier,
+            container: true,
+            child: formField,
           ),
-        ),
       ],
     );
   }
@@ -278,57 +282,48 @@ class _AddProfileFormState extends State<AddProfileForm> {
                 },
               ),
             ] else ...[
-              Semantics(
-                identifier: 'sip_username_field',
-                container: true,
-                child: CustomFormField(
-                  key: const ValueKey('sip_username_field'),
-                  title: 'SIP Username',
-                  controller: _sipUserController,
-                  hintText: 'Enter your SIP username',
-                  validator: (value) {
-                    if (value == null || value.isEmpty) {
-                      return 'Please enter a SIP username';
-                    }
-                    return null;
-                  },
-                ),
-              ),
-              const SizedBox(height: spacingS),
-              Semantics(
-                identifier: 'sip_password_field',
-                container: true,
-                child: CustomFormField(
-                  key: const ValueKey('sip_password_field'),
-                  title: 'SIP Password',
-                  controller: _sipPasswordController,
-                  hintText: 'Enter your SIP password',
-                  isPassword: true,
-                  validator: (value) {
-                    if (value == null || value.isEmpty) {
-                      return 'Please enter a SIP password';
-                    }
-                    return null;
-                  },
-                ),
-              ),
-            ],
-            const SizedBox(height: spacingS),
-            Semantics(
-              identifier: 'caller_name_field',
-              container: true,
-              child: CustomFormField(
-                key: const ValueKey('caller_name_field'),
-                title: 'Caller ID Name',
-                controller: _sipCallerIDNameController,
-                hintText: 'Enter your caller ID name',
+              CustomFormField(
+                key: const ValueKey('sip_username_field'),
+                semanticsIdentifier: 'sip_username_field',
+                title: 'SIP Username',
+                controller: _sipUserController,
+                hintText: 'Enter your SIP username',
                 validator: (value) {
                   if (value == null || value.isEmpty) {
-                    return 'Please enter a caller ID name';
+                    return 'Please enter a SIP username';
                   }
                   return null;
                 },
               ),
+              const SizedBox(height: spacingS),
+              CustomFormField(
+                key: const ValueKey('sip_password_field'),
+                semanticsIdentifier: 'sip_password_field',
+                title: 'SIP Password',
+                controller: _sipPasswordController,
+                hintText: 'Enter your SIP password',
+                isPassword: true,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter a SIP password';
+                  }
+                  return null;
+                },
+              ),
+            ],
+            const SizedBox(height: spacingS),
+            CustomFormField(
+              key: const ValueKey('caller_name_field'),
+              semanticsIdentifier: 'caller_name_field',
+              title: 'Caller ID Name',
+              controller: _sipCallerIDNameController,
+              hintText: 'Enter your caller ID name',
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Please enter a caller ID name';
+                }
+                return null;
+              },
             ),
             const SizedBox(height: spacingS),
             CustomFormField(


### PR DESCRIPTION
Adds stable Flutter semantics identifiers for the caller-number input and Save action used by the Android release-checklist Maestro flow.

Validated during a clean APK rebuild/install: profile creation completed successfully through the new selectors. SIP registration then failed independently at the Client-ready assertion.