### PR TITLE
VSUP-226: harden Flutter CallKit audio activation

### DIFF
--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -410,6 +410,33 @@ Also, as we are using WebRTC we need to add the following lines to avoid a bug w
 ```swift
 @main
 @objc class AppDelegate: FlutterAppDelegate, PKPushRegistryDelegate, CallkitIncomingAppDelegate {
+    private func activateWebRTCAudio(_ audioSession: AVAudioSession) {
+        let rtcAudioSession = RTCAudioSession.sharedInstance()
+        let wasAudioEnabled = rtcAudioSession.isAudioEnabled
+        rtcAudioSession.lockForConfiguration()
+
+        let configuration = RTCAudioSessionConfiguration.webRTC()
+        configuration.categoryOptions = [.duckOthers, .allowBluetooth]
+        do {
+            try rtcAudioSession.setConfiguration(configuration)
+        } catch {
+            NSLog("WebRTC audio configuration failed: \(error)")
+        }
+
+        do {
+            try rtcAudioSession.setActive(true)
+            rtcAudioSession.isAudioEnabled = true
+        } catch {
+            rtcAudioSession.isAudioEnabled = false
+            NSLog("WebRTC audio activation failed: \(error)")
+        }
+        rtcAudioSession.unlockForConfiguration()
+
+        if rtcAudioSession.isAudioEnabled && !wasAudioEnabled {
+            rtcAudioSession.audioSessionDidActivate(audioSession)
+        }
+    }
+
     func onAccept(_ call: flutter_callkit_incoming.Call, _ action: CXAnswerCallAction) {
         NSLog("onRunner ::  Accept")
         action.fulfill()
@@ -432,8 +459,7 @@ Also, as we are using WebRTC we need to add the following lines to avoid a bug w
 
     func didActivateAudioSession(_ audioSession: AVAudioSession) {
         NSLog("onRunner  :: Activate Audio Session")
-        RTCAudioSession.sharedInstance().audioSessionDidActivate(audioSession)
-        RTCAudioSession.sharedInstance().isAudioEnabled = true
+        activateWebRTCAudio(audioSession)
     }
 
     func didDeactivateAudioSession(_ audioSession: AVAudioSession) {
@@ -445,7 +471,7 @@ Also, as we are using WebRTC we need to add the following lines to avoid a bug w
     ....
   ```  
 
-Note: Notice for didActivateAudioSession and didDeactivateAudioSession that we are handling WebRTC manually. This is to handle the before mentioned bug where there is no audio on iOS when using it with CallKit.
+Note: `didActivateAudioSession` and `didDeactivateAudioSession` manually bridge CallKit ownership into WebRTC. Keep activation idempotent, do not mark audio enabled when `setActive(true)` fails, and verify the state shortly after answering. The demo `AppDelegate.swift` includes a guarded post-answer recovery that is cancelled by decline, end, timeout, or deactivation.
 
 1. Register / Invalidate the push device token for iOS within AppDelegate.swift class
 ```swift
@@ -827,5 +853,4 @@ No migration is required for the timeout feature - it works automatically with e
 - The timeout only applies to accepted push notifications (`isAnswer: true`)
 - Normal incoming calls (not from push) are not affected by this timeout
 - If INVITE arrives after timeout, it will be ignored as the call is already terminated
-
 

--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -410,7 +410,9 @@ Also, as we are using WebRTC we need to add the following lines to avoid a bug w
 ```swift
 @main
 @objc class AppDelegate: FlutterAppDelegate, PKPushRegistryDelegate, CallkitIncomingAppDelegate {
-    private func activateWebRTCAudio(_ audioSession: AVAudioSession) {
+    // Minimal activation excerpt. The demo AppDelegate.swift is the source of truth for
+    // guarded post-answer recovery and lifecycle invalidation.
+    private func activateWebRTCAudio(_ audioSession: AVAudioSession, reason: String) {
         let rtcAudioSession = RTCAudioSession.sharedInstance()
         let wasAudioEnabled = rtcAudioSession.isAudioEnabled
         rtcAudioSession.lockForConfiguration()
@@ -423,16 +425,21 @@ Also, as we are using WebRTC we need to add the following lines to avoid a bug w
             NSLog("WebRTC audio configuration failed: \(error)")
         }
 
+        var activationSucceeded = false
         do {
             try rtcAudioSession.setActive(true)
-            rtcAudioSession.isAudioEnabled = true
+            activationSucceeded = true
         } catch {
+            NSLog("WebRTC audio activation (\(reason)) failed: \(error)")
+        }
+        if activationSucceeded {
+            rtcAudioSession.isAudioEnabled = true
+        } else if !wasAudioEnabled {
             rtcAudioSession.isAudioEnabled = false
-            NSLog("WebRTC audio activation failed: \(error)")
         }
         rtcAudioSession.unlockForConfiguration()
 
-        if rtcAudioSession.isAudioEnabled && !wasAudioEnabled {
+        if activationSucceeded && !wasAudioEnabled {
             rtcAudioSession.audioSessionDidActivate(audioSession)
         }
     }
@@ -853,4 +860,3 @@ No migration is required for the timeout feature - it works automatically with e
 - The timeout only applies to accepted push notifications (`isAnswer: true`)
 - Normal incoming calls (not from push) are not affected by this timeout
 - If INVITE arrives after timeout, it will be ignored as the call is already terminated
-

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -8,10 +8,49 @@ import WebRTC
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, PKPushRegistryDelegate, CallkitIncomingAppDelegate {
+    private let audioRaceChannelName = "org.telnyx.webrtc/audio-race-debug"
+
+    private func activateWebRTCAudio(_ audioSession: AVAudioSession, reason: String) {
+        let rtcAudioSession = RTCAudioSession.sharedInstance()
+        let wasAudioEnabled = rtcAudioSession.isAudioEnabled
+        print("[CALLKIT_AUDIO] Activating WebRTC audio (\(reason)); enabled=\(rtcAudioSession.isAudioEnabled)")
+        rtcAudioSession.lockForConfiguration()
+        let configuration = RTCAudioSessionConfiguration.webRTC()
+        configuration.categoryOptions = [.duckOthers, .allowBluetooth]
+        do {
+            try rtcAudioSession.setConfiguration(configuration)
+            try rtcAudioSession.setActive(true)
+        } catch {
+            print("[CALLKIT_AUDIO] Activation failed: \(error)")
+        }
+        rtcAudioSession.isAudioEnabled = true
+        rtcAudioSession.unlockForConfiguration()
+        if !wasAudioEnabled {
+            rtcAudioSession.audioSessionDidActivate(audioSession)
+        }
+    }
+
     func onAccept(_ call: flutter_callkit_incoming.Call, _ action: CXAnswerCallAction) {
         print("[iOS_PUSH_DEBUG] AppDelegate - onAccept called by CallKit for call ID: \\(call.uuid)")
         action.fulfill()
-        
+        verifyAudioAfterAnswer()
+    }
+
+    private func verifyAudioAfterAnswer() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) { [weak self] in
+            let rtcAudioSession = RTCAudioSession.sharedInstance()
+            if rtcAudioSession.isAudioEnabled {
+                print("[CALLKIT_AUDIO] Post-answer verification passed")
+            } else if AVAudioSession.sharedInstance().category == .playAndRecord {
+                print("[CALLKIT_AUDIO] Recovering disabled audio after CallKit answer")
+                self?.activateWebRTCAudio(
+                    AVAudioSession.sharedInstance(),
+                    reason: "post-answer verification"
+                )
+            } else {
+                print("[CALLKIT_AUDIO] Verification skipped; CallKit session is not active")
+            }
+        }
     }
     
     func onDecline(_ call: flutter_callkit_incoming.Call, _ action: CXEndCallAction) {
@@ -30,9 +69,7 @@ import WebRTC
     
     func didActivateAudioSession(_ audioSession: AVAudioSession) {
         print("onRunner  :: Activate Audio Session")
-
-        RTCAudioSession.sharedInstance().audioSessionDidActivate(audioSession)
-        RTCAudioSession.sharedInstance().isAudioEnabled = true
+        activateWebRTCAudio(audioSession, reason: "CallKit didActivate")
     }
     
     func didDeactivateAudioSession(_ audioSession: AVAudioSession) {
@@ -47,6 +84,24 @@ import WebRTC
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+
+      #if DEBUG
+      if let controller = window?.rootViewController as? FlutterViewController {
+          let audioRaceChannel = FlutterMethodChannel(
+              name: audioRaceChannelName,
+              binaryMessenger: controller.binaryMessenger
+          )
+          audioRaceChannel.setMethodCallHandler { [weak self] call, result in
+              guard call.method == "simulateAudioSetupRace" else {
+                  result(FlutterMethodNotImplemented)
+                  return
+              }
+              let delayMilliseconds = (call.arguments as? [String: Any])?["delayMilliseconds"] as? Int ?? 250
+              self?.simulateAudioSetupRace(delay: Double(delayMilliseconds) / 1_000)
+              result(["scheduled": true, "delayMilliseconds": delayMilliseconds])
+          }
+      }
+      #endif
       
       //Setup VOIP
       let mainQueue = DispatchQueue.main
@@ -59,6 +114,22 @@ import WebRTC
       
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
+
+    #if DEBUG
+    private func simulateAudioSetupRace(delay: TimeInterval) {
+        print("[VSUP-226] Scheduling late audio reset in \(delay)s")
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            RTCAudioSession.sharedInstance().isAudioEnabled = false
+            print("[VSUP-226] Injected late setup reset; enabled=false")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
+                self?.activateWebRTCAudio(
+                    AVAudioSession.sharedInstance(),
+                    reason: "debug connected-call recovery"
+                )
+            }
+        }
+    }
+    #endif
     
     // Call back from Recent history
         override func application(_ application: UIApplication,

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -9,6 +9,10 @@ import WebRTC
 @main
 @objc class AppDelegate: FlutterAppDelegate, PKPushRegistryDelegate, CallkitIncomingAppDelegate {
     private let audioRaceChannelName = "org.telnyx.webrtc/audio-race-debug"
+    private var audioLifecycleGeneration = 0
+    #if DEBUG
+    private var audioRaceChannel: FlutterMethodChannel?
+    #endif
 
     private func activateWebRTCAudio(_ audioSession: AVAudioSession, reason: String) {
         let rtcAudioSession = RTCAudioSession.sharedInstance()
@@ -19,25 +23,38 @@ import WebRTC
         configuration.categoryOptions = [.duckOthers, .allowBluetooth]
         do {
             try rtcAudioSession.setConfiguration(configuration)
+        } catch {
+            print("[CALLKIT_AUDIO] Configuration failed: \(error)")
+        }
+
+        var activationSucceeded = false
+        do {
             try rtcAudioSession.setActive(true)
+            activationSucceeded = true
         } catch {
             print("[CALLKIT_AUDIO] Activation failed: \(error)")
         }
-        rtcAudioSession.isAudioEnabled = true
+        rtcAudioSession.isAudioEnabled = activationSucceeded
         rtcAudioSession.unlockForConfiguration()
-        if !wasAudioEnabled {
+        if activationSucceeded && !wasAudioEnabled {
             rtcAudioSession.audioSessionDidActivate(audioSession)
         }
     }
 
     func onAccept(_ call: flutter_callkit_incoming.Call, _ action: CXAnswerCallAction) {
         print("[iOS_PUSH_DEBUG] AppDelegate - onAccept called by CallKit for call ID: \\(call.uuid)")
+        audioLifecycleGeneration += 1
+        let verificationGeneration = audioLifecycleGeneration
         action.fulfill()
-        verifyAudioAfterAnswer()
+        verifyAudioAfterAnswer(generation: verificationGeneration)
     }
 
-    private func verifyAudioAfterAnswer() {
+    private func verifyAudioAfterAnswer(generation: Int) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) { [weak self] in
+            guard self?.audioLifecycleGeneration == generation else {
+                print("[CALLKIT_AUDIO] Skipping stale post-answer verification")
+                return
+            }
             let rtcAudioSession = RTCAudioSession.sharedInstance()
             if rtcAudioSession.isAudioEnabled {
                 print("[CALLKIT_AUDIO] Post-answer verification passed")
@@ -54,16 +71,19 @@ import WebRTC
     }
     
     func onDecline(_ call: flutter_callkit_incoming.Call, _ action: CXEndCallAction) {
+        audioLifecycleGeneration += 1
         print("onRunner ::  Decline")
         action.fulfill()
     }
     
     func onEnd(_ call: flutter_callkit_incoming.Call, _ action: CXEndCallAction) {
+        audioLifecycleGeneration += 1
         print("onRunner ::  End")
         action.fulfill()
     }
     
     func onTimeOut(_ call: flutter_callkit_incoming.Call) {
+        audioLifecycleGeneration += 1
         print("onRunner ::  TimeOut")
     }
     
@@ -73,6 +93,7 @@ import WebRTC
     }
     
     func didDeactivateAudioSession(_ audioSession: AVAudioSession) {
+        audioLifecycleGeneration += 1
         print("onRunner  :: DeActivate Audio Session")
 
         RTCAudioSession.sharedInstance().audioSessionDidDeactivate(audioSession)
@@ -84,24 +105,6 @@ import WebRTC
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
-
-      #if DEBUG
-      if let controller = window?.rootViewController as? FlutterViewController {
-          let audioRaceChannel = FlutterMethodChannel(
-              name: audioRaceChannelName,
-              binaryMessenger: controller.binaryMessenger
-          )
-          audioRaceChannel.setMethodCallHandler { [weak self] call, result in
-              guard call.method == "simulateAudioSetupRace" else {
-                  result(FlutterMethodNotImplemented)
-                  return
-              }
-              let delayMilliseconds = (call.arguments as? [String: Any])?["delayMilliseconds"] as? Int ?? 250
-              self?.simulateAudioSetupRace(delay: Double(delayMilliseconds) / 1_000)
-              result(["scheduled": true, "delayMilliseconds": delayMilliseconds])
-          }
-      }
-      #endif
       
       //Setup VOIP
       let mainQueue = DispatchQueue.main
@@ -111,11 +114,44 @@ import WebRTC
 
       RTCAudioSession.sharedInstance().useManualAudio = true
       RTCAudioSession.sharedInstance().isAudioEnabled = false
-      
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+
+      let didFinishLaunching = super.application(
+          application,
+          didFinishLaunchingWithOptions: launchOptions
+      )
+
+      #if DEBUG
+      DispatchQueue.main.async { [weak self] in
+          self?.installAudioRaceDebugChannel()
+      }
+      #endif
+
+      return didFinishLaunching
   }
 
     #if DEBUG
+    private func installAudioRaceDebugChannel() {
+        guard let controller = window?.rootViewController as? FlutterViewController else {
+            print("[VSUP-226] Audio race channel unavailable: missing FlutterViewController")
+            return
+        }
+        let channel = FlutterMethodChannel(
+            name: audioRaceChannelName,
+            binaryMessenger: controller.binaryMessenger
+        )
+        channel.setMethodCallHandler { [weak self] call, result in
+            guard call.method == "simulateAudioSetupRace" else {
+                result(FlutterMethodNotImplemented)
+                return
+            }
+            let delayMilliseconds =
+                (call.arguments as? [String: Any])?["delayMilliseconds"] as? Int ?? 250
+            self?.simulateAudioSetupRace(delay: Double(delayMilliseconds) / 1_000)
+            result(["scheduled": true, "delayMilliseconds": delayMilliseconds])
+        }
+        audioRaceChannel = channel
+    }
+
     private func simulateAudioSetupRace(delay: TimeInterval) {
         print("[VSUP-226] Scheduling late audio reset in \(delay)s")
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -9,6 +9,7 @@ import WebRTC
 @main
 @objc class AppDelegate: FlutterAppDelegate, PKPushRegistryDelegate, CallkitIncomingAppDelegate {
     private let audioRaceChannelName = "org.telnyx.webrtc/audio-race-debug"
+    private let postAnswerVerificationDelay: TimeInterval = 0.75
     private var audioLifecycleGeneration = 0
     #if DEBUG
     private var audioRaceChannel: FlutterMethodChannel?
@@ -34,7 +35,11 @@ import WebRTC
         } catch {
             print("[CALLKIT_AUDIO] Activation failed: \(error)")
         }
-        rtcAudioSession.isAudioEnabled = activationSucceeded
+        if activationSucceeded {
+            rtcAudioSession.isAudioEnabled = true
+        } else if !wasAudioEnabled {
+            rtcAudioSession.isAudioEnabled = false
+        }
         rtcAudioSession.unlockForConfiguration()
         if activationSucceeded && !wasAudioEnabled {
             rtcAudioSession.audioSessionDidActivate(audioSession)
@@ -50,7 +55,7 @@ import WebRTC
     }
 
     private func verifyAudioAfterAnswer(generation: Int) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + postAnswerVerificationDelay) { [weak self] in
             guard self?.audioLifecycleGeneration == generation else {
                 print("[CALLKIT_AUDIO] Skipping stale post-answer verification")
                 return
@@ -155,9 +160,12 @@ import WebRTC
     private func simulateAudioSetupRace(delay: TimeInterval) {
         print("[VSUP-226] Scheduling late audio reset in \(delay)s")
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            RTCAudioSession.sharedInstance().isAudioEnabled = false
+            let rtcAudioSession = RTCAudioSession.sharedInstance()
+            rtcAudioSession.lockForConfiguration()
+            rtcAudioSession.isAudioEnabled = false
+            rtcAudioSession.unlockForConfiguration()
             print("[VSUP-226] Injected late setup reset; enabled=false")
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + (self?.postAnswerVerificationDelay ?? 0.75)) {
                 self?.activateWebRTCAudio(
                     AVAudioSession.sharedInstance(),
                     reason: "debug connected-call recovery"

--- a/lib/view/screen/home_screen.dart
+++ b/lib/view/screen/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_callkit_incoming/flutter_callkit_incoming.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
@@ -24,6 +25,10 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
+  // Change by hand for VSUP-226 validation. The native hook is DEBUG-only.
+  static const bool enableAudioRaceDebug = false;
+  static const MethodChannel _audioRaceChannel =
+      MethodChannel('org.telnyx.webrtc/audio-race-debug');
   final TextEditingController _targetIdController = TextEditingController();
   final TextEditingController _conversationIdController =
       TextEditingController();
@@ -177,7 +182,21 @@ class _HomeScreenState extends State<HomeScreen> {
       case 'Start Call Muted Off':
         _toggleMuteOnStart();
         break;
+      case 'Inject Audio Setup Race':
+        _injectAudioSetupRace();
+        break;
     }
+  }
+
+  Future<void> _injectAudioSetupRace() async {
+    await _audioRaceChannel.invokeMethod<void>(
+      'simulateAudioSetupRace',
+      const {'delayMilliseconds': 250},
+    );
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Audio race scheduled; check Xcode logs')),
+    );
   }
 
   void _toggleMuteOnStart() {
@@ -319,6 +338,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   'Force ICE Renegotiation',
                   'Export Logs',
                   'Diagnostics',
+                  if (enableAudioRaceDebug) 'Inject Audio Setup Race',
                 ].map((String choice) {
                   return PopupMenuItem<String>(
                     value: choice,


### PR DESCRIPTION
## Summary

- Centralize the sample app WebRTC audio activation path
- Configure and activate `RTCAudioSession` idempotently from the CallKit callback
- Verify audio after answering and recover only while CallKit owns a play-and-record session
- Add a DEBUG-only method channel and a menu button hidden behind `enableAudioRaceDebug = false`

## Reproduction

Set `enableAudioRaceDebug` to `true` in `lib/view/screen/home_screen.dart`, connect a call, and select **Inject Audio Setup Race**. The injector disables WebRTC audio after 250 ms and exercises the recovery path.

Flutter delegates `CXProvider` ownership to the host app, so the hardening belongs in the required `AppDelegate` integration.

## Validation

- Flutter analyzer passes
- Flutter tests pass
- Swift parser passes
- Full iOS simulator build was blocked while Xcode package resolution remained stuck

Tracks VSUP-226.