### PR TITLE
[VSDK-631] - Remove turn2.telnyx.com from default ICE servers

### DIFF
--- a/packages/telnyx_webrtc/README.md
+++ b/packages/telnyx_webrtc/README.md
@@ -226,7 +226,7 @@ inbound, and recovered calls. STUN entries may still be present in the ICE
 catalog, but they cannot become the selected media path. A reachable TURN
 server and valid credentials are therefore mandatory. The production defaults
 include TURN over UDP and TCP on port 3478, followed by TURNS on port 443 at
-`turn.telnyx.com` and `turn2.telnyx.com`.
+`turn.telnyx.com`.
 
 Use this setting selectively. Relaying all media can increase connection time,
 latency, relay bandwidth/cost, and may reduce quality for devices that could

--- a/packages/telnyx_webrtc/lib/config.dart
+++ b/packages/telnyx_webrtc/lib/config.dart
@@ -31,10 +31,7 @@ class DefaultConfig {
   /// (last-resort fallback for restrictive firewalls that block non-443 traffic)
   static const String defaultTurns443 = 'turns:turn.telnyx.com:443';
 
-  /// Secondary production TURNS endpoint retained during DNS migration.
-  static const String secondaryTurns443 = 'turns:turn2.telnyx.com:443';
-
-  /// Production STUN server
+/// Production STUN server
   static const String defaultStun = 'stun:stun.telnyx.com:3478';
 
   // MARK: - Development TURN/STUN Servers
@@ -88,11 +85,6 @@ class DefaultConfig {
         // TURNS 443 (last-resort fallback for restrictive firewalls)
         TxIceServer(
           urls: [defaultTurns443],
-          username: username,
-          credential: password,
-        ),
-        TxIceServer(
-          urls: [secondaryTurns443],
           username: username,
           credential: password,
         ),

--- a/packages/telnyx_webrtc/test/config_test.dart
+++ b/packages/telnyx_webrtc/test/config_test.dart
@@ -21,25 +21,16 @@ void main() {
   group('DefaultConfig.defaultProdIceServers', () {
     final servers = DefaultConfig.defaultProdIceServers;
 
-    test('contains 6 entries including both production TURNS endpoints', () {
-      expect(servers.length, equals(6));
+    test('contains 5 entries including production TURNS endpoint', () {
+      expect(servers.length, equals(5));
     });
 
-    test('preserves ordering with primary and secondary TURNS last',
-        () {
+    test('preserves ordering with TURNS 443 last', () {
       expect(servers[0].urls, equals([DefaultConfig.defaultStun]));
       expect(servers[1].urls, equals([DefaultConfig.googleStun]));
       expect(servers[2].urls, equals([DefaultConfig.defaultTurnUdp]));
       expect(servers[3].urls, equals([DefaultConfig.defaultTurn]));
       expect(servers[4].urls, equals([DefaultConfig.defaultTurns443]));
-      expect(servers[5].urls, equals([DefaultConfig.secondaryTurns443]));
-    });
-
-    test('secondary TURNS 443 entry has correct credentials', () {
-      final turns443 = servers[5];
-      expect(turns443.urls, equals([DefaultConfig.secondaryTurns443]));
-      expect(turns443.username, equals(DefaultConfig.username));
-      expect(turns443.credential, equals(DefaultConfig.password));
     });
 
     test('TURNS 443 entry (5th) has correct URL and credentials', () {
@@ -83,10 +74,10 @@ void main() {
   });
 
   group('DefaultConfig ICE server ordering invariants', () {
-    test('secondary prod TURNS and dev TURNS are last', () {
+    test('prod TURNS and dev TURNS are last', () {
       expect(
         DefaultConfig.defaultProdIceServers.last.urls,
-        equals([DefaultConfig.secondaryTurns443]),
+        equals([DefaultConfig.defaultTurns443]),
       );
       expect(
         DefaultConfig.defaultDevIceServers.last.urls,
@@ -100,15 +91,11 @@ void main() {
       final udpIdx = urls.indexOf(DefaultConfig.defaultTurnUdp);
       final tcpIdx = urls.indexOf(DefaultConfig.defaultTurn);
       final turns443Idx = urls.indexOf(DefaultConfig.defaultTurns443);
-      final secondaryTurns443Idx =
-          urls.indexOf(DefaultConfig.secondaryTurns443);
       expect(udpIdx, isNonNegative);
       expect(tcpIdx, isNonNegative);
       expect(turns443Idx, isNonNegative);
-      expect(secondaryTurns443Idx, isNonNegative);
       expect(udpIdx, lessThan(turns443Idx));
       expect(tcpIdx, lessThan(turns443Idx));
-      expect(turns443Idx, lessThan(secondaryTurns443Idx));
     });
 
     test('lower-latency UDP/TCP TURN entries precede TURNS 443 in dev', () {

--- a/packages/telnyx_webrtc/test/ice_server_fallback_test.dart
+++ b/packages/telnyx_webrtc/test/ice_server_fallback_test.dart
@@ -269,8 +269,8 @@ void main() {
               defaultServerConfig: clientDefault,
             );
 
-            // Production includes both primary and secondary TURNS endpoints.
-            expect(result.length, 6);
+            // Production includes the TURNS 443 endpoint.
+            expect(result.length, 5);
             expect(result, equals(DefaultConfig.defaultProdIceServers));
           },
         );


### PR DESCRIPTION
## Summary

Remove the secondary TURNS 443 endpoint (`turns:turn2.telnyx.com:443`) from the default production ICE server list in the Flutter SDK.

## Context

- **Linear:** [VSDK-631](https://linear.app/telnyx/issue/VSDK-631)
- **Project:** [Add TURNS over TCP 443 support to Mobile SDKs](https://linear.app/telnyx/project/add-turns-over-tcp-443-support-to-mobile-sdks-fc251074990b)
- **Slack:** [thread](https://telnyx.slack.com/archives/CM7AYEY78/p1787831838887139)

## Changes

- Remove `secondaryTurns443` constant from `config.dart`
- Remove `TxIceServer` block using `secondaryTurns443` from `defaultProdIceServers` getter
- Update `config_test.dart`: prod server count 6→5, remove `secondaryTurns443` assertions
- Update `README.md` to remove turn2 reference

## Scope

Only `turns:turn2.telnyx.com:443` is removed. The five other default prod ICE servers are unchanged:
1. `stun:stun.telnyx.com:3478`
2. `stun:stun.l.google.com:19302`
3. `turn:turn.telnyx.com:3478?transport=udp`
4. `turn:turn.telnyx.com:3478?transport=tcp`
5. `turns:turn.telnyx.com:443`

## Test plan

- [x] Unit tests updated to reflect 5-server prod list
- [ ] CI passes